### PR TITLE
chore: prepare RoomCard 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to OneLine Room Card are documented here.
 
 ## [Unreleased]
 
+---
+
+## [1.4.0]
+
 * Reliability & Accessibility: Refresh templates for arbitrary dependency-attribute changes, keep template sub-chips live, preserve media-control focus, remove collapsed controls from the tab order, expose a separate collapse button when the header has another action, and rebuild already-open editors after bundle upgrades.
 * Runtime: Split full media-player controls into separate transport and volume rows, add Previous, respect `supported_features`, and keep artwork square on compact cards. Closes [#102](https://github.com/lop1505/RoomCard/issues/102).
 * Accessibility: Add keyboard activation, ARIA state and labels, visible focus, semantic inline controls, and modal focus management for the alert dialog. Closes [#97](https://github.com/lop1505/RoomCard/issues/97).

--- a/README.md
+++ b/README.md
@@ -9,29 +9,34 @@
 A clean, performant, and fully visually configurable room card for Home Assistant.
 Developed with a focus on stability, simple design, and maximum flexibility.
 
-## Screenshots
+## 📸 Screenshots
 
-**Full-width room controls**
+**🎛️ Full-width room controls**
 
 ![RoomCard with full-width controls for climate, lights, and covers](docs/images/roomcard-full-width.png)
 
-**Compact grid layout**
+**📱 Compact grid layout**
 
 ![Two compact RoomCards in a responsive grid](docs/images/roomcard-grid.png)
 
-**Collapsed view**
+**🗂️ Collapsed view**
 
 ![Collapsed RoomCard](docs/images/roomcard-collapsed.png)
 
 ---
 
-## 🆕 What's new in 1.3.1
+## 🆕 What's new in 1.4.0
 
-* 🏠 Choose from 16 bundled room-image presets in **Configuration → Header → Image → Built-in room image**
-* 🖼️ Custom image URLs and Home Assistant uploads remain supported and take precedence over presets
-* 🔄 Display-precision, unit, device-class and locale-number-format changes now refresh immediately without waiting for the entity state to change
+* 🖼️ Position header images with a visual focal-point editor and upload validated, automatically optimized JPEG, PNG, or WebP files
+* ▶️ Use improved media controls with separate transport and volume rows, Previous support, square artwork, and stable keyboard focus
+* 📈 Configure the card-level sparkline refresh interval; shared history requests and visibility-aware polling reduce background work
+* 🚨 Disable warning borders independently while keeping active sensor chips visible
+* ♿ Navigate cards, collapsed controls, dialogs, and inline actions with improved keyboard and screen-reader support
+* ⚡ Keep template controls and sub-chips current when arbitrary referenced attributes change
+* 🛡️ Render state-derived content safely by default, with trusted template HTML available only through explicit opt-in
+* 🧪 Rely on expanded runtime/editor regression coverage and stricter release/HACS validation
 
-All 1.3.1 options are available in the visual editor and remain backwards compatible with existing cards.
+All 1.4.0 options remain backwards compatible with existing cards.
 
 ---
 

--- a/dist/room-card.js
+++ b/dist/room-card.js
@@ -1,4 +1,4 @@
-const VERSION = "1.3.1";
+const VERSION = "1.4.0";
 const EDITOR_DOM_REVISION = "2";
 const LOG_FLAG = `customCards_RoomCard_Logged_${VERSION}`;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oneline-room-card",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oneline-room-card",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "devDependencies": {
         "happy-dom": "20.11.6"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oneline-room-card",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/room-card.js
+++ b/src/room-card.js
@@ -1,4 +1,4 @@
-const VERSION = "1.3.1";
+const VERSION = "1.4.0";
 const EDITOR_DOM_REVISION = "2";
 const LOG_FLAG = `customCards_RoomCard_Logged_${VERSION}`;
 


### PR DESCRIPTION
## Summary
- bump RoomCard release metadata and the built artifact to v1.4.0
- move completed changes from Unreleased into the 1.4.0 changelog
- refresh README highlights, screenshots, and visual icons

## Validation
- `npm run check`
- 42 automated tests passed
- manual Home Assistant smoke test passed on Core 2026.8.2 / Frontend 20260729.7
- tag/version consistency verified for `v1.4.0`

## Release
- backward compatible with existing cards
- GitHub release publication and tag creation remain manual after merge