### PR TITLE
test: establish runtime and editor coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,122 @@
     "": {
       "name": "oneline-room-card",
       "version": "1.3.1",
+      "devDependencies": {
+        "happy-dom": "20.11.6"
+      },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.6.tgz",
+      "integrity": "sha512-Hldbg8AdAa5a5oDcZpjqnGitp7JB0hqWmfv/8qr+kft4vzSD8BHsbdRfzYvL/0QcbKcURC/yyoygbeDQarPvYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "devDependencies": {
+    "happy-dom": "20.11.6"
   }
 }

--- a/tests/editor-behavior.test.mjs
+++ b/tests/editor-behavior.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createHass, importRoomCard, installDomEnvironment, wait } from "./support/dom-env.mjs";
+
+installDomEnvironment();
+await importRoomCard();
+
+const createEditor = () => {
+  const editor = document.createElement("oneline-room-card-editor");
+  document.body.appendChild(editor);
+  editor.hass = createHass();
+  return editor;
+};
+
+test("the text-field compatibility wrapper supports native, legacy, and current inputs", () => {
+  const NativeWrapper = customElements.get("oneline-room-card-textfield");
+  assert.ok(NativeWrapper);
+
+  const nativeWrapper = document.createElement("oneline-room-card-textfield");
+  document.body.appendChild(nativeWrapper);
+  assert.equal(nativeWrapper.shadowRoot.querySelector("input")?.tagName, "INPUT");
+
+  customElements.define("ha-textfield", class extends HTMLElement {});
+  const legacyWrapper = document.createElement("oneline-room-card-textfield");
+  document.body.appendChild(legacyWrapper);
+  assert.equal(legacyWrapper.shadowRoot.querySelector("ha-textfield")?.tagName, "HA-TEXTFIELD");
+
+  customElements.define("ha-input", class extends HTMLElement {});
+  const currentWrapper = document.createElement("oneline-room-card-textfield");
+  document.body.appendChild(currentWrapper);
+  assert.equal(currentWrapper.shadowRoot.querySelector("ha-input")?.tagName, "HA-INPUT");
+});
+
+test("the visual editor renders from a cold configuration", () => {
+  const editor = createEditor();
+  editor.setConfig({ name: "Kitchen" });
+
+  assert.deepEqual(editor._config.controls, []);
+  assert.ok(editor.shadowRoot.querySelector("[data-rc-version]"));
+  assert.ok(editor.shadowRoot.getElementById("show-name-toggle"));
+  assert.ok(editor.shadowRoot.getElementById("tab-config-btn"));
+  assert.ok(editor.shadowRoot.getElementById("tab-buttons-btn"));
+
+  editor.remove();
+});
+
+test("live editor changes emit the expected config-changed event", async () => {
+  const editor = createEditor();
+  editor.setConfig({ name: "Kitchen", controls: [] });
+  const received = [];
+  editor.addEventListener("config-changed", (event) => received.push(event.detail.config));
+
+  editor._fire({ name: "Living Room", controls: [] });
+  await wait(120);
+
+  assert.deepEqual(received, [{ name: "Living Room", controls: [] }]);
+  editor.remove();
+});
+
+test("disabled live preview defers changes until the primary save flow flushes them", () => {
+  const editor = createEditor();
+  editor.setConfig({ name: "Kitchen", controls: [] });
+  editor._livePreview = false;
+  const received = [];
+  editor.addEventListener("config-changed", (event) => received.push(event.detail.config));
+
+  editor._fire({ name: "Office", controls: [] });
+  assert.equal(received.length, 0);
+  assert.deepEqual(editor._pendingConfig, { name: "Office", controls: [] });
+
+  editor._flushPendingConfig();
+  assert.deepEqual(received, [{ name: "Office", controls: [] }]);
+  assert.equal(editor._pendingConfig, null);
+  editor.remove();
+});
+
+test("disconnecting the editor clears its pending event timer", async () => {
+  const editor = createEditor();
+  editor.setConfig({ controls: [] });
+  let emitted = false;
+  editor.addEventListener("config-changed", () => { emitted = true; });
+  editor._fire({ name: "Should not emit", controls: [] });
+
+  editor.remove();
+  await wait(120);
+
+  assert.equal(emitted, false);
+});

