### PR TITLE
fix: track template sub-chip attributes

### DIFF
--- a/dist/room-card.js
+++ b/dist/room-card.js
@@ -1546,9 +1546,13 @@ class OneLineRoomCard extends HTMLElement {
 
   _getTemplateDependencyEntityIds() {
     const ids = new Set();
+    const add = (entityId) => {
+      if (typeof entityId === "string" && entityId.trim()) ids.add(entityId.trim());
+    };
     for (const ctrl of (Array.isArray(this.config?.controls) ? this.config.controls : [])) {
       if (ctrl?.type !== "template") continue;
-      getTemplateEntityDependencies(ctrl).forEach((entityId) => ids.add(entityId));
+      getTemplateEntityDependencies(ctrl).forEach(add);
+      (Array.isArray(ctrl.sub_chips) ? ctrl.sub_chips : []).forEach((chip) => add(chip?.entity));
     }
     return ids;
   }

--- a/src/room-card.js
+++ b/src/room-card.js
@@ -1546,9 +1546,13 @@ class OneLineRoomCard extends HTMLElement {
 
   _getTemplateDependencyEntityIds() {
     const ids = new Set();
+    const add = (entityId) => {
+      if (typeof entityId === "string" && entityId.trim()) ids.add(entityId.trim());
+    };
     for (const ctrl of (Array.isArray(this.config?.controls) ? this.config.controls : [])) {
       if (ctrl?.type !== "template") continue;
-      getTemplateEntityDependencies(ctrl).forEach((entityId) => ids.add(entityId));
+      getTemplateEntityDependencies(ctrl).forEach(add);
+      (Array.isArray(ctrl.sub_chips) ? ctrl.sub_chips : []).forEach((chip) => add(chip?.entity));
     }
     return ids;
   }

--- a/tests/performance-behavior.test.mjs
+++ b/tests/performance-behavior.test.mjs
@@ -126,16 +126,16 @@ test("template controls refresh sub-chips even when template output is unchanged
     controls: [{
       type: "template",
       content: "Static",
-      sub_chips: [{ entity: "sensor.sub_chip", label: "Value {state}" }]
+      sub_chips: [{ entity: "sensor.sub_chip", attribute: "custom_status", label: "Value {state}" }]
     }]
   };
   const card = createRenderedCard(config, createHass({
-    states: { "sensor.sub_chip": { state: "one", attributes: {} } }
+    states: { "sensor.sub_chip": { state: "unchanged", attributes: { custom_status: "one" } } }
   }));
   assert.equal(card.shadowRoot.querySelector(".btn-chip span").textContent, "Value one");
 
   card.hass = createHass({
-    states: { "sensor.sub_chip": { state: "two", attributes: {} } }
+    states: { "sensor.sub_chip": { state: "unchanged", attributes: { custom_status: "two" } } }
   });
   assert.equal(card.shadowRoot.querySelector(".btn-chip span").textContent, "Value two");
   card.remove();


### PR DESCRIPTION
## Summary

- include entities used by template sub-chips in the full-state dependency set
- trigger template-control reevaluation when a sub-chip attribute changes without an entity-state change
- harden the existing sub-chip regression test around this exact attribute-only update path

## Context

Follow-up to the post-merge review finding on #120: template output signatures already included rendered sub-chips, but `_shouldUpdateFromHass` could still stop before recomputing them because sub-chip-only entities used the limited state signature.

## Validation

- `npm run build`
- `npm run check`
- 42/42 automated tests passing
- generated `dist/room-card.js` verified against `src/room-card.js`