### PR TITLE
feat: show live position label on cover inline slider

### DIFF
--- a/room-card.js
+++ b/room-card.js
@@ -1801,6 +1801,8 @@ class OneLineRoomCard extends HTMLElement {
           if (cur != null) return cur + unit;
           return s;
         })()
+        : typ === "shutter" && st?.attributes?.current_position != null
+          ? `${100 - Math.round(st.attributes.current_position)}% closed`
         : typ === "light" && s === "on" && ctrl.show_brightness_value !== false && st?.attributes?.brightness != null
           ? `${s} · ${Math.round((st.attributes.brightness / 255) * 100)} %`
           : s));
@@ -2108,6 +2110,9 @@ class OneLineRoomCard extends HTMLElement {
           } else if (sliderCaps.action === "brightness" && ctrl.show_brightness_value !== false) {
             const stateEl = topDiv.querySelector(".btn-state");
             if (stateEl) stateEl.textContent = `${s} · ${Math.round(v)} %`;
+          } else if (sliderCaps.action === "position") {
+            const stateEl = topDiv.querySelector(".btn-state");
+            if (stateEl) stateEl.textContent = `${100 - Math.round(v)}% closed`;
           }
         });
         slider.addEventListener("change", e => {


### PR DESCRIPTION
## What this PR does

Adds a live position label to the inline slider for `cover` entities, consistent
with how the card already handles `light` (brightness) and `climate` (temperature)
sliders.

**Two small additions, no existing behaviour changed.**

---

### Change 1 — Resting state label (`stateText` block)

When a cover tile uses `control_mode: slider` and `show_state: true`, the state
line currently shows the raw HA state string (`open` / `closed` / `opening` etc.).

This patch adds a `shutter` branch (the card already sets `typ = "shutter"` for
all `cover` domain entities) so the state line instead shows a human-readable
position value, e.g. **`16% closed`**, derived from `current_position` (0 = open,
100 = closed — inverted from HA's native 0–100 open convention).

```diff
-        : typ === "light" && s === "on" && ctrl.show_brightness_value !== false && st?.attributes?.brightness != null
+        : typ === "shutter" && st?.attributes?.current_position != null
+          ? `${100 - Math.round(st.attributes.current_position)}% closed`
+        : typ === "light" && s === "on" && ctrl.show_brightness_value !== false && st?.attributes?.brightness != null
           ? `${s} · ${Math.round((st.attributes.brightness / 255) * 100)} %`
           : s));
```

---

### Change 2 — Live drag label (inline slider `input` handler)

The `input` event handler that fires while the user drags the inline slider already
updates the state line live for `climate`, `color_temp`, and `brightness` actions.
`position` (cover) was missing from that list, so the label stayed frozen during
the drag and only updated after release when HA reported the new state.

This patch adds the missing `position` branch so the label tracks the handle in
real time as you drag, matching the behaviour of other slider domains.

```diff
           } else if (sliderCaps.action === "brightness" && ctrl.show_brightness_value !== false) {
             const stateEl = topDiv.querySelector(".btn-state");
             if (stateEl) stateEl.textContent = `${s} · ${Math.round(v)} %`;
+          } else if (sliderCaps.action === "position") {
+            const stateEl = topDiv.querySelector(".btn-state");
+            if (stateEl) stateEl.textContent = `${100 - Math.round(v)}% closed`;
           }
         });
```

---

### Notes

- The `% closed` convention (inverted from `current_position`) was chosen because
  for roller shutters and blinds the natural user-facing question is "how much is
  it closed", not "how open is it". If the maintainer prefers `% open` (i.e.
  `Math.round(v)` directly), that is a trivial one-character change and happy to
  update.
- Falls back gracefully: if `current_position` is `null` / `undefined` (e.g. right
  after a Z2M restart before the first position report), the `stateText` branch is
  skipped and the raw HA state string is shown instead — same as before.
- No editor schema changes, no new config options, no dependency changes.
- Tested on an Aqara Shutter Switch H2 EU via Zigbee2MQTT.