--- a/tests/runtime-behavior.test.mjs
+++ b/tests/runtime-behavior.test.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createHass, importRoomCard, installDomEnvironment } from "./support/dom-env.mjs";
+
+installDomEnvironment();
+
+const helpers = [
+  "clampNum",
+  "convertTemperatureValue",
+  "evalTemplateString",
+  "formatConvertedTemperature",
+  "formatEntityStateForDisplay",
+  "hexToRgba",
+  "normalizeTemperatureUnit",
+  "readableTextForHex",
+  "replaceTemplateExpressions"
+];
+const roomCardModule = await importRoomCard(helpers);
+const RoomCard = customElements.get("oneline-room-card");
+
+const createCard = (hass = createHass()) => {
+  const card = document.createElement("oneline-room-card");
+  card._hass = hass;
+  return card;
+};
+
+test("pure helpers preserve formatting, conversion, and template behavior", () => {
+  assert.equal(roomCardModule.clampNum("12", 0, 10, 5), 10);
+  assert.equal(roomCardModule.clampNum("invalid", 0, 10, 5), 5);
+  assert.equal(roomCardModule.normalizeTemperatureUnit("F"), "°F");
+  assert.equal(roomCardModule.normalizeTemperatureUnit(" C "), "°C");
+  assert.equal(roomCardModule.convertTemperatureValue(0, "°C", "°F"), 32);
+  assert.equal(roomCardModule.convertTemperatureValue(212, "°F", "°C"), 100);
+  assert.equal(roomCardModule.hexToRgba("#336699", 0.2), "rgba(51, 102, 153, 0.2)");
+  assert.equal(roomCardModule.readableTextForHex("#ffffff"), "#000000");
+  assert.equal(roomCardModule.readableTextForHex("#000000"), "#ffffff");
+
+  const replaced = roomCardModule.replaceTemplateExpressions("A ${1 + 1} B", (expression) => expression === "1 + 1" ? 2 : "");
+  assert.equal(replaced, "A 2 B");
+
+  const hass = createHass({
+    states: {
+      "sensor.temperature": { state: "21", attributes: { unit_of_measurement: "°C" } }
+    },
+    formatEntityState: () => "21.0 °C"
+  });
+  assert.equal(
+    roomCardModule.formatEntityStateForDisplay(hass, hass.states["sensor.temperature"]),
+    "21.0 °C"
+  );
+  const conversionHass = createHass();
+  assert.equal(
+    roomCardModule.formatConvertedTemperature(conversionHass, hass.states["sensor.temperature"], 0, "°C", "°F"),
+    "32.0 °F"
+  );
+  assert.equal(
+    roomCardModule.evalTemplateString('Next: ${Number(entity("sensor.temperature").state) + 1}', hass, {}),
+    "Next: 22"
+  );
+  assert.equal(roomCardModule.evalTemplateString("Safe ${not valid JavaScript}", hass, {}), "Safe ");
+});
+
+test("visibility conditions handle state, numeric, user, and nested logic", () => {
+  const hass = createHass({
+    states: {
+      "binary_sensor.window": { state: "off", attributes: {} },
+      "sensor.humidity": { state: "61", attributes: {} }
+    },
+    user: { id: "owner" }
+  });
+  const card = createCard(hass);
+
+  assert.equal(card._checkCondition({ condition: "state", entity: "binary_sensor.window", state: "off" }, hass), true);
+  assert.equal(card._checkCondition({ condition: "numeric_state", entity: "sensor.humidity", above: 60, below: 70 }, hass), true);
+  assert.equal(card._checkCondition({ condition: "user", users: ["owner"] }, hass), true);
+  assert.equal(card._checkCondition({
+    condition: "and",
+    conditions: [
+      { condition: "state", entity: "binary_sensor.window", state: "off" },
+      { condition: "not", conditions: [{ condition: "numeric_state", entity: "sensor.humidity", above: 70 }] }
+    ]
+  }, hass), true);
+  assert.equal(card._checkConditions([{ condition: "numeric_state", entity: "sensor.humidity", below: 60 }], hass), false);
+});
+
+test("alert configuration normalizes states and evaluates thresholds", () => {
+  const card = createCard();
+
+  assert.deepEqual(
+    card._normalizeAlertSensorConfig({ entity: "sensor.status", state: "Warning, Error" }),
+    { entity: "sensor.status", state: ["warning", "error"] }
+  );
+  assert.equal(card._isAlertSensorActive(
+    { entity: "sensor.status", state: ["warning"] },
+    { state: "WARNING", attributes: {} }
+  ), true);
+  assert.equal(card._isAlertSensorActive(
+    { entity: "sensor.humidity", above: 60 },
+    { state: "61", attributes: {} }
+  ), true);
+  assert.equal(card._isAlertSensorActive(
+    { entity: "sensor.humidity", below: 20 },
+    { state: "25", attributes: {} }
+  ), false);
+});
+
+test("slider capabilities convert supported domains without service calls", () => {
+  const hass = createHass({
+    states: {
+      "light.ceiling": { state: "on", attributes: { brightness: 128 } },
+      "climate.room": { state: "heat", attributes: { min_temp: 10, max_temp: 30, temperature: 21 } },
+      "media_player.room": { state: "playing", attributes: { volume_level: 0.42 } }
+    }
+  });
+  const card = createCard(hass);
+
+  assert.deepEqual(
+    card._getSliderCapabilities("light", hass.states["light.ceiling"], { entity: "light.ceiling" }),
+    { supported: true, min: 0, max: 100, step: 1, value: 50, pct: 50, action: "brightness" }
+  );
+  assert.equal(card._getSliderCapabilities("climate", hass.states["climate.room"], { entity: "climate.room" }).value, 21);
+  assert.equal(card._getSliderCapabilities("media_player", hass.states["media_player.room"], { entity: "media_player.room" }).value, 42);
+  assert.equal(hass.__serviceCalls.length, 0);
+});
+
+test("actions dispatch the Home Assistant action contract and suppress unavailable entities", () => {
+  const hass = createHass({
+    states: {
+      "light.ceiling": { state: "on", attributes: {} },
+      "light.offline": { state: "unavailable", attributes: {} }
+    }
+  });
+  const card = createCard(hass);
+  const events = [];
+  card.addEventListener("hass-action", (event) => events.push(event.detail));
+
+  card._fireAction("tap", {
+    entity: "light.ceiling",
+    tap_action: { action: "toggle" }
+  });
+  card._fireAction("tap", {
+    entity: "light.offline",
+    tap_action: { action: "toggle" }
+  });
+
+  assert.deepEqual(events, [{
+    action: "tap",
+    config: {
+      entity: "light.ceiling",
+      tap_action: { action: "toggle" }
+    }
+  }]);
+});
+
+test("disconnecting a card clears timers, intervals, and pending sparkline requests", () => {
+  const card = new RoomCard();
+  const timeout = setTimeout(() => {}, 60_000);
+  card._activeTimers.add(timeout);
+  card._lastChangedInterval = setInterval(() => {}, 60_000);
+  card._sparklineInterval = setInterval(() => {}, 60_000);
+  card._sparklinePending.set("sensor.test|24", Promise.resolve([]));
+
+  card.disconnectedCallback();
+
+  assert.equal(card._activeTimers.size, 0);
+  assert.equal(card._lastChangedInterval, null);
+  assert.equal(card._sparklineInterval, null);
+  assert.equal(card._sparklinePending.size, 0);
+});

