### PR TITLE
ci: harden release and modularization gates

### DIFF
--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -31,8 +31,14 @@ jobs:
       - name: Verify committed distribution
         run: git diff --exit-code -- dist/room-card.js
 
-      - name: Run checks
-        run: npm run check
+      - name: Check JavaScript syntax
+        run: npm run check:syntax
+
+      - name: Verify release metadata
+        run: npm run check:dist
+
+      - name: Run automated regression tests
+        run: npm test
 
       - name: HACS Action
         uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main, reviewed 2026-08-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to OneLine Room Card are documented here.
 * Runtime & Editor: Add `show_status_border` (default `true`) so warning outlines and glow can be disabled without hiding active sensor chips. Closes [#106](https://github.com/lop1505/RoomCard/issues/106).
 * Security: Render entity-derived labels, states, alert chips, modes, and sub-chips through DOM text APIs. Template content is text-only by default with an explicit `trusted_html: true` compatibility opt-in, and the JavaScript-template trust boundary is documented. Closes [#95](https://github.com/lop1505/RoomCard/issues/95).
 * Performance: Track literal or declared template dependencies, skip unchanged template DOM work, share and bound sparkline history requests/cache across cards, and pause polling for hidden or off-screen cards. Closes [#98](https://github.com/lop1505/RoomCard/issues/98).
+* CI: Document the manual release checklist, make syntax/release/test checks explicit, and add regression coverage for tag/version consistency. Closes [#99](https://github.com/lop1505/RoomCard/issues/99).
+* Developer documentation: Select and gate the future single-artifact build approach, record modularization failure modes, and add a manual Home Assistant smoke-test matrix as the first deliverable for [#100](https://github.com/lop1505/RoomCard/issues/100).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@
 - `docs/` contains screenshots and supporting documentation.
 
 The current source intentionally remains a single file. Structural extraction should happen only in small, test-gated changes so existing Home Assistant behavior remains stable.
+See [the modularization plan](docs/modularization-plan.md) and [manual Home Assistant smoke-test matrix](docs/manual-smoke-test.md) before changing the build pipeline or moving source code.
 
 ## Local checks
 
@@ -33,3 +34,20 @@ For a release, keep these values identical:
 - the newest version heading in `CHANGELOG.md`
 - the “What's new” version in `README.md`
 - the Git tag in the form `vX.Y.Z`
+
+## Manual release checklist
+
+Release publication remains manual. CI validates a release but does not create a
+GitHub release or publish artifacts.
+
+1. Update `VERSION`, `package.json`, the README “What's new” heading, and the
+   newest changelog version to the same `X.Y.Z` value.
+2. Move applicable Unreleased entries under that changelog version.
+3. Run `npm ci`, `npm run build`, and `npm run check` from a clean checkout.
+4. Run the Home Assistant checks in `docs/manual-smoke-test.md` when runtime,
+   editor, build, or packaging behavior changed.
+5. Commit the generated `dist/room-card.js` and any changed `dist/rooms/` assets.
+6. Merge only after the Validate workflow and HACS validation pass.
+7. Create and push the annotated tag `vX.Y.Z`; tag CI will reject a mismatch.
+8. Manually create the GitHub release and attach/package the tested `dist/`
+   contents according to the existing HACS release process.

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the full release history.
 
 ## 🛠️ Development
 
-The canonical source lives in `src/room-card.js`; `dist/room-card.js` is the generated HACS artifact. See [CONTRIBUTING.md](CONTRIBUTING.md) for the repository layout and the build, test, and release checks.
+The canonical source lives in `src/room-card.js`; `dist/room-card.js` is the generated HACS artifact. See [CONTRIBUTING.md](CONTRIBUTING.md) for the repository layout and the build, test, and release checks. Structural work follows the [test-gated modularization plan](docs/modularization-plan.md) and [manual Home Assistant smoke-test matrix](docs/manual-smoke-test.md).
 
 ---
 

--- a/dist/room-card.js
+++ b/dist/room-card.js
@@ -8100,9 +8100,11 @@ if (!existingCard) {
 }
 
 window.customCards = window.customCards || [];
-window.customCards.push({
-  type: "oneline-room-card",
-  name: "OneLine Room Card",
-  preview: true,
-  description: "Minimalist Room Card for Home Assistant"
-});
+if (!window.customCards.some((card) => card?.type === "oneline-room-card")) {
+  window.customCards.push({
+    type: "oneline-room-card",
+    name: "OneLine Room Card",
+    preview: true,
+    description: "Minimalist Room Card for Home Assistant"
+  });
+}

--- a/docs/manual-smoke-test.md
+++ b/docs/manual-smoke-test.md
@@ -1,0 +1,24 @@
+# Manual Home Assistant smoke-test matrix
+
+Run this matrix before approving a build-pipeline or modularization gate. Record
+the Home Assistant version, browser, viewport, theme, commit SHA, and result.
+
+| Area | Check | Expected result |
+|---|---|---|
+| Fresh load | Hard-refresh a dashboard containing minimal and fully configured RoomCards | Cards load without console errors, duplicate registration, or extra module requests |
+| Cold editor | Open the visual editor before HA internal text fields have been used elsewhere | Native fallback is editable; delayed HA input registration does not clear values |
+| Editor persistence | Change fields with live preview on/off, save, close, and reopen | Preview and saved YAML agree; no pending change is lost |
+| Responsive layout | Check narrow mobile and desktop widths | Controls wrap without clipping; media artwork remains square |
+| Themes | Check light and dark themes | Text, badges, chips, focus outlines, and controls remain readable |
+| Collapse | Test fixed, collapsed, expanded, and remembered states across navigation/reload | State and persistence match configuration |
+| Actions | Exercise tap, hold, double tap, navigation, toggle, and service actions | Exactly one expected HA action/service call occurs |
+| Controls | Exercise climate slider/presets, cover actions/presets, light brightness/colors, media transport/volume, and select options | UI state and service payloads are correct |
+| Sensors | Trigger battery, humidity, presence, window, and configured alerts | Chips, optional status border, and alert dialog update correctly |
+| Templates | Test static, dependency-tracked, and trusted-HTML template examples | Output updates only for relevant state changes and follows the documented trust model |
+| Sparklines | Use two cards with the same sensor, scroll them off/on screen, and hide/show the tab | History is shared, polling pauses, and stale data refreshes on return |
+| Images | Select a preset, move focal point, and upload a valid/invalid image | Preview, validation, upload, and persisted configuration remain correct |
+| Navigation cleanup | Repeatedly enter/leave the dashboard and recreate editor previews | No orphan timers, observers, dialogs, or increasing history traffic remain |
+
+Gate approval requires all rows to pass. Attach failures to the gate PR; do not
+continue to the next extraction phase while any result is unexplained.
+

--- a/docs/modularization-plan.md
+++ b/docs/modularization-plan.md
@@ -1,0 +1,97 @@
+# Test-gated modularization plan
+
+This note is the Phase 0 / first-deliverable decision for issue #100. It does
+not authorize a source split. The current single-file source and copy build
+remain the known-good rollback point until a separate Gate 1 pull request is
+reviewed and manually smoke-tested in Home Assistant.
+
+## Build approach decision
+
+Use **esbuild**, pinned exactly to `0.28.2`, for the future Gate 1 experiment.
+That version was reviewed on 2026-08-20 from the [official npm package](https://www.npmjs.com/package/esbuild).
+It is selected because it can bundle ESM into one readable, unminified ESM
+artifact without adding a browser/runtime dependency. Rollup remains the
+fallback if esbuild changes registration order or output semantics.
+
+The Gate 1 experiment must use these constraints:
+
+```js
+{
+  bundle: true,
+  format: "esm",
+  minify: false,
+  sourcemap: false,
+  outfile: "dist/room-card.js"
+}
+```
+
+The esbuild dependency is deliberately not installed by this planning change.
+Adding it, replacing the current copy build, or moving code requires its own
+reversible PR. That PR must compare the generated artifact against the current
+baseline and pass the manual matrix in `docs/manual-smoke-test.md`.
+
+## Current baseline and artifact contract
+
+- `src/room-card.js` is the canonical, single-file source.
+- `dist/room-card.js` is the readable generated HACS artifact.
+- `scripts/build.mjs` currently performs a deterministic byte-for-byte copy.
+- `scripts/check-release.mjs` rejects stale output and version drift.
+- CI builds from a clean checkout, rejects a changed artifact, runs syntax and
+  regression checks, then runs the HACS validator.
+- The artifact contains no runtime imports or external browser dependencies.
+- All registration remains in the same entry artifact and is duplicate-safe.
+  Card/editor/`window.customCards` registration shares the final registration
+  block; the compatibility input remains guarded directly after its class until
+  a later gated move can preserve its cold-load order.
+
+This establishes a known-good build/test baseline without changing runtime
+behavior. Automated coverage includes cold-load editor behavior, actions,
+service calls, media, alerts, images, templates, sparklines, security boundaries,
+multi-card performance, and lifecycle cleanup. Manual Home Assistant coverage
+remains a required Gate 1 check because tests do not reproduce every internal
+HA component-loading order.
+
+## Recovered and likely failure modes
+
+No preserved modular branch or patch was found in the reachable repository
+history. The available evidence and current architecture identify these concrete
+risks:
+
+1. Runtime ESM imports would violate the single-artifact HACS contract.
+2. Moving registration can define custom elements twice or in the wrong order.
+3. Extracted editor callbacks can lose `this`, live-preview state, pending-save
+   state, or drag/drop state.
+4. Home Assistant may open the editor before `ha-input` / `ha-textfield` exists;
+   the native compatibility fallback must survive intact.
+5. A build that is not checked from a clean checkout can silently publish stale
+   `dist/room-card.js`.
+6. Combining file moves with behavior changes makes failures hard to explain and
+   removes the safe rollback point.
+
+## Gates and PR boundaries
+
+1. **Gate 0 — baseline:** keep all checks green and complete the manual smoke
+   matrix before changing the build tool.
+2. **Gate 1 — bundler only:** pin esbuild, bundle the unchanged source, verify
+   deterministic readable output, registration count/order, cold load, editor
+   save, and HACS validation. Stop and revert if any result is unexplained.
+3. **Gate 2 — pure helpers:** extract one tested helper family per PR. No DOM,
+   timer, global, or `this` dependencies may enter `lib/`.
+4. **Gate 3 — translations:** move dictionaries only after adding locale key
+   parity coverage; do not edit wording in the move.
+5. **Gates 4–5 — isolated services/runtime:** use explicit inputs and callbacks;
+   keep DOM/listener ownership in the card until interfaces are proven.
+6. **Gate 6 — editor last:** first move the compatibility wrapper intact, then
+   the editor class intact. Section renderers are a later decision.
+
+Every gate is a separate PR and rollback point. A failed gate is reverted rather
+than repaired by stacking more structural changes on top.
+
+## Intended dependency direction
+
+```text
+entry → card/editor → lib/i18n
+```
+
+`lib` and `i18n` must never import card or editor code. Custom-element and
+`window.customCards` registration stays exclusively in the entry module.

--- a/src/room-card.js
+++ b/src/room-card.js
@@ -8100,9 +8100,11 @@ if (!existingCard) {
 }
 
 window.customCards = window.customCards || [];
-window.customCards.push({
-  type: "oneline-room-card",
-  name: "OneLine Room Card",
-  preview: true,
-  description: "Minimalist Room Card for Home Assistant"
-});
+if (!window.customCards.some((card) => card?.type === "oneline-room-card")) {
+  window.customCards.push({
+    type: "oneline-room-card",
+    name: "OneLine Room Card",
+    preview: true,
+    description: "Minimalist Room Card for Home Assistant"
+  });
+}

--- a/tests/build-release-contract.test.mjs
+++ b/tests/build-release-contract.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { installDomEnvironment } from "./support/dom-env.mjs";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+test("the committed HACS artifact is deterministic, self-contained, and registers once", async () => {
+  installDomEnvironment();
+  const [source, distribution] = await Promise.all([
+    readFile(resolve(repositoryRoot, "src/room-card.js"), "utf8"),
+    readFile(resolve(repositoryRoot, "dist/room-card.js"), "utf8")
+  ]);
+  assert.equal(distribution, source);
+  assert.equal(/^\s*import\s/m.test(distribution), false);
+
+  const load = (suffix) => import(`data:text/javascript;base64,${Buffer.from(`${distribution}\n// ${suffix}`).toString("base64")}`);
+  await load("first registration pass");
+  await load("second registration pass");
+
+  assert.ok(customElements.get("oneline-room-card-textfield"));
+  assert.ok(customElements.get("oneline-room-card"));
+  assert.ok(customElements.get("oneline-room-card-editor"));
+  assert.equal(window.customCards.filter((card) => card.type === "oneline-room-card").length, 1);
+});
+
+test("release metadata accepts the matching tag and rejects a mismatched tag clearly", async () => {
+  const source = await readFile(resolve(repositoryRoot, "src/room-card.js"), "utf8");
+  const version = source.match(/const VERSION = "(\d+\.\d+\.\d+)";/)?.[1];
+  assert.ok(version);
+  const runCheck = (tag) => spawnSync(process.execPath, ["scripts/check-release.mjs"], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    env: { ...process.env, GITHUB_REF_TYPE: "tag", GITHUB_REF_NAME: tag }
+  });
+
+  const matching = runCheck(`v${version}`);
+  assert.equal(matching.status, 0, matching.stderr);
+  assert.match(matching.stdout, new RegExp(`consistent for v${version.replaceAll(".", "\\.")}`));
+
+  const mismatch = runCheck("v9.9.9");
+  assert.notEqual(mismatch.status, 0);
+  assert.match(mismatch.stderr, new RegExp(`Tag v9\\.9\\.9 does not match source version ${version.replaceAll(".", "\\.")}`));
+});


### PR DESCRIPTION
## Summary
- make syntax, release metadata, regression, and HACS validation explicit in CI while retaining immutable action SHAs and minimal permissions
- test matching and mismatched release tags with clear failures
- verify the committed HACS artifact is deterministic, self-contained, and duplicate-safe at registration time
- document a complete manual release checklist
- deliver Phase 0 for #100: select the future pinned esbuild approach, record known failure modes and rollback gates, and add a manual Home Assistant smoke-test matrix

## Scope boundary
This intentionally does **not** split source files or install a bundler. Issue #100 explicitly requires the design/gate deliverable first and remains open for separate reversible phase PRs.

## Verification
- `npm run build`
- `npm run check` (36 tests passing)

Closes #99
Progresses #100