--- a/tests/support/dom-env.mjs
+++ b/tests/support/dom-env.mjs
@@ -1,0 +1,100 @@
+import { readFile } from "node:fs/promises";
+import { Window } from "happy-dom";
+
+const browserGlobals = [
+  "Node",
+  "Element",
+  "HTMLElement",
+  "HTMLInputElement",
+  "HTMLButtonElement",
+  "Event",
+  "CustomEvent",
+  "KeyboardEvent",
+  "MouseEvent",
+  "PointerEvent",
+  "MutationObserver",
+  "ResizeObserver",
+  "FormData",
+  "File",
+  "Blob",
+  "URL",
+  "CSS"
+];
+
+export const installDomEnvironment = () => {
+  const window = new Window({ url: "http://localhost/lovelace/0" });
+  const installGlobal = (name, value) => {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value
+    });
+  };
+
+  installGlobal("window", window);
+  installGlobal("document", window.document);
+  installGlobal("customElements", window.customElements);
+  installGlobal("navigator", window.navigator);
+  installGlobal("localStorage", window.localStorage);
+  installGlobal("history", window.history);
+  installGlobal("location", window.location);
+  installGlobal("getComputedStyle", window.getComputedStyle.bind(window));
+  installGlobal("requestAnimationFrame", window.requestAnimationFrame.bind(window));
+  installGlobal("cancelAnimationFrame", window.cancelAnimationFrame.bind(window));
+
+  for (const name of browserGlobals) {
+    if (window[name]) installGlobal(name, window[name]);
+  }
+
+  return window;
+};
+
+export const importRoomCard = async (extraExports = []) => {
+  const sourceUrl = new URL("../../dist/room-card.js", import.meta.url);
+  const source = await readFile(sourceUrl, "utf8");
+  const exportStatement = extraExports.length > 0
+    ? `\nexport { ${extraExports.join(", ")} };`
+    : "";
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(`${source}${exportStatement}`).toString("base64")}`;
+  return import(moduleUrl);
+};
+
+export const createHass = (overrides = {}) => {
+  const serviceCalls = [];
+  const hass = {
+    language: "en",
+    locale: { language: "en-US", number_format: "comma_decimal" },
+    config: {
+      unit_system: {
+        temperature: "°C",
+        length: "km",
+        pressure: "Pa"
+      }
+    },
+    user: { id: "test-user" },
+    entities: {},
+    states: {},
+    panels: {},
+    callService(domain, service, data) {
+      serviceCalls.push({ domain, service, data });
+    },
+    callWS: async () => ({}),
+    fetchWithAuth: async () => ({ ok: true, json: async () => ({ id: "image-id" }) }),
+    connection: {
+      sendMessagePromise: async () => ({ views: [] })
+    },
+    formatEntityState(stateObj) {
+      const unit = stateObj?.attributes?.unit_of_measurement;
+      return unit ? `${stateObj.state} ${unit}` : String(stateObj?.state ?? "");
+    },
+    formatEntityAttributeValue(stateObj, attribute) {
+      return String(stateObj?.attributes?.[attribute] ?? "");
+    },
+    ...overrides
+  };
+
+  hass.__serviceCalls = serviceCalls;
+  return hass;
+};
+
+export const wait = (milliseconds = 0) => new Promise((resolve) => setTimeout(resolve, milliseconds));


### PR DESCRIPTION
## Summary
- add a pinned Happy DOM test environment without runtime dependencies
- cover formatting, templates, visibility, alerts, sliders, actions, and lifecycle cleanup
- cover cold editor rendering, native/legacy/current input fallbacks, deferred saves, and config events

## Validation
- `npm run check`
- 12 tests passing

Advances #96. Additional security and media regressions will land with their dedicated implementation packages.