### PR TITLE
build: establish esbuild gate 1 for v1.5 modularization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to OneLine Room Card are documented here.
 
 ## [Unreleased]
 
+* Build: Introduce pinned esbuild 0.28.2 as the first isolated step toward #100. Keep runtime/editor behavior and the single-file HACS delivery unchanged; verify a fresh reproducible build, registration order, explicit helper test imports, and adjacent room-image assets. Source extraction and the Room Detail Drawer remain gated follow-up work for v1.5.0.
+
 ---
 
 ## [1.4.0]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ See [the modularization plan](docs/modularization-plan.md) and [manual Home Assi
 ## Local checks
 
 Node.js 20 or newer is required. The project has no runtime dependencies.
+The build uses esbuild pinned to `0.28.2`. It produces one readable ESM file,
+without minification, code splitting, source maps, or runtime imports.
 
 ```sh
 npm ci
@@ -24,12 +26,23 @@ npm run check
 
 After changing `src/room-card.js`, always run `npm run build` and commit the matching `dist/room-card.js` artifact. CI rejects stale distribution output and inconsistent release versions.
 
+`scripts/build-config.mjs` owns the shared build options. `npm run check:dist`
+builds into an isolated temporary directory, compares that artifact byte for
+byte with the committed distribution, and removes only its temporary output.
+It does not repair or overwrite a stale committed artifact. `dist/rooms/` stays
+alongside the bundle and is not transformed by esbuild.
+
+Runtime/editor tests import the actual distribution. Direct helper assertions
+use explicit named ESM exports declared in the source, not exports appended to
+bundler-generated text. These internal test seams are not a supported consumer
+API; they will move with their owning modules during the gated extraction.
+
 ## Release metadata
 
 For a release, keep these values identical:
 
 - `const VERSION` in `src/room-card.js`
-- `const VERSION` in `dist/room-card.js`
+- the generated `VERSION` value in `dist/room-card.js` (esbuild may emit `var`)
 - `version` in `package.json`
 - the newest version heading in `CHANGELOG.md`
 - the “What's new” version in `README.md`

--- a/dist/room-card.js
+++ b/dist/room-card.js
@@ -1,8 +1,8 @@
-const VERSION = "1.4.0";
-const EDITOR_DOM_REVISION = "6";
-const LOG_FLAG = `customCards_RoomCard_Logged_${VERSION}`;
-
-const MEDIA_PLAYER_FEATURES = Object.freeze({
+// src/room-card.js
+var VERSION = "1.4.0";
+var EDITOR_DOM_REVISION = "6";
+var LOG_FLAG = `customCards_RoomCard_Logged_${VERSION}`;
+var MEDIA_PLAYER_FEATURES = Object.freeze({
   PAUSE: 1,
   VOLUME_SET: 4,
   VOLUME_MUTE: 8,
@@ -10,32 +10,26 @@ const MEDIA_PLAYER_FEATURES = Object.freeze({
   NEXT_TRACK: 32,
   PLAY: 16384
 });
-
-const IMAGE_UPLOAD_LIMITS = Object.freeze({
+var IMAGE_UPLOAD_LIMITS = Object.freeze({
   maxSourceBytes: 20 * 1024 * 1024,
   maxDimension: 2560,
   quality: 0.86,
   supportedTypes: ["image/jpeg", "image/png", "image/webp"]
 });
-
-const parseImagePosition = (value) => {
-  const match = typeof value === "string"
-    ? value.trim().match(/^(-?\d+(?:\.\d+)?)%\s+(-?\d+(?:\.\d+)?)%$/)
-    : null;
+var parseImagePosition = (value) => {
+  const match = typeof value === "string" ? value.trim().match(/^(-?\d+(?:\.\d+)?)%\s+(-?\d+(?:\.\d+)?)%$/) : null;
   if (!match) return { x: 50, y: 50, value: "50% 50%", isDefault: true };
   const x = Math.max(0, Math.min(100, Number(match[1])));
   const y = Math.max(0, Math.min(100, Number(match[2])));
   return { x, y, value: `${x}% ${y}%`, isDefault: x === 50 && y === 50 };
 };
-
-const validateImageUpload = (file) => {
+var validateImageUpload = (file) => {
   if (!file || !IMAGE_UPLOAD_LIMITS.supportedTypes.includes(String(file.type || "").toLowerCase())) return "upload_unsupported";
   if (!Number.isFinite(file.size) || file.size <= 0) return "upload_decode_error";
   if (file.size > IMAGE_UPLOAD_LIMITS.maxSourceBytes) return "upload_too_large";
   return "";
 };
-
-const ROOM_IMAGE_PRESETS = Object.freeze([
+var ROOM_IMAGE_PRESETS = Object.freeze([
   { id: "living-room", file: "living-room.jpg", labelKey: "image_preset_living_room" },
   { id: "kitchen", file: "kitchen.jpg", labelKey: "image_preset_kitchen" },
   { id: "bedroom", file: "bedroom.jpg", labelKey: "image_preset_bedroom" },
@@ -53,9 +47,8 @@ const ROOM_IMAGE_PRESETS = Object.freeze([
   { id: "attic", file: "attic.jpg", labelKey: "image_preset_attic" },
   { id: "workshop", file: "workshop.jpg", labelKey: "image_preset_workshop" }
 ]);
-const ROOM_IMAGE_PRESET_MAP = new Map(ROOM_IMAGE_PRESETS.map((preset) => [preset.id, preset]));
-
-const getRoomImagePresetUrl = (presetId) => {
+var ROOM_IMAGE_PRESET_MAP = new Map(ROOM_IMAGE_PRESETS.map((preset) => [preset.id, preset]));
+var getRoomImagePresetUrl = (presetId) => {
   const preset = ROOM_IMAGE_PRESET_MAP.get(String(presetId || ""));
   if (!preset) return "";
   let url;
@@ -67,24 +60,21 @@ const getRoomImagePresetUrl = (presetId) => {
   url.searchParams.set("v", VERSION);
   return url.href;
 };
-
-const resolveRoomImageUrl = (config) => {
+var resolveRoomImageUrl = (config) => {
   const customImage = typeof config?.image === "string" ? config.image.trim() : "";
   if (customImage) return customImage;
   return getRoomImagePresetUrl(config?.image_preset);
 };
-
-const parseTimeOfDay = (value) => {
+var parseTimeOfDay = (value) => {
   const match = typeof value === "string" ? value.trim().match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/) : null;
   if (!match) return null;
   const hours = Number(match[1]);
   const minutes = Number(match[2]);
   const seconds = Number(match[3] || 0);
   if (hours > 23 || minutes > 59 || seconds > 59) return null;
-  return (hours * 3600) + (minutes * 60) + seconds;
+  return hours * 3600 + minutes * 60 + seconds;
 };
-
-const evaluateAdaptiveImageCondition = (condition, hass, now = new Date()) => {
+var evaluateAdaptiveImageCondition = (condition, hass, now = /* @__PURE__ */ new Date()) => {
   if (!condition || typeof condition !== "object") return { valid: false, active: false };
   const type = condition.condition;
   if (type === "state") {
@@ -93,13 +83,11 @@ const evaluateAdaptiveImageCondition = (condition, hass, now = new Date()) => {
     const stateObj = hass?.states?.[entity];
     if (!stateObj || isEntityOffline(stateObj)) return { valid: false, active: false };
     const current = String(stateObj.state ?? "");
-    if (condition.state_not !== undefined && trimStr(String(condition.state_not)) !== "") {
+    if (condition.state_not !== void 0 && trimStr(String(condition.state_not)) !== "") {
       const excluded = (Array.isArray(condition.state_not) ? condition.state_not : [condition.state_not]).map(String);
       return { valid: true, active: !excluded.includes(current) };
     }
-    const expected = (Array.isArray(condition.state) ? condition.state : [condition.state])
-      .filter((value) => value !== undefined && trimStr(String(value)) !== "")
-      .map(String);
+    const expected = (Array.isArray(condition.state) ? condition.state : [condition.state]).filter((value) => value !== void 0 && trimStr(String(value)) !== "").map(String);
     return expected.length > 0 ? { valid: true, active: expected.includes(current) } : { valid: false, active: false };
   }
   if (type === "numeric_state") {
@@ -116,28 +104,29 @@ const evaluateAdaptiveImageCondition = (condition, hass, now = new Date()) => {
     const below = resolveThreshold(condition.below);
     const stateObj = entity ? hass?.states?.[entity] : null;
     const value = Number(stateObj?.state);
-    if (!entity || (above === null && below === null) || !stateObj || isEntityOffline(stateObj) || !Number.isFinite(value)) return { valid: false, active: false };
+    if (!entity || above === null && below === null || !stateObj || isEntityOffline(stateObj) || !Number.isFinite(value)) return { valid: false, active: false };
     return { valid: true, active: (above === null || value > above) && (below === null || value < below) };
   }
   if (type === "time") {
-    const after = condition.after === undefined ? null : parseTimeOfDay(condition.after);
-    const before = condition.before === undefined ? null : parseTimeOfDay(condition.before);
+    const after = condition.after === void 0 ? null : parseTimeOfDay(condition.after);
+    const before = condition.before === void 0 ? null : parseTimeOfDay(condition.before);
     const weekdays = Array.isArray(condition.weekday) ? condition.weekday.map((day) => String(day).toLowerCase()) : [];
     const weekdayNames = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
     if (after === null && before === null && weekdays.length === 0) return { valid: false, active: false };
-    if ((condition.after !== undefined && after === null) || (condition.before !== undefined && before === null)) return { valid: false, active: false };
+    if (condition.after !== void 0 && after === null || condition.before !== void 0 && before === null) return { valid: false, active: false };
     if (weekdays.some((day) => !weekdayNames.includes(day))) return { valid: false, active: false };
-    const current = (now.getHours() * 3600) + (now.getMinutes() * 60) + now.getSeconds();
-    const timeActive = after !== null && before !== null && after > before
-      ? current > after || current < before
-      : (after === null || current > after) && (before === null || current < before);
+    const current = now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds();
+    const timeActive = after !== null && before !== null && after > before ? current > after || current < before : (after === null || current > after) && (before === null || current < before);
     return { valid: true, active: timeActive && (weekdays.length === 0 || weekdays.includes(weekdayNames[now.getDay()])) };
   }
   if (type === "screen") {
     const query = trimStr(condition.media_query);
     if (!query || typeof window.matchMedia !== "function") return { valid: false, active: false };
-    try { return { valid: true, active: window.matchMedia(query).matches }; }
-    catch (_error) { return { valid: false, active: false }; }
+    try {
+      return { valid: true, active: window.matchMedia(query).matches };
+    } catch (_error) {
+      return { valid: false, active: false };
+    }
   }
   if (type === "user") {
     if (!Array.isArray(condition.users) || condition.users.length === 0 || !hass?.user?.id) return { valid: false, active: false };
@@ -153,14 +142,12 @@ const evaluateAdaptiveImageCondition = (condition, hass, now = new Date()) => {
   }
   return { valid: false, active: false };
 };
-
-const evaluateAdaptiveImageConditions = (conditions, hass, now = new Date()) => {
+var evaluateAdaptiveImageConditions = (conditions, hass, now = /* @__PURE__ */ new Date()) => {
   if (!Array.isArray(conditions) || conditions.length === 0) return { valid: false, active: false };
   const results = conditions.map((condition) => evaluateAdaptiveImageCondition(condition, hass, now));
   return { valid: results.every((result) => result.valid), active: results.every((result) => result.valid && result.active) };
 };
-
-const resolveAdaptiveRoomImage = (config, hass, now = new Date()) => {
+var resolveAdaptiveRoomImage = (config, hass, now = /* @__PURE__ */ new Date()) => {
   const fallback = {
     url: resolveRoomImageUrl(config),
     position: parseImagePosition(config?.image_position).value,
@@ -182,19 +169,15 @@ const resolveAdaptiveRoomImage = (config, hass, now = new Date()) => {
   }
   return fallback;
 };
-
-const POWER_UNIT_FACTORS = Object.freeze({ mW: 0.001, W: 1, kW: 1000, MW: 1000000 });
-
-const getStatusGroupResult = (group, hass) => {
+var POWER_UNIT_FACTORS = Object.freeze({ mW: 1e-3, W: 1, kW: 1e3, MW: 1e6 });
+var getStatusGroupResult = (group, hass) => {
   const empty = { visible: false, value: "", numericValue: 0, contributors: [], error: "" };
   if (!group || typeof group !== "object") return empty;
   if (Array.isArray(group.conditions) && group.conditions.length > 0) {
     const gate = evaluateAdaptiveImageConditions(group.conditions, hass);
     if (!gate.valid || !gate.active) return empty;
   }
-  const entries = (Array.isArray(group.entities) ? group.entities : [])
-    .map((item) => typeof item === "string" ? { entity: item } : item)
-    .filter((item) => item && typeof item.entity === "string" && item.entity.trim());
+  const entries = (Array.isArray(group.entities) ? group.entities : []).map((item) => typeof item === "string" ? { entity: item } : item).filter((item) => item && typeof item.entity === "string" && item.entity.trim());
   const numericMode = group.aggregate === "sum" || group.display === "value";
   const contributors = [];
   entries.forEach((entry) => {
@@ -205,9 +188,7 @@ const getStatusGroupResult = (group, hass) => {
       const condition = evaluateAdaptiveImageConditions(entry.conditions, hass);
       if (!condition.valid || !condition.active) return;
     }
-    const configuredStates = Array.isArray(entry.active_states)
-      ? entry.active_states
-      : (Array.isArray(group.active_states) ? group.active_states : (numericMode ? [] : ["on"]));
+    const configuredStates = Array.isArray(entry.active_states) ? entry.active_states : Array.isArray(group.active_states) ? group.active_states : numericMode ? [] : ["on"];
     const activeStates = configuredStates.map((state) => String(state).toLowerCase().trim()).filter(Boolean);
     if (activeStates.length > 0 && !activeStates.includes(String(stateObj.state).toLowerCase().trim())) return;
     const number = Number(stateObj.state);
@@ -221,7 +202,6 @@ const getStatusGroupResult = (group, hass) => {
       unit: trimStr(stateObj.attributes?.unit_of_measurement)
     });
   });
-
   if (!numericMode) {
     const count = contributors.length;
     return {
@@ -232,23 +212,21 @@ const getStatusGroupResult = (group, hass) => {
       error: ""
     };
   }
-
   const requestedUnit = trimStr(group.unit);
   const units = contributors.map((item) => item.unit).filter(Boolean);
   const targetUnit = requestedUnit || units[0] || "";
-  const allPower = units.length > 0 && units.every((unit) => POWER_UNIT_FACTORS[unit] !== undefined);
+  const allPower = units.length > 0 && units.every((unit) => POWER_UNIT_FACTORS[unit] !== void 0);
   const hasMissingUnit = units.length !== contributors.length;
-  const compatible = (!targetUnit && units.length === 0)
-    || (!hasMissingUnit && (units.every((unit) => unit === targetUnit) || (allPower && POWER_UNIT_FACTORS[targetUnit] !== undefined)));
+  const compatible = !targetUnit && units.length === 0 || !hasMissingUnit && (units.every((unit) => unit === targetUnit) || allPower && POWER_UNIT_FACTORS[targetUnit] !== void 0);
   if (!compatible) {
     return { visible: true, value: "—", numericValue: NaN, contributors, error: "status_group_incompatible_units" };
   }
   const total = contributors.reduce((sum, item) => {
     if (!item.unit || item.unit === targetUnit) return sum + item.number;
-    return sum + ((item.number * POWER_UNIT_FACTORS[item.unit]) / POWER_UNIT_FACTORS[targetUnit]);
+    return sum + item.number * POWER_UNIT_FACTORS[item.unit] / POWER_UNIT_FACTORS[targetUnit];
   }, 0);
   const precision = Math.max(0, Math.min(4, Number.isFinite(Number(group.precision)) ? Number(group.precision) : 1));
-  const locale = hass?.locale?.language || hass?.language || undefined;
+  const locale = hass?.locale?.language || hass?.language || void 0;
   const formatted = new Intl.NumberFormat(locale, { maximumFractionDigits: precision }).format(total);
   return {
     visible: !(group.hide_when_zero === true && total === 0),
@@ -258,7 +236,6 @@ const getStatusGroupResult = (group, hass) => {
     error: ""
   };
 };
-
 if (!window[LOG_FLAG]) {
   console.info(
     `%c ONELINE-ROOM-CARD %c ${VERSION} `,
@@ -267,18 +244,23 @@ if (!window[LOG_FLAG]) {
   );
   window[LOG_FLAG] = true;
 }
-
-// Home Assistant no longer guarantees that its internal text field component is
-// registered before a custom card editor is opened. Keep the editor usable on a
-// cold dashboard load, then adopt HA's current/legacy input as soon as it exists.
-class OneLineRoomCardTextField extends HTMLElement {
+var OneLineRoomCardTextField = class extends HTMLElement {
   static get observedAttributes() {
     return [
-      "label", "placeholder", "type", "min", "max", "step", "rows",
-      "multiline", "disabled", "readonly", "required", "icon"
+      "label",
+      "placeholder",
+      "type",
+      "min",
+      "max",
+      "step",
+      "rows",
+      "multiline",
+      "disabled",
+      "readonly",
+      "required",
+      "icon"
     ];
   }
-
   constructor() {
     super();
     this.attachShadow({ mode: "open", delegatesFocus: true });
@@ -287,17 +269,16 @@ class OneLineRoomCardTextField extends HTMLElement {
     this._control = null;
     this._watchedDefinitions = false;
   }
-
   connectedCallback() {
     this._renderControl();
     this._watchForHomeAssistantInputs();
   }
-
   attributeChangedCallback() {
     if (this.isConnected) this._renderControl();
   }
-
-  get value() { return this._value; }
+  get value() {
+    return this._value;
+  }
   set value(value) {
     this._value = value == null ? "" : String(value);
     this._committedValue = this._value;
@@ -305,61 +286,106 @@ class OneLineRoomCardTextField extends HTMLElement {
       this._control.value = this._value;
     }
   }
-
-  get hass() { return this._hass; }
+  get hass() {
+    return this._hass;
+  }
   set hass(hass) {
     this._hass = hass;
     if (this._control && "hass" in this._control) this._control.hass = hass;
   }
-
-  get label() { return this.getAttribute("label") || ""; }
-  set label(value) { this._setStringAttribute("label", value); }
-  get placeholder() { return this.getAttribute("placeholder") || ""; }
-  set placeholder(value) { this._setStringAttribute("placeholder", value); }
-  get type() { return this.getAttribute("type") || "text"; }
-  set type(value) { this._setStringAttribute("type", value || "text"); }
-  get min() { return this.getAttribute("min"); }
-  set min(value) { this._setOptionalAttribute("min", value); }
-  get max() { return this.getAttribute("max"); }
-  set max(value) { this._setOptionalAttribute("max", value); }
-  get step() { return this.getAttribute("step"); }
-  set step(value) { this._setOptionalAttribute("step", value); }
-  get rows() { return Number(this.getAttribute("rows") || 3); }
-  set rows(value) { this._setOptionalAttribute("rows", value); }
-  get multiline() { return this.hasAttribute("multiline"); }
-  set multiline(value) { this.toggleAttribute("multiline", Boolean(value)); }
-  get disabled() { return this.hasAttribute("disabled"); }
-  set disabled(value) { this.toggleAttribute("disabled", Boolean(value)); }
-  get readonly() { return this.hasAttribute("readonly"); }
-  set readonly(value) { this.toggleAttribute("readonly", Boolean(value)); }
-  get required() { return this.hasAttribute("required"); }
-  set required(value) { this.toggleAttribute("required", Boolean(value)); }
-
-  focus(options) { this._control?.focus(options); }
-  select() { this._control?.select?.(); }
-  checkValidity() { return this._control?.checkValidity?.() ?? true; }
-  reportValidity() { return this._control?.reportValidity?.() ?? true; }
-
+  get label() {
+    return this.getAttribute("label") || "";
+  }
+  set label(value) {
+    this._setStringAttribute("label", value);
+  }
+  get placeholder() {
+    return this.getAttribute("placeholder") || "";
+  }
+  set placeholder(value) {
+    this._setStringAttribute("placeholder", value);
+  }
+  get type() {
+    return this.getAttribute("type") || "text";
+  }
+  set type(value) {
+    this._setStringAttribute("type", value || "text");
+  }
+  get min() {
+    return this.getAttribute("min");
+  }
+  set min(value) {
+    this._setOptionalAttribute("min", value);
+  }
+  get max() {
+    return this.getAttribute("max");
+  }
+  set max(value) {
+    this._setOptionalAttribute("max", value);
+  }
+  get step() {
+    return this.getAttribute("step");
+  }
+  set step(value) {
+    this._setOptionalAttribute("step", value);
+  }
+  get rows() {
+    return Number(this.getAttribute("rows") || 3);
+  }
+  set rows(value) {
+    this._setOptionalAttribute("rows", value);
+  }
+  get multiline() {
+    return this.hasAttribute("multiline");
+  }
+  set multiline(value) {
+    this.toggleAttribute("multiline", Boolean(value));
+  }
+  get disabled() {
+    return this.hasAttribute("disabled");
+  }
+  set disabled(value) {
+    this.toggleAttribute("disabled", Boolean(value));
+  }
+  get readonly() {
+    return this.hasAttribute("readonly");
+  }
+  set readonly(value) {
+    this.toggleAttribute("readonly", Boolean(value));
+  }
+  get required() {
+    return this.hasAttribute("required");
+  }
+  set required(value) {
+    this.toggleAttribute("required", Boolean(value));
+  }
+  focus(options) {
+    this._control?.focus(options);
+  }
+  select() {
+    this._control?.select?.();
+  }
+  checkValidity() {
+    return this._control?.checkValidity?.() ?? true;
+  }
+  reportValidity() {
+    return this._control?.reportValidity?.() ?? true;
+  }
   _setStringAttribute(name, value) {
     this.setAttribute(name, value == null ? "" : String(value));
   }
-
   _setOptionalAttribute(name, value) {
     if (value == null || value === "") this.removeAttribute(name);
     else this.setAttribute(name, String(value));
   }
-
   _watchForHomeAssistantInputs() {
     if (this._watchedDefinitions) return;
     this._watchedDefinitions = true;
-    const tags = this.multiline
-      ? ["ha-textarea", "ha-textfield"]
-      : ["ha-input", "ha-textfield"];
+    const tags = this.multiline ? ["ha-textarea", "ha-textfield"] : ["ha-input", "ha-textfield"];
     Promise.race(tags.map((tag) => customElements.whenDefined(tag))).then(() => {
       if (this.isConnected) this._renderControl();
     });
   }
-
   _preferredControlTag() {
     if (this.multiline) {
       if (customElements.get("ha-textarea")) return "ha-textarea";
@@ -370,14 +396,12 @@ class OneLineRoomCardTextField extends HTMLElement {
     if (customElements.get("ha-textfield")) return "ha-textfield";
     return "input";
   }
-
   _renderControl() {
     const tag = this._preferredControlTag();
     if (this._control?.localName === tag) {
       this._syncControlProperties();
       return;
     }
-
     const style = document.createElement("style");
     style.textContent = `
       :host { display: block; box-sizing: border-box; width: 100%; }
@@ -400,7 +424,6 @@ class OneLineRoomCardTextField extends HTMLElement {
       input:disabled, textarea:disabled { opacity: .55; cursor: not-allowed; }
       ha-input, ha-textfield, ha-textarea { display: block; width: 100%; }
     `;
-
     const control = document.createElement(tag);
     this._control = control;
     this._syncControlProperties();
@@ -409,7 +432,6 @@ class OneLineRoomCardTextField extends HTMLElement {
     if (tag === "input" || tag === "textarea") {
       control.addEventListener("blur", (event) => this._forwardValueEvent(event, "change"));
     }
-
     const fragment = document.createDocumentFragment();
     fragment.appendChild(style);
     if (tag === "input" || tag === "textarea") {
@@ -434,7 +456,6 @@ class OneLineRoomCardTextField extends HTMLElement {
     }
     this.shadowRoot.replaceChildren(fragment);
   }
-
   _syncControlProperties() {
     const control = this._control;
     if (!control) return;
@@ -461,7 +482,6 @@ class OneLineRoomCardTextField extends HTMLElement {
       control.icon = this.getAttribute("icon");
     }
   }
-
   _forwardValueEvent(event, type) {
     event.stopPropagation();
     this._value = this._control?.value == null ? "" : String(this._control.value);
@@ -471,33 +491,85 @@ class OneLineRoomCardTextField extends HTMLElement {
     }
     this.dispatchEvent(new Event(type, { bubbles: true, composed: true }));
   }
-}
-
+};
 if (!customElements.get("oneline-room-card-textfield")) {
   customElements.define("oneline-room-card-textfield", OneLineRoomCardTextField);
 }
-
-// TRANSLATIONS
-const TRANSLATIONS = {
+var TRANSLATIONS = {
   en: {
-    empty: "Empty", low: "Low", critical: "Critical", window: "Window", general: "General",
-    sensors_manual: "Sensors (Manual)", buttons: "Buttons", button: "Button", add_button: "Add Button",
-    main_climate: "Main Climate Device (Optional)", climate_info: "Fills Temp/Humidity automatically if empty below.",
-    temp_label: "Temperature (overrides climate)", target_temp_label: "Target Temperature", humid_label: "Humidity (overrides climate)", temp_unit: "Temperature Unit", temp_unit_default: "Home Assistant default",
-    window_label: "Windows (List)", battery_label: "Batteries (List)", name: "Name", icon: "Icon", color: "Icon Color",
-    humid_warn_threshold: "Humidity Warning Threshold (%)", high_humidity: "High humidity", device_unavailable: "Device unavailable",
-    force_color: "Force Manual Color (Always visible)", img_url: "Image URL", image: "Image", path: "Path (Tap Action)", entity: "Entity", device: "Device (Optional)",
-    image_entity: "Light Entity (Grayscale when off)", image_entity_help: "When the selected light/switch is off, the header image fades to grayscale.",
+    empty: "Empty",
+    low: "Low",
+    critical: "Critical",
+    window: "Window",
+    general: "General",
+    sensors_manual: "Sensors (Manual)",
+    buttons: "Buttons",
+    button: "Button",
+    add_button: "Add Button",
+    main_climate: "Main Climate Device (Optional)",
+    climate_info: "Fills Temp/Humidity automatically if empty below.",
+    temp_label: "Temperature (overrides climate)",
+    target_temp_label: "Target Temperature",
+    humid_label: "Humidity (overrides climate)",
+    temp_unit: "Temperature Unit",
+    temp_unit_default: "Home Assistant default",
+    window_label: "Windows (List)",
+    battery_label: "Batteries (List)",
+    name: "Name",
+    icon: "Icon",
+    color: "Icon Color",
+    humid_warn_threshold: "Humidity Warning Threshold (%)",
+    high_humidity: "High humidity",
+    device_unavailable: "Device unavailable",
+    force_color: "Force Manual Color (Always visible)",
+    img_url: "Image URL",
+    image: "Image",
+    path: "Path (Tap Action)",
+    entity: "Entity",
+    device: "Device (Optional)",
+    image_entity: "Light Entity (Grayscale when off)",
+    image_entity_help: "When the selected light/switch is off, the header image fades to grayscale.",
     show_image: "Show background image",
-    image_preset_title: "Built-in room image", image_preset_help: "Choose a RoomCard image or keep using your own URL/upload.", image_preset_custom: "Own image",
-    image_preset_living_room: "Living room", image_preset_kitchen: "Kitchen", image_preset_bedroom: "Bedroom", image_preset_bathroom: "Bathroom",
-    image_preset_dining_room: "Dining room", image_preset_home_office: "Home office", image_preset_childrens_room: "Children's room", image_preset_hallway: "Hallway",
-    image_preset_guest_room: "Guest room", image_preset_garage: "Garage", image_preset_garden_patio: "Garden / patio", image_preset_balcony: "Balcony",
-    image_preset_basement: "Basement", image_preset_laundry_room: "Laundry room", image_preset_attic: "Attic", image_preset_workshop: "Workshop",
-    presence_sensor: "Presence Sensor (Motion/Person)", presence_detected: "Present", presence_chip_color: "Presence Chip Color", presence_solid_background: "Solid Presence Background",
-    area_setup: "Area Setup", area_setup_desc: "Automatically populate controls and sensors from area entities", area_picker: "Home Assistant Area", area_generate: "Generate from Area", area_no_entities: "No entities found in this area",
-    alert_sensors: "Alert Sensors", alert_sensor_add: "Add Alert Sensor", alert_sensor_entity: "Sensor", alert_sensor_above: "Above", alert_sensor_below: "Below", alert_sensor_state: "State", alert_border_color: "Card Border Color", alert_chip_collapsed: "Show as badges (collapsed)", active_alerts: "Active Alerts",
-    template: "Type Filter", add_template: "with Filter", add_prefix: "Add",
+    image_preset_title: "Built-in room image",
+    image_preset_help: "Choose a RoomCard image or keep using your own URL/upload.",
+    image_preset_custom: "Own image",
+    image_preset_living_room: "Living room",
+    image_preset_kitchen: "Kitchen",
+    image_preset_bedroom: "Bedroom",
+    image_preset_bathroom: "Bathroom",
+    image_preset_dining_room: "Dining room",
+    image_preset_home_office: "Home office",
+    image_preset_childrens_room: "Children's room",
+    image_preset_hallway: "Hallway",
+    image_preset_guest_room: "Guest room",
+    image_preset_garage: "Garage",
+    image_preset_garden_patio: "Garden / patio",
+    image_preset_balcony: "Balcony",
+    image_preset_basement: "Basement",
+    image_preset_laundry_room: "Laundry room",
+    image_preset_attic: "Attic",
+    image_preset_workshop: "Workshop",
+    presence_sensor: "Presence Sensor (Motion/Person)",
+    presence_detected: "Present",
+    presence_chip_color: "Presence Chip Color",
+    presence_solid_background: "Solid Presence Background",
+    area_setup: "Area Setup",
+    area_setup_desc: "Automatically populate controls and sensors from area entities",
+    area_picker: "Home Assistant Area",
+    area_generate: "Generate from Area",
+    area_no_entities: "No entities found in this area",
+    alert_sensors: "Alert Sensors",
+    alert_sensor_add: "Add Alert Sensor",
+    alert_sensor_entity: "Sensor",
+    alert_sensor_above: "Above",
+    alert_sensor_below: "Below",
+    alert_sensor_state: "State",
+    alert_border_color: "Card Border Color",
+    alert_chip_collapsed: "Show as badges (collapsed)",
+    active_alerts: "Active Alerts",
+    template: "Type Filter",
+    add_template: "with Filter",
+    add_prefix: "Add",
     quick_add_title: "Quick Add",
     quick_add_desc: "Quickly add buttons from existing entities.",
     quick_add_entity_type_label: "Entity type",
@@ -516,39 +588,142 @@ const TRANSLATIONS = {
     pos_bottom: "Bottom",
     pos_left: "Left",
     pos_top: "Top",
-    row_type: "Row Type", type_entity: "Entity", type_template: "Template",
-    tmpl_content: "Content (Template)", tmpl_icon: "Icon (Template)", tmpl_color: "Color (Template)", tmpl_state: "State (Template)", tmpl_preview: "Preview",
-    tmpl_light: "Light", tmpl_switch: "Switch / Socket", tmpl_select: "Select", tmpl_climate: "Climate", tmpl_cover: "Cover / Shutter", tmpl_media: "Media Player",
-    show_state: "Show State", show_label: "Show Label", show_icon: "Show Icon", show_last_changed: "Last Changed", show_sparkline: "Show Sparkline", sparkline_detail: "Open history details", sparkline_hours: "History (hours)", sparkline_refresh: "Sparkline refresh (seconds)", sparkline_refresh_adjusted: "Enter 60–3600 seconds. The value was adjusted to {value}.", sparkline_detail_title: "History details", sparkline_loading: "Loading history…", sparkline_empty: "No history data available.", sparkline_error: "History could not be loaded.", sparkline_current: "Current", sparkline_min: "Min", sparkline_max: "Max", sparkline_average: "Average", lc_just_now: "just now", state_first: "State First", text_layout: "Text Order", primary_text: "First line", primary_state: "State / value first", primary_name: "Name first",
-    height: "Height", width: "Width", align: "Align", visible: "Visible", left: "Left", center: "Center", right: "Right",
-    tap_action: "Tap Action", hold_action: "Hold Action", double_tap_action: "Double Tap Action",
+    row_type: "Row Type",
+    type_entity: "Entity",
+    type_template: "Template",
+    tmpl_content: "Content (Template)",
+    tmpl_icon: "Icon (Template)",
+    tmpl_color: "Color (Template)",
+    tmpl_state: "State (Template)",
+    tmpl_preview: "Preview",
+    tmpl_light: "Light",
+    tmpl_switch: "Switch / Socket",
+    tmpl_select: "Select",
+    tmpl_climate: "Climate",
+    tmpl_cover: "Cover / Shutter",
+    tmpl_media: "Media Player",
+    show_state: "Show State",
+    show_label: "Show Label",
+    show_icon: "Show Icon",
+    show_last_changed: "Last Changed",
+    show_sparkline: "Show Sparkline",
+    sparkline_detail: "Open history details",
+    sparkline_hours: "History (hours)",
+    sparkline_refresh: "Sparkline refresh (seconds)",
+    sparkline_refresh_adjusted: "Enter 60–3600 seconds. The value was adjusted to {value}.",
+    sparkline_detail_title: "History details",
+    sparkline_loading: "Loading history…",
+    sparkline_empty: "No history data available.",
+    sparkline_error: "History could not be loaded.",
+    sparkline_current: "Current",
+    sparkline_min: "Min",
+    sparkline_max: "Max",
+    sparkline_average: "Average",
+    lc_just_now: "just now",
+    state_first: "State First",
+    text_layout: "Text Order",
+    primary_text: "First line",
+    primary_state: "State / value first",
+    primary_name: "Name first",
+    height: "Height",
+    width: "Width",
+    align: "Align",
+    visible: "Visible",
+    left: "Left",
+    center: "Center",
+    right: "Right",
+    tap_action: "Tap Action",
+    hold_action: "Hold Action",
+    double_tap_action: "Double Tap Action",
     actions: "Actions",
-    act_more: "Details (Default)", act_toggle: "Toggle", act_navigate: "Navigate", act_call_service: "Action (service)", act_none: "None",
-    service: "Service (domain.service)", service_data: "Service Data (JSON)", target_entity: "Target entity",
+    act_more: "Details (Default)",
+    act_toggle: "Toggle",
+    act_navigate: "Navigate",
+    act_call_service: "Action (service)",
+    act_none: "None",
+    service: "Service (domain.service)",
+    service_data: "Service Data (JSON)",
+    target_entity: "Target entity",
     live_preview: "Live preview",
-    upload_btn: "Upload Image", uploading: "Uploading...", upload_success: "Image uploaded", upload_optimized: "Image optimized and uploaded",
-    upload_unsupported: "Choose a JPEG, PNG, or WebP image.", upload_too_large: "The source image exceeds the 20 MB limit.", upload_decode_error: "The image could not be decoded.", upload_failed: "Upload failed ({status}).",
-    image_focal_point: "Image focal point", image_focal_help: "Click or drag the marker to keep the important area visible.", image_center: "Center", image_horizontal: "Horizontal position", image_vertical: "Vertical position",
-    show_name: "Show Title", header_badges: "Badge", badge_add: "Add Info Entry", badge_label: "Label (optional)", badge_background: "Background (rgba)", standard_badge_background: "Standard Badge Background (rgba)", badge_auto_climate_btn: "Automatically add climate control button",
-    visibility: "Visibility", visibility_cond: "Conditional Visibility", vis_entity: "Condition Entity", vis_state: "Show if state is", vis_invert: "Invert Logic (Hide if state corresponds)",
+    upload_btn: "Upload Image",
+    uploading: "Uploading...",
+    upload_success: "Image uploaded",
+    upload_optimized: "Image optimized and uploaded",
+    upload_unsupported: "Choose a JPEG, PNG, or WebP image.",
+    upload_too_large: "The source image exceeds the 20 MB limit.",
+    upload_decode_error: "The image could not be decoded.",
+    upload_failed: "Upload failed ({status}).",
+    image_focal_point: "Image focal point",
+    image_focal_help: "Click or drag the marker to keep the important area visible.",
+    image_center: "Center",
+    image_horizontal: "Horizontal position",
+    image_vertical: "Vertical position",
+    show_name: "Show Title",
+    header_badges: "Badge",
+    badge_add: "Add Info Entry",
+    badge_label: "Label (optional)",
+    badge_background: "Background (rgba)",
+    standard_badge_background: "Standard Badge Background (rgba)",
+    badge_auto_climate_btn: "Automatically add climate control button",
+    visibility: "Visibility",
+    visibility_cond: "Conditional Visibility",
+    vis_entity: "Condition Entity",
+    vis_state: "Show if state is",
+    vis_invert: "Invert Logic (Hide if state corresponds)",
     migration_title: "Action Required",
     migration_text: "Card renamed to <b>oneline-room-card</b> to avoid conflicts.<br>Please change <code>type: custom:room-card</code> to <code>type: custom:oneline-room-card</code> in your YAML.",
-    control_mode: "Control Mode", ctrl_default: "Default", ctrl_slider: "Inline Slider", ctrl_buttons: "Inline Buttons", ctrl_full: "Full Controls", ctrl_all_options: "All Options",
-    slider_mode: "Slider Mode", slider_mode_brightness: "Brightness", slider_mode_color_temp: "Color Temperature",
-    slider_style: "Slider Style", style_inline: "Inline", style_bg: "Background",
-    collapsible: "Collapsible", default_state: "Default State", state_expanded: "Expanded", state_collapsed: "Collapsed",
+    control_mode: "Control Mode",
+    ctrl_default: "Default",
+    ctrl_slider: "Inline Slider",
+    ctrl_buttons: "Inline Buttons",
+    ctrl_full: "Full Controls",
+    ctrl_all_options: "All Options",
+    slider_mode: "Slider Mode",
+    slider_mode_brightness: "Brightness",
+    slider_mode_color_temp: "Color Temperature",
+    slider_style: "Slider Style",
+    style_inline: "Inline",
+    style_bg: "Background",
+    collapsible: "Collapsible",
+    default_state: "Default State",
+    state_expanded: "Expanded",
+    state_collapsed: "Collapsed",
     header_height: "Header Height (px)",
-    typography: "Header Typography", name_font: "Room Name Font", info_font: "Info Line Font", show_header_text_shadow: "Header Text Shadow",
-    font_size: "Size (px)", font_weight: "Weight", font_style: "Style", font_color: "Color", badge_bg: "Badge Background",
-    card_behavior: "Card Behavior", behavior: "Collapse Mode", behavior_fixed: "Disabled", behavior_collapsed: "Collapsed", behavior_expanded: "Expanded", behavior_remember: "Remember",
-    header: "Header", configuration: "Configuration",
-    color_map: "State Colors", color_map_add: "Add State Color", color_map_state: "State",
-    window_always_show: "Always Show (incl. closed)", window_open_color: "Open Color", window_closed_color: "Closed Color",
-    window_solid_background: "Solid Background", window_labels: "Window Labels",
+    typography: "Header Typography",
+    name_font: "Room Name Font",
+    info_font: "Info Line Font",
+    show_header_text_shadow: "Header Text Shadow",
+    font_size: "Size (px)",
+    font_weight: "Weight",
+    font_style: "Style",
+    font_color: "Color",
+    badge_bg: "Badge Background",
+    card_behavior: "Card Behavior",
+    behavior: "Collapse Mode",
+    behavior_fixed: "Disabled",
+    behavior_collapsed: "Collapsed",
+    behavior_expanded: "Expanded",
+    behavior_remember: "Remember",
+    header: "Header",
+    configuration: "Configuration",
+    color_map: "State Colors",
+    color_map_add: "Add State Color",
+    color_map_state: "State",
+    window_always_show: "Always Show (incl. closed)",
+    window_open_color: "Open Color",
+    window_closed_color: "Closed Color",
+    window_solid_background: "Solid Background",
+    window_labels: "Window Labels",
     window_custom_label: "Custom Label",
-    window_open_states: "Open States (comma-separated)", window_state_colors: "State Colors", window_state_colors_add: "Add State Color",
-    sensors: "Sensors", show_chip_shadow: "Sensor Chip Shadow", show_status_border: "Status border and glow", show_status_border_help: "Controls only the warning outline and glow; sensor badges remain visible.",
-    icon_size: "Icon Size", global_icon_size: "Global Icon Size (px)",
+    window_open_states: "Open States (comma-separated)",
+    window_state_colors: "State Colors",
+    window_state_colors_add: "Add State Color",
+    sensors: "Sensors",
+    show_chip_shadow: "Sensor Chip Shadow",
+    show_status_border: "Status border and glow",
+    show_status_border_help: "Controls only the warning outline and glow; sensor badges remain visible.",
+    icon_size: "Icon Size",
+    global_icon_size: "Global Icon Size (px)",
     header_info_offset: "Info Line Position",
     header_name_offset: "Title Position",
     header_sync_offsets: "Synchronize Positions",
@@ -558,7 +733,8 @@ const TRANSLATIONS = {
     cover_presets_label: "Preset Values (comma-separated)",
     show_climate_presets: "Temperature Presets",
     climate_presets_label: "Temperatures (comma-separated)",
-    show_hvac_modes: "HVAC Mode Chips", show_fan_modes: "Fan Speed Chips",
+    show_hvac_modes: "HVAC Mode Chips",
+    show_fan_modes: "Fan Speed Chips",
     show_brightness_presets: "Brightness Presets",
     brightness_presets_label: "Brightness values (comma-separated)",
     show_brightness_value: "Show Brightness %",
@@ -567,36 +743,153 @@ const TRANSLATIONS = {
     show_media_sources: "Source Chips",
     show_media_sound_modes: "Sound Mode Chips",
     show_media_title: "Media Title",
-    sub_chips: "Sub-Chips", chip_add: "Add Chip", chip_entity: "Entity", chip_attribute: "Attribute (optional)", chip_icon: "Icon (optional)", chip_label: "Label (optional)", chips_position: "Chip Position", chips_top: "Above title", chips_bottom: "Below title",
-    vis_add: "Add Condition", vis_eq: "State is equal", vis_neq: "State is not equal", vis_above: "State is strictly greater than", vis_below: "State is strictly less than",
-    info_line_position: "Info Line Position", info_position_header: "Inside header (default)", info_position_below: "Below header",
-    last_activity_title: "Last Activity", last_activity_show: "Show last activity",
-    room_modes: "Room Modes", room_modes_help: "Run scenes or scripts directly from the room card.", room_mode_add: "Add Room Mode", room_mode_entity: "Scene or script", room_mode_active_when: "Active when", room_mode_remove: "Remove mode", room_mode_up: "Move mode up", room_mode_down: "Move mode down",
-    adaptive_images: "Adaptive images", adaptive_images_help: "The first matching rule replaces the fallback header image.", adaptive_image_add: "Add image rule", adaptive_image_name: "Rule name (optional)", adaptive_image_conditions: "Conditions", adaptive_image_preset: "Built-in image", adaptive_image_custom: "Custom URL / upload", adaptive_image_duplicate: "Duplicate image rule", adaptive_image_remove: "Remove image rule", adaptive_image_up: "Move image rule up", adaptive_image_down: "Move image rule down", adaptive_image_position: "Rule focal point",
-    status_groups: "Room status", status_groups_help: "Summarize configured entities without changing alert priority.", status_group_add: "Add status group", status_group_preset_lights: "Lights on", status_group_preset_windows: "Open windows", status_group_preset_media: "Active media", status_group_preset_power: "Power", status_group_entities: "Entities", status_group_active_states: "Active states (comma-separated)", status_group_display: "Display", status_group_count: "Count", status_group_value: "Numeric sum", status_group_unit: "Output unit", status_group_precision: "Decimals", status_group_hide_zero: "Hide when zero", status_group_details: "Open contributing entities", status_group_conditions: "Show group when", status_group_duplicate: "Duplicate status group", status_group_remove: "Remove status group", status_group_up: "Move status group up", status_group_down: "Move status group down", status_group_incompatible_units: "Incompatible units",
-    a11y_close: "Close", a11y_previous_track: "Previous track", a11y_play_pause: "Play or pause", a11y_next_track: "Next track",
-    a11y_mute: "Mute or unmute", a11y_volume: "Volume", a11y_expand: "Expand room controls", a11y_collapse: "Collapse room controls",
-    a11y_activate: "Activate {name}", a11y_set_value: "Set {name}", a11y_select_option: "Select {name}"
+    sub_chips: "Sub-Chips",
+    chip_add: "Add Chip",
+    chip_entity: "Entity",
+    chip_attribute: "Attribute (optional)",
+    chip_icon: "Icon (optional)",
+    chip_label: "Label (optional)",
+    chips_position: "Chip Position",
+    chips_top: "Above title",
+    chips_bottom: "Below title",
+    vis_add: "Add Condition",
+    vis_eq: "State is equal",
+    vis_neq: "State is not equal",
+    vis_above: "State is strictly greater than",
+    vis_below: "State is strictly less than",
+    info_line_position: "Info Line Position",
+    info_position_header: "Inside header (default)",
+    info_position_below: "Below header",
+    last_activity_title: "Last Activity",
+    last_activity_show: "Show last activity",
+    room_modes: "Room Modes",
+    room_modes_help: "Run scenes or scripts directly from the room card.",
+    room_mode_add: "Add Room Mode",
+    room_mode_entity: "Scene or script",
+    room_mode_active_when: "Active when",
+    room_mode_remove: "Remove mode",
+    room_mode_up: "Move mode up",
+    room_mode_down: "Move mode down",
+    adaptive_images: "Adaptive images",
+    adaptive_images_help: "The first matching rule replaces the fallback header image.",
+    adaptive_image_add: "Add image rule",
+    adaptive_image_name: "Rule name (optional)",
+    adaptive_image_conditions: "Conditions",
+    adaptive_image_preset: "Built-in image",
+    adaptive_image_custom: "Custom URL / upload",
+    adaptive_image_duplicate: "Duplicate image rule",
+    adaptive_image_remove: "Remove image rule",
+    adaptive_image_up: "Move image rule up",
+    adaptive_image_down: "Move image rule down",
+    adaptive_image_position: "Rule focal point",
+    status_groups: "Room status",
+    status_groups_help: "Summarize configured entities without changing alert priority.",
+    status_group_add: "Add status group",
+    status_group_preset_lights: "Lights on",
+    status_group_preset_windows: "Open windows",
+    status_group_preset_media: "Active media",
+    status_group_preset_power: "Power",
+    status_group_entities: "Entities",
+    status_group_active_states: "Active states (comma-separated)",
+    status_group_display: "Display",
+    status_group_count: "Count",
+    status_group_value: "Numeric sum",
+    status_group_unit: "Output unit",
+    status_group_precision: "Decimals",
+    status_group_hide_zero: "Hide when zero",
+    status_group_details: "Open contributing entities",
+    status_group_conditions: "Show group when",
+    status_group_duplicate: "Duplicate status group",
+    status_group_remove: "Remove status group",
+    status_group_up: "Move status group up",
+    status_group_down: "Move status group down",
+    status_group_incompatible_units: "Incompatible units",
+    a11y_close: "Close",
+    a11y_previous_track: "Previous track",
+    a11y_play_pause: "Play or pause",
+    a11y_next_track: "Next track",
+    a11y_mute: "Mute or unmute",
+    a11y_volume: "Volume",
+    a11y_expand: "Expand room controls",
+    a11y_collapse: "Collapse room controls",
+    a11y_activate: "Activate {name}",
+    a11y_set_value: "Set {name}",
+    a11y_select_option: "Select {name}"
   },
   de: {
-    empty: "Leer", low: "Niedrig", critical: "Kritisch", window: "Fenster", general: "Allgemein",
-    sensors_manual: "Sensoren (Manuell)", buttons: "Buttons", button: "Button", add_button: "Button hinzufügen",
-    main_climate: "Haupt-Klima-Gerät", climate_info: "Füllt Temp/Feuchtigkeit automatisch, wenn unten leer.",
-    temp_label: "Temperatur (überschreibt Klima)", target_temp_label: "Soll-Temperatur", humid_label: "Luftfeuchtigkeit (überschreibt Klima)", temp_unit: "Temperatureinheit", temp_unit_default: "Home-Assistant-Standard",
-    window_label: "Fenster (Liste)", battery_label: "Batterien (Liste)", name: "Name", icon: "Icon", color: "Iconfarbe",
-    humid_warn_threshold: "Feuchte-Warnschwelle (%)", high_humidity: "Hohe Luftfeuchtigkeit", device_unavailable: "Gerät nicht verfügbar",
-    force_color: "Manuelle Farbe erzwingen (Immer sichtbar)", img_url: "Bild URL", image: "Bild", path: "Pfad (Tap Action)", entity: "Entität", device: "Gerät (Optional)",
-    image_entity: "Licht-Entität (Graustufen wenn aus)", image_entity_help: "Wenn die gewählte Licht-/Schalter-Entität aus ist, wird das Header-Bild in Graustufen dargestellt.",
+    empty: "Leer",
+    low: "Niedrig",
+    critical: "Kritisch",
+    window: "Fenster",
+    general: "Allgemein",
+    sensors_manual: "Sensoren (Manuell)",
+    buttons: "Buttons",
+    button: "Button",
+    add_button: "Button hinzufügen",
+    main_climate: "Haupt-Klima-Gerät",
+    climate_info: "Füllt Temp/Feuchtigkeit automatisch, wenn unten leer.",
+    temp_label: "Temperatur (überschreibt Klima)",
+    target_temp_label: "Soll-Temperatur",
+    humid_label: "Luftfeuchtigkeit (überschreibt Klima)",
+    temp_unit: "Temperatureinheit",
+    temp_unit_default: "Home-Assistant-Standard",
+    window_label: "Fenster (Liste)",
+    battery_label: "Batterien (Liste)",
+    name: "Name",
+    icon: "Icon",
+    color: "Iconfarbe",
+    humid_warn_threshold: "Feuchte-Warnschwelle (%)",
+    high_humidity: "Hohe Luftfeuchtigkeit",
+    device_unavailable: "Gerät nicht verfügbar",
+    force_color: "Manuelle Farbe erzwingen (Immer sichtbar)",
+    img_url: "Bild URL",
+    image: "Bild",
+    path: "Pfad (Tap Action)",
+    entity: "Entität",
+    device: "Gerät (Optional)",
+    image_entity: "Licht-Entität (Graustufen wenn aus)",
+    image_entity_help: "Wenn die gewählte Licht-/Schalter-Entität aus ist, wird das Header-Bild in Graustufen dargestellt.",
     show_image: "Hintergrundbild anzeigen",
-    image_preset_title: "Integriertes Raumbild", image_preset_help: "Wähle ein RoomCard-Bild oder nutze weiterhin eine eigene URL bzw. einen Upload.", image_preset_custom: "Eigenes Bild",
-    image_preset_living_room: "Wohnzimmer", image_preset_kitchen: "Küche", image_preset_bedroom: "Schlafzimmer", image_preset_bathroom: "Badezimmer",
-    image_preset_dining_room: "Esszimmer", image_preset_home_office: "Arbeitszimmer", image_preset_childrens_room: "Kinderzimmer", image_preset_hallway: "Flur",
-    image_preset_guest_room: "Gästezimmer", image_preset_garage: "Garage", image_preset_garden_patio: "Garten / Terrasse", image_preset_balcony: "Balkon",
-    image_preset_basement: "Keller", image_preset_laundry_room: "Waschküche", image_preset_attic: "Dachboden", image_preset_workshop: "Werkstatt",
-    presence_sensor: "Anwesenheits-Sensor (Bewegung/Person)", presence_detected: "Anwesend", presence_chip_color: "Farbe des Anwesenheits-Chips", presence_solid_background: "Durchgefärbter Anwesenheits-Chip",
-    area_setup: "Bereich-Setup", area_setup_desc: "Steuerungen und Sensoren automatisch aus dem Bereich übernehmen", area_picker: "Home Assistant Bereich", area_generate: "Aus Bereich generieren", area_no_entities: "Keine Entitäten in diesem Bereich gefunden",
-    alert_sensors: "Alarm-Sensoren", alert_sensor_add: "Alarm-Sensor hinzufügen", alert_sensor_entity: "Sensor", alert_sensor_above: "Über", alert_sensor_below: "Unter", alert_sensor_state: "Zustand", alert_border_color: "Kartenrahmenfarbe", alert_chip_collapsed: "Als Sammel-Badge anzeigen", active_alerts: "Aktive Alarme",
-    template: "Typ-Filter", add_template: "mit Filter", add_prefix: "Add",
+    image_preset_title: "Integriertes Raumbild",
+    image_preset_help: "Wähle ein RoomCard-Bild oder nutze weiterhin eine eigene URL bzw. einen Upload.",
+    image_preset_custom: "Eigenes Bild",
+    image_preset_living_room: "Wohnzimmer",
+    image_preset_kitchen: "Küche",
+    image_preset_bedroom: "Schlafzimmer",
+    image_preset_bathroom: "Badezimmer",
+    image_preset_dining_room: "Esszimmer",
+    image_preset_home_office: "Arbeitszimmer",
+    image_preset_childrens_room: "Kinderzimmer",
+    image_preset_hallway: "Flur",
+    image_preset_guest_room: "Gästezimmer",
+    image_preset_garage: "Garage",
+    image_preset_garden_patio: "Garten / Terrasse",
+    image_preset_balcony: "Balkon",
+    image_preset_basement: "Keller",
+    image_preset_laundry_room: "Waschküche",
+    image_preset_attic: "Dachboden",
+    image_preset_workshop: "Werkstatt",
+    presence_sensor: "Anwesenheits-Sensor (Bewegung/Person)",
+    presence_detected: "Anwesend",
+    presence_chip_color: "Farbe des Anwesenheits-Chips",
+    presence_solid_background: "Durchgefärbter Anwesenheits-Chip",
+    area_setup: "Bereich-Setup",
+    area_setup_desc: "Steuerungen und Sensoren automatisch aus dem Bereich übernehmen",
+    area_picker: "Home Assistant Bereich",
+    area_generate: "Aus Bereich generieren",
+    area_no_entities: "Keine Entitäten in diesem Bereich gefunden",
+    alert_sensors: "Alarm-Sensoren",
+    alert_sensor_add: "Alarm-Sensor hinzufügen",
+    alert_sensor_entity: "Sensor",
+    alert_sensor_above: "Über",
+    alert_sensor_below: "Unter",
+    alert_sensor_state: "Zustand",
+    alert_border_color: "Kartenrahmenfarbe",
+    alert_chip_collapsed: "Als Sammel-Badge anzeigen",
+    active_alerts: "Aktive Alarme",
+    template: "Typ-Filter",
+    add_template: "mit Filter",
+    add_prefix: "Add",
     quick_add_title: "Schnellerfassung",
     quick_add_desc: "Schnell Buttons aus bestehenden Entitäten hinzufügen.",
     quick_add_entity_type_label: "Entitätstyp",
@@ -615,43 +908,142 @@ const TRANSLATIONS = {
     pos_bottom: "Unten",
     pos_left: "Links",
     pos_top: "Oben",
-    row_type: "Zeilentyp", type_entity: "Entität", type_template: "Template",
-    tmpl_content: "Text (Template)", tmpl_icon: "Icon (Template)", tmpl_color: "Farbe (Template)", tmpl_state: "Status (Template)", tmpl_preview: "Vorschau",
-    tmpl_light: "Licht", tmpl_switch: "Schalter / Steckdose", tmpl_select: "Auswahl", tmpl_climate: "Klima", tmpl_cover: "Rollladen / Abdeckung", tmpl_media: "Media Player",
-    show_state: "Status anzeigen", show_label: "Bezeichnung anzeigen", show_icon: "Icon anzeigen", show_last_changed: "Letzte Änderung", show_sparkline: "Sparkline anzeigen", sparkline_detail: "Verlaufsdetails öffnen", sparkline_hours: "Verlauf (Stunden)", sparkline_refresh: "Sparkline-Aktualisierung (Sekunden)", sparkline_refresh_adjusted: "Bitte 60–3600 Sekunden eingeben. Der Wert wurde auf {value} angepasst.", sparkline_detail_title: "Verlaufsdetails", sparkline_loading: "Verlauf wird geladen…", sparkline_empty: "Keine Verlaufsdaten verfügbar.", sparkline_error: "Verlauf konnte nicht geladen werden.", sparkline_current: "Aktuell", sparkline_min: "Min", sparkline_max: "Max", sparkline_average: "Durchschnitt", lc_just_now: "gerade eben", state_first: "Wert zuerst", text_layout: "Text-Reihenfolge", primary_text: "Erste Zeile", primary_state: "Wert zuerst", primary_name: "Name zuerst",
-    height: "Höhe", width: "Breite", align: "Ausrichtung", visible: "Sichtbar", left: "Links", center: "Mitte", right: "Rechts",
-    tap_action: "Antippen", hold_action: "Gedrückt halten", double_tap_action: "Doppelklick",
+    row_type: "Zeilentyp",
+    type_entity: "Entität",
+    type_template: "Template",
+    tmpl_content: "Text (Template)",
+    tmpl_icon: "Icon (Template)",
+    tmpl_color: "Farbe (Template)",
+    tmpl_state: "Status (Template)",
+    tmpl_preview: "Vorschau",
+    tmpl_light: "Licht",
+    tmpl_switch: "Schalter / Steckdose",
+    tmpl_select: "Auswahl",
+    tmpl_climate: "Klima",
+    tmpl_cover: "Rollladen / Abdeckung",
+    tmpl_media: "Media Player",
+    show_state: "Status anzeigen",
+    show_label: "Bezeichnung anzeigen",
+    show_icon: "Icon anzeigen",
+    show_last_changed: "Letzte Änderung",
+    show_sparkline: "Sparkline anzeigen",
+    sparkline_detail: "Verlaufsdetails öffnen",
+    sparkline_hours: "Verlauf (Stunden)",
+    sparkline_refresh: "Sparkline-Aktualisierung (Sekunden)",
+    sparkline_refresh_adjusted: "Bitte 60–3600 Sekunden eingeben. Der Wert wurde auf {value} angepasst.",
+    sparkline_detail_title: "Verlaufsdetails",
+    sparkline_loading: "Verlauf wird geladen…",
+    sparkline_empty: "Keine Verlaufsdaten verfügbar.",
+    sparkline_error: "Verlauf konnte nicht geladen werden.",
+    sparkline_current: "Aktuell",
+    sparkline_min: "Min",
+    sparkline_max: "Max",
+    sparkline_average: "Durchschnitt",
+    lc_just_now: "gerade eben",
+    state_first: "Wert zuerst",
+    text_layout: "Text-Reihenfolge",
+    primary_text: "Erste Zeile",
+    primary_state: "Wert zuerst",
+    primary_name: "Name zuerst",
+    height: "Höhe",
+    width: "Breite",
+    align: "Ausrichtung",
+    visible: "Sichtbar",
+    left: "Links",
+    center: "Mitte",
+    right: "Rechts",
+    tap_action: "Antippen",
+    hold_action: "Gedrückt halten",
+    double_tap_action: "Doppelklick",
     actions: "Aktionen",
-    act_more: "Details (Standard)", act_toggle: "Umschalten", act_navigate: "Navigieren", act_call_service: "Aktion (service)", act_none: "Nichts",
-    service: "Service (domain.service)", service_data: "Service Daten (JSON)", target_entity: "Ziel-Entität",
+    act_more: "Details (Standard)",
+    act_toggle: "Umschalten",
+    act_navigate: "Navigieren",
+    act_call_service: "Aktion (service)",
+    act_none: "Nichts",
+    service: "Service (domain.service)",
+    service_data: "Service Daten (JSON)",
+    target_entity: "Ziel-Entität",
     live_preview: "Live-Vorschau",
-    upload_btn: "Bild hochladen", uploading: "Wird hochgeladen...", upload_success: "Bild hochgeladen", upload_optimized: "Bild optimiert und hochgeladen",
-    upload_unsupported: "Bitte ein JPEG-, PNG- oder WebP-Bild wählen.", upload_too_large: "Das Ausgangsbild überschreitet das Limit von 20 MB.", upload_decode_error: "Das Bild konnte nicht gelesen werden.", upload_failed: "Upload fehlgeschlagen ({status}).",
-    image_focal_point: "Bildfokus", image_focal_help: "Klicke oder ziehe die Markierung auf den wichtigen Bildbereich.", image_center: "Zentrieren", image_horizontal: "Horizontale Position", image_vertical: "Vertikale Position",
-    show_name: "Titel anzeigen", header_badges: "Badge", badge_add: "Info-Eintrag hinzufügen", badge_label: "Bezeichnung (optional)", badge_background: "Hintergrund (rgba)", standard_badge_background: "Standard Badge Hintergrund (rgba)", badge_auto_climate_btn: "Klima-Steuerungs-Button automatisch hinzufügen",
-    visibility: "Sichtbarkeit", visibility_cond: "Bedingte Sichtbarkeit", vis_entity: "Bedingungs-Entität", vis_state: "Anzeigen falls Status gleich", vis_invert: "Logik umkehren (Ausblenden falls entsprechend)",
+    upload_btn: "Bild hochladen",
+    uploading: "Wird hochgeladen...",
+    upload_success: "Bild hochgeladen",
+    upload_optimized: "Bild optimiert und hochgeladen",
+    upload_unsupported: "Bitte ein JPEG-, PNG- oder WebP-Bild wählen.",
+    upload_too_large: "Das Ausgangsbild überschreitet das Limit von 20 MB.",
+    upload_decode_error: "Das Bild konnte nicht gelesen werden.",
+    upload_failed: "Upload fehlgeschlagen ({status}).",
+    image_focal_point: "Bildfokus",
+    image_focal_help: "Klicke oder ziehe die Markierung auf den wichtigen Bildbereich.",
+    image_center: "Zentrieren",
+    image_horizontal: "Horizontale Position",
+    image_vertical: "Vertikale Position",
+    show_name: "Titel anzeigen",
+    header_badges: "Badge",
+    badge_add: "Info-Eintrag hinzufügen",
+    badge_label: "Bezeichnung (optional)",
+    badge_background: "Hintergrund (rgba)",
+    standard_badge_background: "Standard Badge Hintergrund (rgba)",
+    badge_auto_climate_btn: "Klima-Steuerungs-Button automatisch hinzufügen",
+    visibility: "Sichtbarkeit",
+    visibility_cond: "Bedingte Sichtbarkeit",
+    vis_entity: "Bedingungs-Entität",
+    vis_state: "Anzeigen falls Status gleich",
+    vis_invert: "Logik umkehren (Ausblenden falls entsprechend)",
     migration_title: "Handlung erforderlich",
     migration_text: "Karte wurde in <b>oneline-room-card</b> umbenannt.<br>Bitte ändere <code>type: custom:room-card</code> zu <code>type: custom:oneline-room-card</code> in deiner YAML-Konfiguration.",
-    control_mode: "Steuerungsmodus", ctrl_default: "Standard", ctrl_slider: "Inline-Slider", ctrl_buttons: "Inline-Buttons", ctrl_full: "Alle Steuerungen", ctrl_all_options: "Alle Optionen",
-    slider_mode: "Slider Modus", slider_mode_brightness: "Helligkeit", slider_mode_color_temp: "Farbtemperatur",
-    slider_style: "Slider Stil", style_inline: "Inline", style_bg: "Hintergrund",
-    collapsible: "Einklappbar", default_state: "Standardzustand", state_expanded: "Ausgeklappt", state_collapsed: "Eingeklappt",
+    control_mode: "Steuerungsmodus",
+    ctrl_default: "Standard",
+    ctrl_slider: "Inline-Slider",
+    ctrl_buttons: "Inline-Buttons",
+    ctrl_full: "Alle Steuerungen",
+    ctrl_all_options: "Alle Optionen",
+    slider_mode: "Slider Modus",
+    slider_mode_brightness: "Helligkeit",
+    slider_mode_color_temp: "Farbtemperatur",
+    slider_style: "Slider Stil",
+    style_inline: "Inline",
+    style_bg: "Hintergrund",
+    collapsible: "Einklappbar",
+    default_state: "Standardzustand",
+    state_expanded: "Ausgeklappt",
+    state_collapsed: "Eingeklappt",
     header_height: "Kopfzeilenhöhe (px)",
-    typography: "Header Typografie", name_font: "Raumname Schrift", info_font: "Info-Zeile Schrift", show_header_text_shadow: "Header-Textschatten",
-    font_size: "Größe (px)", font_weight: "Gewicht", font_style: "Stil", font_color: "Farbe", badge_bg: "Badge Hintergrund",
-    card_behavior: "Kartenverhalten", behavior: "Einklapp-Modus",
+    typography: "Header Typografie",
+    name_font: "Raumname Schrift",
+    info_font: "Info-Zeile Schrift",
+    show_header_text_shadow: "Header-Textschatten",
+    font_size: "Größe (px)",
+    font_weight: "Gewicht",
+    font_style: "Stil",
+    font_color: "Farbe",
+    badge_bg: "Badge Hintergrund",
+    card_behavior: "Kartenverhalten",
+    behavior: "Einklapp-Modus",
     behavior_fixed: "Deaktiviert",
     behavior_collapsed: "Eingeklappt",
     behavior_expanded: "Ausgeklappt",
     behavior_remember: "Remember",
-    header: "Header", configuration: "Konfiguration",
-    color_map: "Zustandsfarben", color_map_add: "Farbe hinzufügen", color_map_state: "Zustand",
-    window_always_show: "Immer anzeigen (auch geschlossen)", window_open_color: "Farbe geöffnet", window_closed_color: "Farbe geschlossen",
-    window_solid_background: "Durchgefärbter Hintergrund", window_labels: "Fensterbezeichnungen",
+    header: "Header",
+    configuration: "Konfiguration",
+    color_map: "Zustandsfarben",
+    color_map_add: "Farbe hinzufügen",
+    color_map_state: "Zustand",
+    window_always_show: "Immer anzeigen (auch geschlossen)",
+    window_open_color: "Farbe geöffnet",
+    window_closed_color: "Farbe geschlossen",
+    window_solid_background: "Durchgefärbter Hintergrund",
+    window_labels: "Fensterbezeichnungen",
     window_custom_label: "Eigene Bezeichnung",
-    window_open_states: "Geöffnete Zustände (kommagetrennt)", window_state_colors: "Zustandsfarben", window_state_colors_add: "Farbe hinzufügen",
-    sensors: "Sensoren", show_chip_shadow: "Sensor-Chip-Schatten", show_status_border: "Statusrahmen und Leuchten", show_status_border_help: "Steuert nur Warnrahmen und Leuchten; Sensor-Badges bleiben sichtbar.",
-    icon_size: "Icon-Größe", global_icon_size: "Globale Icon-Größe (px)",
+    window_open_states: "Geöffnete Zustände (kommagetrennt)",
+    window_state_colors: "Zustandsfarben",
+    window_state_colors_add: "Farbe hinzufügen",
+    sensors: "Sensoren",
+    show_chip_shadow: "Sensor-Chip-Schatten",
+    show_status_border: "Statusrahmen und Leuchten",
+    show_status_border_help: "Steuert nur Warnrahmen und Leuchten; Sensor-Badges bleiben sichtbar.",
+    icon_size: "Icon-Größe",
+    global_icon_size: "Globale Icon-Größe (px)",
     header_info_offset: "Info-Zeile Position",
     header_name_offset: "Titel Position",
     header_sync_offsets: "Synchron Bewegen",
@@ -661,7 +1053,8 @@ const TRANSLATIONS = {
     cover_presets_label: "Voreinstellungen (kommagetrennt)",
     show_climate_presets: "Temperatur-Voreinstellungen",
     climate_presets_label: "Temperaturen (kommagetrennt)",
-    show_hvac_modes: "HVAC-Modus-Chips", show_fan_modes: "Lüftergeschwindigkeit-Chips",
+    show_hvac_modes: "HVAC-Modus-Chips",
+    show_fan_modes: "Lüftergeschwindigkeit-Chips",
     show_brightness_presets: "Helligkeits-Voreinstellungen",
     brightness_presets_label: "Helligkeiten (kommagetrennt)",
     show_brightness_value: "Helligkeit % anzeigen",
@@ -670,36 +1063,153 @@ const TRANSLATIONS = {
     show_media_sources: "Quellen-Chips",
     show_media_sound_modes: "Soundmodus-Chips",
     show_media_title: "Medientitel",
-    sub_chips: "Sub-Chips", chip_add: "Chip hinzufügen", chip_entity: "Entität", chip_attribute: "Attribut (optional)", chip_icon: "Icon (optional)", chip_label: "Bezeichnung (optional)", chips_position: "Chip-Position", chips_top: "Über dem Titel", chips_bottom: "Unter dem Titel",
-    vis_add: "Bedingung hinzufügen", vis_eq: "Zustand ist gleich", vis_neq: "Zustand ist nicht gleich", vis_above: "Numerisch größer als", vis_below: "Numerisch kleiner als",
-    info_line_position: "Info-Zeile Position", info_position_header: "Im Header (Standard)", info_position_below: "Unter dem Header",
-    last_activity_title: "Letzte Aktivität", last_activity_show: "Letzte Aktivität anzeigen",
-    room_modes: "Raum-Modi", room_modes_help: "Szenen oder Skripte direkt über die Raumkarte starten.", room_mode_add: "Raum-Modus hinzufügen", room_mode_entity: "Szene oder Skript", room_mode_active_when: "Aktiv wenn", room_mode_remove: "Modus entfernen", room_mode_up: "Modus nach oben", room_mode_down: "Modus nach unten",
-    adaptive_images: "Adaptive Bilder", adaptive_images_help: "Die erste passende Regel ersetzt das Standardbild im Header.", adaptive_image_add: "Bildregel hinzufügen", adaptive_image_name: "Regelname (optional)", adaptive_image_conditions: "Bedingungen", adaptive_image_preset: "Integriertes Bild", adaptive_image_custom: "Eigene URL / Upload", adaptive_image_duplicate: "Bildregel duplizieren", adaptive_image_remove: "Bildregel entfernen", adaptive_image_up: "Bildregel nach oben", adaptive_image_down: "Bildregel nach unten", adaptive_image_position: "Bildfokus der Regel",
-    status_groups: "Raumstatus", status_groups_help: "Konfigurierte Entitäten zusammenfassen, ohne die Alarmpriorität zu verändern.", status_group_add: "Statusgruppe hinzufügen", status_group_preset_lights: "Lichter an", status_group_preset_windows: "Offene Fenster", status_group_preset_media: "Aktive Medien", status_group_preset_power: "Leistung", status_group_entities: "Entitäten", status_group_active_states: "Aktive Zustände (kommagetrennt)", status_group_display: "Anzeige", status_group_count: "Anzahl", status_group_value: "Numerische Summe", status_group_unit: "Ausgabeeinheit", status_group_precision: "Nachkommastellen", status_group_hide_zero: "Bei null ausblenden", status_group_details: "Beitragende Entitäten öffnen", status_group_conditions: "Gruppe anzeigen wenn", status_group_duplicate: "Statusgruppe duplizieren", status_group_remove: "Statusgruppe entfernen", status_group_up: "Statusgruppe nach oben", status_group_down: "Statusgruppe nach unten", status_group_incompatible_units: "Nicht kompatible Einheiten",
-    a11y_close: "Schließen", a11y_previous_track: "Vorheriger Titel", a11y_play_pause: "Wiedergabe oder Pause", a11y_next_track: "Nächster Titel",
-    a11y_mute: "Stumm schalten oder Ton einschalten", a11y_volume: "Lautstärke", a11y_expand: "Raumsteuerung aufklappen", a11y_collapse: "Raumsteuerung zuklappen",
-    a11y_activate: "{name} bedienen", a11y_set_value: "{name} einstellen", a11y_select_option: "{name} auswählen"
+    sub_chips: "Sub-Chips",
+    chip_add: "Chip hinzufügen",
+    chip_entity: "Entität",
+    chip_attribute: "Attribut (optional)",
+    chip_icon: "Icon (optional)",
+    chip_label: "Bezeichnung (optional)",
+    chips_position: "Chip-Position",
+    chips_top: "Über dem Titel",
+    chips_bottom: "Unter dem Titel",
+    vis_add: "Bedingung hinzufügen",
+    vis_eq: "Zustand ist gleich",
+    vis_neq: "Zustand ist nicht gleich",
+    vis_above: "Numerisch größer als",
+    vis_below: "Numerisch kleiner als",
+    info_line_position: "Info-Zeile Position",
+    info_position_header: "Im Header (Standard)",
+    info_position_below: "Unter dem Header",
+    last_activity_title: "Letzte Aktivität",
+    last_activity_show: "Letzte Aktivität anzeigen",
+    room_modes: "Raum-Modi",
+    room_modes_help: "Szenen oder Skripte direkt über die Raumkarte starten.",
+    room_mode_add: "Raum-Modus hinzufügen",
+    room_mode_entity: "Szene oder Skript",
+    room_mode_active_when: "Aktiv wenn",
+    room_mode_remove: "Modus entfernen",
+    room_mode_up: "Modus nach oben",
+    room_mode_down: "Modus nach unten",
+    adaptive_images: "Adaptive Bilder",
+    adaptive_images_help: "Die erste passende Regel ersetzt das Standardbild im Header.",
+    adaptive_image_add: "Bildregel hinzufügen",
+    adaptive_image_name: "Regelname (optional)",
+    adaptive_image_conditions: "Bedingungen",
+    adaptive_image_preset: "Integriertes Bild",
+    adaptive_image_custom: "Eigene URL / Upload",
+    adaptive_image_duplicate: "Bildregel duplizieren",
+    adaptive_image_remove: "Bildregel entfernen",
+    adaptive_image_up: "Bildregel nach oben",
+    adaptive_image_down: "Bildregel nach unten",
+    adaptive_image_position: "Bildfokus der Regel",
+    status_groups: "Raumstatus",
+    status_groups_help: "Konfigurierte Entitäten zusammenfassen, ohne die Alarmpriorität zu verändern.",
+    status_group_add: "Statusgruppe hinzufügen",
+    status_group_preset_lights: "Lichter an",
+    status_group_preset_windows: "Offene Fenster",
+    status_group_preset_media: "Aktive Medien",
+    status_group_preset_power: "Leistung",
+    status_group_entities: "Entitäten",
+    status_group_active_states: "Aktive Zustände (kommagetrennt)",
+    status_group_display: "Anzeige",
+    status_group_count: "Anzahl",
+    status_group_value: "Numerische Summe",
+    status_group_unit: "Ausgabeeinheit",
+    status_group_precision: "Nachkommastellen",
+    status_group_hide_zero: "Bei null ausblenden",
+    status_group_details: "Beitragende Entitäten öffnen",
+    status_group_conditions: "Gruppe anzeigen wenn",
+    status_group_duplicate: "Statusgruppe duplizieren",
+    status_group_remove: "Statusgruppe entfernen",
+    status_group_up: "Statusgruppe nach oben",
+    status_group_down: "Statusgruppe nach unten",
+    status_group_incompatible_units: "Nicht kompatible Einheiten",
+    a11y_close: "Schließen",
+    a11y_previous_track: "Vorheriger Titel",
+    a11y_play_pause: "Wiedergabe oder Pause",
+    a11y_next_track: "Nächster Titel",
+    a11y_mute: "Stumm schalten oder Ton einschalten",
+    a11y_volume: "Lautstärke",
+    a11y_expand: "Raumsteuerung aufklappen",
+    a11y_collapse: "Raumsteuerung zuklappen",
+    a11y_activate: "{name} bedienen",
+    a11y_set_value: "{name} einstellen",
+    a11y_select_option: "{name} auswählen"
   },
   fr: {
-    empty: "Vide", low: "Faible", critical: "Critique", window: "Fenêtre", general: "Général",
-    sensors_manual: "Capteurs (Manuel)", buttons: "Boutons", button: "Bouton", add_button: "Ajouter un bouton",
-    main_climate: "Appareil climatique principal (Optionnel)", climate_info: "Remplit automatiquement Temp/Humidité si vide ci-dessous.",
-    temp_label: "Température (remplace climat)", target_temp_label: "Température cible", humid_label: "Humidité (remplace climat)", temp_unit: "Unité de température", temp_unit_default: "Valeur par défaut de Home Assistant",
-    window_label: "Fenêtres (Liste)", battery_label: "Batteries (Liste)", name: "Nom", icon: "Icône", color: "Couleur",
-    humid_warn_threshold: "Seuil d'alerte d'humidité (%)", high_humidity: "Humidité élevée", device_unavailable: "Appareil indisponible",
-    force_color: "Forcer la couleur", img_url: "URL de l'image", image: "Image", path: "Chemin (Tap Action)", entity: "Entité", device: "Appareil (Optionnel)",
-    image_entity: "Entité lumineuse (Niveaux de gris si éteint)", image_entity_help: "Lorsque l'entité sélectionnée est éteinte, l'image d'en-tête passe en niveaux de gris.",
+    empty: "Vide",
+    low: "Faible",
+    critical: "Critique",
+    window: "Fenêtre",
+    general: "Général",
+    sensors_manual: "Capteurs (Manuel)",
+    buttons: "Boutons",
+    button: "Bouton",
+    add_button: "Ajouter un bouton",
+    main_climate: "Appareil climatique principal (Optionnel)",
+    climate_info: "Remplit automatiquement Temp/Humidité si vide ci-dessous.",
+    temp_label: "Température (remplace climat)",
+    target_temp_label: "Température cible",
+    humid_label: "Humidité (remplace climat)",
+    temp_unit: "Unité de température",
+    temp_unit_default: "Valeur par défaut de Home Assistant",
+    window_label: "Fenêtres (Liste)",
+    battery_label: "Batteries (Liste)",
+    name: "Nom",
+    icon: "Icône",
+    color: "Couleur",
+    humid_warn_threshold: "Seuil d'alerte d'humidité (%)",
+    high_humidity: "Humidité élevée",
+    device_unavailable: "Appareil indisponible",
+    force_color: "Forcer la couleur",
+    img_url: "URL de l'image",
+    image: "Image",
+    path: "Chemin (Tap Action)",
+    entity: "Entité",
+    device: "Appareil (Optionnel)",
+    image_entity: "Entité lumineuse (Niveaux de gris si éteint)",
+    image_entity_help: "Lorsque l'entité sélectionnée est éteinte, l'image d'en-tête passe en niveaux de gris.",
     show_image: "Afficher l'image de fond",
-    image_preset_title: "Image de pièce intégrée", image_preset_help: "Choisissez une image RoomCard ou continuez à utiliser votre propre URL ou import.", image_preset_custom: "Image personnalisée",
-    image_preset_living_room: "Salon", image_preset_kitchen: "Cuisine", image_preset_bedroom: "Chambre", image_preset_bathroom: "Salle de bain",
-    image_preset_dining_room: "Salle à manger", image_preset_home_office: "Bureau", image_preset_childrens_room: "Chambre d'enfant", image_preset_hallway: "Entrée",
-    image_preset_guest_room: "Chambre d'amis", image_preset_garage: "Garage", image_preset_garden_patio: "Jardin / terrasse", image_preset_balcony: "Balcon",
-    image_preset_basement: "Sous-sol", image_preset_laundry_room: "Buanderie", image_preset_attic: "Grenier", image_preset_workshop: "Atelier",
-    presence_sensor: "Capteur de présence (Mouvement/Personne)", presence_detected: "Présent", presence_chip_color: "Couleur du badge de présence", presence_solid_background: "Arrière-plan plein du badge de présence",
-    area_setup: "Configuration de zone", area_setup_desc: "Remplir automatiquement les contrôles et capteurs à partir des entités de la zone", area_picker: "Zone Home Assistant", area_generate: "Générer depuis la zone", area_no_entities: "Aucune entité trouvée dans cette zone",
-    alert_sensors: "Capteurs d'alerte", alert_sensor_add: "Ajouter un capteur d'alerte", alert_sensor_entity: "Capteur", alert_sensor_above: "Supérieur à", alert_sensor_below: "Inférieur à", alert_sensor_state: "État", alert_border_color: "Couleur du contour", alert_chip_collapsed: "Afficher en badge groupé", active_alerts: "Alertes actives",
-    template: "Filtre de type", add_template: "avec filtre", add_prefix: "Ajouter",
+    image_preset_title: "Image de pièce intégrée",
+    image_preset_help: "Choisissez une image RoomCard ou continuez à utiliser votre propre URL ou import.",
+    image_preset_custom: "Image personnalisée",
+    image_preset_living_room: "Salon",
+    image_preset_kitchen: "Cuisine",
+    image_preset_bedroom: "Chambre",
+    image_preset_bathroom: "Salle de bain",
+    image_preset_dining_room: "Salle à manger",
+    image_preset_home_office: "Bureau",
+    image_preset_childrens_room: "Chambre d'enfant",
+    image_preset_hallway: "Entrée",
+    image_preset_guest_room: "Chambre d'amis",
+    image_preset_garage: "Garage",
+    image_preset_garden_patio: "Jardin / terrasse",
+    image_preset_balcony: "Balcon",
+    image_preset_basement: "Sous-sol",
+    image_preset_laundry_room: "Buanderie",
+    image_preset_attic: "Grenier",
+    image_preset_workshop: "Atelier",
+    presence_sensor: "Capteur de présence (Mouvement/Personne)",
+    presence_detected: "Présent",
+    presence_chip_color: "Couleur du badge de présence",
+    presence_solid_background: "Arrière-plan plein du badge de présence",
+    area_setup: "Configuration de zone",
+    area_setup_desc: "Remplir automatiquement les contrôles et capteurs à partir des entités de la zone",
+    area_picker: "Zone Home Assistant",
+    area_generate: "Générer depuis la zone",
+    area_no_entities: "Aucune entité trouvée dans cette zone",
+    alert_sensors: "Capteurs d'alerte",
+    alert_sensor_add: "Ajouter un capteur d'alerte",
+    alert_sensor_entity: "Capteur",
+    alert_sensor_above: "Supérieur à",
+    alert_sensor_below: "Inférieur à",
+    alert_sensor_state: "État",
+    alert_border_color: "Couleur du contour",
+    alert_chip_collapsed: "Afficher en badge groupé",
+    active_alerts: "Alertes actives",
+    template: "Filtre de type",
+    add_template: "avec filtre",
+    add_prefix: "Ajouter",
     quick_add_title: "Ajout rapide",
     quick_add_desc: "Ajouter rapidement des boutons à partir d’entités existantes.",
     quick_add_entity_type_label: "Type d’entité",
@@ -718,39 +1228,142 @@ const TRANSLATIONS = {
     pos_bottom: "Bas",
     pos_left: "Gauche",
     pos_top: "Haut",
-    row_type: "Type de ligne", type_entity: "Entité", type_template: "Template",
-    tmpl_content: "Contenu (Template)", tmpl_icon: "Icône (Template)", tmpl_color: "Couleur (Template)", tmpl_state: "État (Template)", tmpl_preview: "Aperçu",
-    tmpl_light: "Lumière", tmpl_switch: "Interrupteur / Prise", tmpl_select: "Sélection", tmpl_climate: "Climatisation", tmpl_cover: "Volet / Store", tmpl_media: "Lecteur multimédia",
-    show_state: "Afficher l’état", show_label: "Afficher le libellé", show_icon: "Afficher l’icône", show_last_changed: "Dernier changement", show_sparkline: "Afficher la Sparkline", sparkline_detail: "Ouvrir les détails de l’historique", sparkline_hours: "Historique (heures)", sparkline_refresh: "Actualisation de la Sparkline (secondes)", sparkline_refresh_adjusted: "Saisissez 60 à 3600 secondes. La valeur a été ajustée à {value}.", sparkline_detail_title: "Détails de l’historique", sparkline_loading: "Chargement de l’historique…", sparkline_empty: "Aucune donnée d’historique disponible.", sparkline_error: "Impossible de charger l’historique.", sparkline_current: "Actuel", sparkline_min: "Min", sparkline_max: "Max", sparkline_average: "Moyenne", lc_just_now: "à l’instant", state_first: "Valeur d’abord", text_layout: "Ordre du texte", primary_text: "Première ligne", primary_state: "Valeur d’abord", primary_name: "Nom d’abord",
-    height: "Hauteur", width: "Largeur", align: "Alignement", visible: "Visible", left: "Gauche", center: "Centre", right: "Droite",
-    tap_action: "Appui court", hold_action: "Appui long", double_tap_action: "Double appui",
+    row_type: "Type de ligne",
+    type_entity: "Entité",
+    type_template: "Template",
+    tmpl_content: "Contenu (Template)",
+    tmpl_icon: "Icône (Template)",
+    tmpl_color: "Couleur (Template)",
+    tmpl_state: "État (Template)",
+    tmpl_preview: "Aperçu",
+    tmpl_light: "Lumière",
+    tmpl_switch: "Interrupteur / Prise",
+    tmpl_select: "Sélection",
+    tmpl_climate: "Climatisation",
+    tmpl_cover: "Volet / Store",
+    tmpl_media: "Lecteur multimédia",
+    show_state: "Afficher l’état",
+    show_label: "Afficher le libellé",
+    show_icon: "Afficher l’icône",
+    show_last_changed: "Dernier changement",
+    show_sparkline: "Afficher la Sparkline",
+    sparkline_detail: "Ouvrir les détails de l’historique",
+    sparkline_hours: "Historique (heures)",
+    sparkline_refresh: "Actualisation de la Sparkline (secondes)",
+    sparkline_refresh_adjusted: "Saisissez 60 à 3600 secondes. La valeur a été ajustée à {value}.",
+    sparkline_detail_title: "Détails de l’historique",
+    sparkline_loading: "Chargement de l’historique…",
+    sparkline_empty: "Aucune donnée d’historique disponible.",
+    sparkline_error: "Impossible de charger l’historique.",
+    sparkline_current: "Actuel",
+    sparkline_min: "Min",
+    sparkline_max: "Max",
+    sparkline_average: "Moyenne",
+    lc_just_now: "à l’instant",
+    state_first: "Valeur d’abord",
+    text_layout: "Ordre du texte",
+    primary_text: "Première ligne",
+    primary_state: "Valeur d’abord",
+    primary_name: "Nom d’abord",
+    height: "Hauteur",
+    width: "Largeur",
+    align: "Alignement",
+    visible: "Visible",
+    left: "Gauche",
+    center: "Centre",
+    right: "Droite",
+    tap_action: "Appui court",
+    hold_action: "Appui long",
+    double_tap_action: "Double appui",
     actions: "Actions",
-    act_more: "Détails (Défaut)", act_toggle: "Basculer", act_navigate: "Navigation", act_call_service: "Action (service)", act_none: "Rien",
-    service: "Service (domain.service)", service_data: "Données du service (JSON)", target_entity: "Entité cible",
+    act_more: "Détails (Défaut)",
+    act_toggle: "Basculer",
+    act_navigate: "Navigation",
+    act_call_service: "Action (service)",
+    act_none: "Rien",
+    service: "Service (domain.service)",
+    service_data: "Données du service (JSON)",
+    target_entity: "Entité cible",
     live_preview: "Aperçu en direct",
-    upload_btn: "Télécharger une image", uploading: "Téléchargement...", upload_success: "Image importée", upload_optimized: "Image optimisée et importée",
-    upload_unsupported: "Choisissez une image JPEG, PNG ou WebP.", upload_too_large: "L'image source dépasse la limite de 20 Mo.", upload_decode_error: "L'image n'a pas pu être décodée.", upload_failed: "Échec de l'import ({status}).",
-    image_focal_point: "Point focal de l'image", image_focal_help: "Cliquez ou déplacez le repère vers la zone importante.", image_center: "Centrer", image_horizontal: "Position horizontale", image_vertical: "Position verticale",
-    show_name: "Afficher le titre", header_badges: "Infos d'en-tête supplémentaires", badge_add: "Ajouter une entrée", badge_label: "Libellé (optionnel)", badge_background: "Arrière-plan (rgba)", standard_badge_background: "Fond du badge climat principal (rgba)", badge_auto_climate_btn: "Ajouter automatiquement un bouton de commande du chauffage",
-    visibility: "Visibilité", visibility_cond: "Visibilité conditionnelle", vis_entity: "Entité de la condition", vis_state: "Afficher si l’état est", vis_invert: "Inverser la logique (masquer si l’état correspond)",
+    upload_btn: "Télécharger une image",
+    uploading: "Téléchargement...",
+    upload_success: "Image importée",
+    upload_optimized: "Image optimisée et importée",
+    upload_unsupported: "Choisissez une image JPEG, PNG ou WebP.",
+    upload_too_large: "L'image source dépasse la limite de 20 Mo.",
+    upload_decode_error: "L'image n'a pas pu être décodée.",
+    upload_failed: "Échec de l'import ({status}).",
+    image_focal_point: "Point focal de l'image",
+    image_focal_help: "Cliquez ou déplacez le repère vers la zone importante.",
+    image_center: "Centrer",
+    image_horizontal: "Position horizontale",
+    image_vertical: "Position verticale",
+    show_name: "Afficher le titre",
+    header_badges: "Infos d'en-tête supplémentaires",
+    badge_add: "Ajouter une entrée",
+    badge_label: "Libellé (optionnel)",
+    badge_background: "Arrière-plan (rgba)",
+    standard_badge_background: "Fond du badge climat principal (rgba)",
+    badge_auto_climate_btn: "Ajouter automatiquement un bouton de commande du chauffage",
+    visibility: "Visibilité",
+    visibility_cond: "Visibilité conditionnelle",
+    vis_entity: "Entité de la condition",
+    vis_state: "Afficher si l’état est",
+    vis_invert: "Inverser la logique (masquer si l’état correspond)",
     migration_title: "Action requise",
     migration_text: "Carte renommée en <b>oneline-room-card</b> pour éviter les conflits.<br>Veuillez changer <code>type: custom:room-card</code> en <code>type: custom:oneline-room-card</code>.",
-    control_mode: "Mode de contrôle", ctrl_default: "Défaut", ctrl_slider: "Curseur", ctrl_buttons: "Boutons", ctrl_full: "Contrôles complets", ctrl_all_options: "Toutes les options",
-    slider_mode: "Mode Curseurs", slider_mode_brightness: "Luminosité", slider_mode_color_temp: "Température de couleur",
-    slider_style: "Style de curseur", style_inline: "Intégré", style_bg: "Arrière-plan",
-    collapsible: "Rétractable", default_state: "État par défaut", state_expanded: "Déplié", state_collapsed: "Replié",
+    control_mode: "Mode de contrôle",
+    ctrl_default: "Défaut",
+    ctrl_slider: "Curseur",
+    ctrl_buttons: "Boutons",
+    ctrl_full: "Contrôles complets",
+    ctrl_all_options: "Toutes les options",
+    slider_mode: "Mode Curseurs",
+    slider_mode_brightness: "Luminosité",
+    slider_mode_color_temp: "Température de couleur",
+    slider_style: "Style de curseur",
+    style_inline: "Intégré",
+    style_bg: "Arrière-plan",
+    collapsible: "Rétractable",
+    default_state: "État par défaut",
+    state_expanded: "Déplié",
+    state_collapsed: "Replié",
     header_height: "Hauteur de l'en-tête (px)",
-    typography: "Typographie de l'en-tête", name_font: "Police du nom", info_font: "Police des infos", show_header_text_shadow: "Ombre du texte de l’en-tête",
-    font_size: "Taille (px)", font_weight: "Poids", font_style: "Style", font_color: "Couleur", badge_bg: "Fond du badge",
-    card_behavior: "Comportement de la carte", behavior: "Mode repli", behavior_fixed: "Désactivé", behavior_collapsed: "Replié", behavior_expanded: "Déplié", behavior_remember: "Remember",
-    header: "En-tête", configuration: "Configuration",
-    color_map: "Couleurs par état", color_map_add: "Ajouter couleur", color_map_state: "État",
-    window_always_show: "Toujours afficher (incl. fermé)", window_open_color: "Couleur ouvert", window_closed_color: "Couleur fermé",
-    window_solid_background: "Arrière-plan plein", window_labels: "Libellés des fenêtres",
+    typography: "Typographie de l'en-tête",
+    name_font: "Police du nom",
+    info_font: "Police des infos",
+    show_header_text_shadow: "Ombre du texte de l’en-tête",
+    font_size: "Taille (px)",
+    font_weight: "Poids",
+    font_style: "Style",
+    font_color: "Couleur",
+    badge_bg: "Fond du badge",
+    card_behavior: "Comportement de la carte",
+    behavior: "Mode repli",
+    behavior_fixed: "Désactivé",
+    behavior_collapsed: "Replié",
+    behavior_expanded: "Déplié",
+    behavior_remember: "Remember",
+    header: "En-tête",
+    configuration: "Configuration",
+    color_map: "Couleurs par état",
+    color_map_add: "Ajouter couleur",
+    color_map_state: "État",
+    window_always_show: "Toujours afficher (incl. fermé)",
+    window_open_color: "Couleur ouvert",
+    window_closed_color: "Couleur fermé",
+    window_solid_background: "Arrière-plan plein",
+    window_labels: "Libellés des fenêtres",
     window_custom_label: "Libellé personnalisé",
-    window_open_states: "États ouverts (séparés par virgule)", window_state_colors: "Couleurs par état", window_state_colors_add: "Ajouter couleur",
-    sensors: "Capteurs", show_chip_shadow: "Ombre des badges de capteur", show_status_border: "Contour et lueur d’état", show_status_border_help: "Contrôle uniquement le contour et la lueur d’alerte ; les badges restent visibles.",
-    icon_size: "Taille icône", global_icon_size: "Taille icône globale (px)",
+    window_open_states: "États ouverts (séparés par virgule)",
+    window_state_colors: "Couleurs par état",
+    window_state_colors_add: "Ajouter couleur",
+    sensors: "Capteurs",
+    show_chip_shadow: "Ombre des badges de capteur",
+    show_status_border: "Contour et lueur d’état",
+    show_status_border_help: "Contrôle uniquement le contour et la lueur d’alerte ; les badges restent visibles.",
+    icon_size: "Taille icône",
+    global_icon_size: "Taille icône globale (px)",
     header_info_offset: "Position ligne info",
     header_name_offset: "Position titre",
     header_sync_offsets: "Synchroniser les positions",
@@ -760,7 +1373,8 @@ const TRANSLATIONS = {
     cover_presets_label: "Valeurs (séparées par virgule)",
     show_climate_presets: "Préréglages de température",
     climate_presets_label: "Températures (séparées par virgule)",
-    show_hvac_modes: "Boutons mode HVAC", show_fan_modes: "Boutons vitesse ventilateur",
+    show_hvac_modes: "Boutons mode HVAC",
+    show_fan_modes: "Boutons vitesse ventilateur",
     show_brightness_presets: "Préréglages de luminosité",
     brightness_presets_label: "Luminosités (séparées par virgule)",
     show_brightness_value: "Afficher luminosité %",
@@ -769,30 +1383,89 @@ const TRANSLATIONS = {
     show_media_sources: "Sources",
     show_media_sound_modes: "Modes audio",
     show_media_title: "Titre média",
-    sub_chips: "Sous-puces", chip_add: "Ajouter une puce", chip_entity: "Entité", chip_attribute: "Attribut (facultatif)", chip_icon: "Icône (facultative)", chip_label: "Libellé (facultatif)", chips_position: "Position des puces", chips_top: "Au-dessus du titre", chips_bottom: "Sous le titre",
-    vis_add: "Ajouter une condition", vis_eq: "L’état est égal à", vis_neq: "L’état est différent de", vis_above: "L’état est strictement supérieur à", vis_below: "L’état est strictement inférieur à",
-    info_line_position: "Position ligne info", info_position_header: "Dans l'en-tête (défaut)", info_position_below: "Sous l'en-tête",
-    last_activity_title: "Dernière activité", last_activity_show: "Afficher la dernière activité",
-    room_modes: "Modes de pièce", room_modes_help: "Lancer des scènes ou des scripts depuis la carte de pièce.", room_mode_add: "Ajouter un mode", room_mode_entity: "Scène ou script", room_mode_active_when: "Actif lorsque", room_mode_remove: "Supprimer le mode", room_mode_up: "Déplacer vers le haut", room_mode_down: "Déplacer vers le bas",
-    adaptive_images: "Images adaptatives", adaptive_images_help: "La première règle correspondante remplace l’image d’en-tête par défaut.", adaptive_image_add: "Ajouter une règle d’image", adaptive_image_name: "Nom de la règle (facultatif)", adaptive_image_conditions: "Conditions", adaptive_image_preset: "Image intégrée", adaptive_image_custom: "URL personnalisée / import", adaptive_image_duplicate: "Dupliquer la règle d’image", adaptive_image_remove: "Supprimer la règle d’image", adaptive_image_up: "Monter la règle d’image", adaptive_image_down: "Descendre la règle d’image", adaptive_image_position: "Point focal de la règle",
-    status_groups: "État de la pièce", status_groups_help: "Résumer les entités configurées sans modifier la priorité des alertes.", status_group_add: "Ajouter un groupe d’état", status_group_preset_lights: "Lumières allumées", status_group_preset_windows: "Fenêtres ouvertes", status_group_preset_media: "Média actif", status_group_preset_power: "Puissance", status_group_entities: "Entités", status_group_active_states: "États actifs (séparés par des virgules)", status_group_display: "Affichage", status_group_count: "Nombre", status_group_value: "Somme numérique", status_group_unit: "Unité de sortie", status_group_precision: "Décimales", status_group_hide_zero: "Masquer à zéro", status_group_details: "Ouvrir les entités contributrices", status_group_conditions: "Afficher le groupe lorsque", status_group_duplicate: "Dupliquer le groupe d’état", status_group_remove: "Supprimer le groupe d’état", status_group_up: "Monter le groupe d’état", status_group_down: "Descendre le groupe d’état", status_group_incompatible_units: "Unités incompatibles",
-    a11y_close: "Fermer", a11y_previous_track: "Piste précédente", a11y_play_pause: "Lecture ou pause", a11y_next_track: "Piste suivante",
-    a11y_mute: "Couper ou rétablir le son", a11y_volume: "Volume", a11y_expand: "Développer les commandes", a11y_collapse: "Réduire les commandes",
-    a11y_activate: "Activer {name}", a11y_set_value: "Régler {name}", a11y_select_option: "Sélectionner {name}"
+    sub_chips: "Sous-puces",
+    chip_add: "Ajouter une puce",
+    chip_entity: "Entité",
+    chip_attribute: "Attribut (facultatif)",
+    chip_icon: "Icône (facultative)",
+    chip_label: "Libellé (facultatif)",
+    chips_position: "Position des puces",
+    chips_top: "Au-dessus du titre",
+    chips_bottom: "Sous le titre",
+    vis_add: "Ajouter une condition",
+    vis_eq: "L’état est égal à",
+    vis_neq: "L’état est différent de",
+    vis_above: "L’état est strictement supérieur à",
+    vis_below: "L’état est strictement inférieur à",
+    info_line_position: "Position ligne info",
+    info_position_header: "Dans l'en-tête (défaut)",
+    info_position_below: "Sous l'en-tête",
+    last_activity_title: "Dernière activité",
+    last_activity_show: "Afficher la dernière activité",
+    room_modes: "Modes de pièce",
+    room_modes_help: "Lancer des scènes ou des scripts depuis la carte de pièce.",
+    room_mode_add: "Ajouter un mode",
+    room_mode_entity: "Scène ou script",
+    room_mode_active_when: "Actif lorsque",
+    room_mode_remove: "Supprimer le mode",
+    room_mode_up: "Déplacer vers le haut",
+    room_mode_down: "Déplacer vers le bas",
+    adaptive_images: "Images adaptatives",
+    adaptive_images_help: "La première règle correspondante remplace l’image d’en-tête par défaut.",
+    adaptive_image_add: "Ajouter une règle d’image",
+    adaptive_image_name: "Nom de la règle (facultatif)",
+    adaptive_image_conditions: "Conditions",
+    adaptive_image_preset: "Image intégrée",
+    adaptive_image_custom: "URL personnalisée / import",
+    adaptive_image_duplicate: "Dupliquer la règle d’image",
+    adaptive_image_remove: "Supprimer la règle d’image",
+    adaptive_image_up: "Monter la règle d’image",
+    adaptive_image_down: "Descendre la règle d’image",
+    adaptive_image_position: "Point focal de la règle",
+    status_groups: "État de la pièce",
+    status_groups_help: "Résumer les entités configurées sans modifier la priorité des alertes.",
+    status_group_add: "Ajouter un groupe d’état",
+    status_group_preset_lights: "Lumières allumées",
+    status_group_preset_windows: "Fenêtres ouvertes",
+    status_group_preset_media: "Média actif",
+    status_group_preset_power: "Puissance",
+    status_group_entities: "Entités",
+    status_group_active_states: "États actifs (séparés par des virgules)",
+    status_group_display: "Affichage",
+    status_group_count: "Nombre",
+    status_group_value: "Somme numérique",
+    status_group_unit: "Unité de sortie",
+    status_group_precision: "Décimales",
+    status_group_hide_zero: "Masquer à zéro",
+    status_group_details: "Ouvrir les entités contributrices",
+    status_group_conditions: "Afficher le groupe lorsque",
+    status_group_duplicate: "Dupliquer le groupe d’état",
+    status_group_remove: "Supprimer le groupe d’état",
+    status_group_up: "Monter le groupe d’état",
+    status_group_down: "Descendre le groupe d’état",
+    status_group_incompatible_units: "Unités incompatibles",
+    a11y_close: "Fermer",
+    a11y_previous_track: "Piste précédente",
+    a11y_play_pause: "Lecture ou pause",
+    a11y_next_track: "Piste suivante",
+    a11y_mute: "Couper ou rétablir le son",
+    a11y_volume: "Volume",
+    a11y_expand: "Développer les commandes",
+    a11y_collapse: "Réduire les commandes",
+    a11y_activate: "Activer {name}",
+    a11y_set_value: "Régler {name}",
+    a11y_select_option: "Sélectionner {name}"
   }
 };
-
-const getTranslation = (hass, key) => {
+var getTranslation = (hass, key) => {
   const lang = hass?.language?.split("-")[0] || "en";
   return TRANSLATIONS[lang]?.[key] ?? TRANSLATIONS["en"]?.[key] ?? key;
 };
-
-const clampNum = (v, min, max, fallback) => {
+var clampNum = (v, min, max, fallback) => {
   const n = Number(v);
   return Number.isFinite(n) ? Math.max(min, Math.min(n, max)) : fallback;
 };
-
-const replaceTemplateExpressions = (str, evalExpr) => {
+var replaceTemplateExpressions = (str, evalExpr) => {
   let out = "";
   let i = 0;
   while (i < str.length) {
@@ -832,13 +1505,35 @@ const replaceTemplateExpressions = (str, evalExpr) => {
           expr += ch;
           continue;
         }
-        if (ch === "'") { inSingle = true; expr += ch; continue; }
-        if (ch === '"') { inDouble = true; expr += ch; continue; }
-        if (ch === "`") { inBacktick = true; expr += ch; continue; }
-        if (ch === "{") { depth++; expr += ch; continue; }
+        if (ch === "'") {
+          inSingle = true;
+          expr += ch;
+          continue;
+        }
+        if (ch === '"') {
+          inDouble = true;
+          expr += ch;
+          continue;
+        }
+        if (ch === "`") {
+          inBacktick = true;
+          expr += ch;
+          continue;
+        }
+        if (ch === "{") {
+          depth++;
+          expr += ch;
+          continue;
+        }
         if (ch === "}") {
-          if (depth === 0) { closed = true; i++; break; }
-          depth--; expr += ch; continue;
+          if (depth === 0) {
+            closed = true;
+            i++;
+            break;
+          }
+          depth--;
+          expr += ch;
+          continue;
         }
         expr += ch;
       }
@@ -854,118 +1549,109 @@ const replaceTemplateExpressions = (str, evalExpr) => {
   }
   return out;
 };
-
-const trimStr = (v) => (typeof v === "string" ? v.trim() : v);
-
-const formatEntityStateForDisplay = (hass, stateObj, fallbackUnit = "") => {
+var trimStr = (v) => typeof v === "string" ? v.trim() : v;
+var formatEntityStateForDisplay = (hass, stateObj, fallbackUnit = "") => {
   if (!stateObj) return "";
   try {
     if (typeof hass?.formatEntityState === "function") {
       const formatted = hass.formatEntityState(stateObj);
-      const entityUnit = trimStr(stateObj.attributes?.unit_of_measurement) || "";
-      return !entityUnit && fallbackUnit ? `${formatted}${fallbackUnit}` : formatted;
+      const entityUnit2 = trimStr(stateObj.attributes?.unit_of_measurement) || "";
+      return !entityUnit2 && fallbackUnit ? `${formatted}${fallbackUnit}` : formatted;
     }
-  } catch (_e) { }
+  } catch (_e) {
+  }
   const raw = stateObj.state ?? "";
   const entityUnit = trimStr(stateObj.attributes?.unit_of_measurement) || fallbackUnit;
   return `${raw}${entityUnit || ""}`;
 };
-
-const formatEntityAttributeForDisplay = (hass, stateObj, attribute, value, fallbackUnit = "") => {
+var formatEntityAttributeForDisplay = (hass, stateObj, attribute, value, fallbackUnit = "") => {
   if (!stateObj || value == null) return "";
   try {
     if (typeof hass?.formatEntityAttributeValue === "function") {
       return hass.formatEntityAttributeValue(stateObj, attribute, value);
     }
-  } catch (_e) { }
+  } catch (_e) {
+  }
   return `${value}${fallbackUnit || ""}`;
 };
-
-const normalizeTemperatureUnit = (unit) => {
+var normalizeTemperatureUnit = (unit) => {
   const normalized = String(unit || "").trim().replace(/\s+/g, "").replace("º", "°").toUpperCase();
   if (normalized === "C" || normalized === "°C") return "°C";
   if (normalized === "F" || normalized === "°F") return "°F";
   return "";
 };
-
-const convertTemperatureValue = (value, sourceUnit, targetUnit) => {
+var convertTemperatureValue = (value, sourceUnit, targetUnit) => {
   const numeric = Number(value);
   const source = normalizeTemperatureUnit(sourceUnit);
   const target = normalizeTemperatureUnit(targetUnit);
   if (!Number.isFinite(numeric) || !source || !target) return null;
   if (source === target) return numeric;
-  return source === "°C"
-    ? (numeric * 9 / 5) + 32
-    : (numeric - 32) * 5 / 9;
+  return source === "°C" ? numeric * 9 / 5 + 32 : (numeric - 32) * 5 / 9;
 };
-
-const temperatureNumberLocale = (hass) => {
+var temperatureNumberLocale = (hass) => {
   switch (hass?.locale?.number_format) {
-    case "comma_decimal": return ["en-US", "en"];
-    case "decimal_comma": return ["de", "es", "it"];
-    case "space_comma": return ["fr", "sv", "cs"];
-    case "quote_decimal": return ["de-CH"];
-    case "system": return undefined;
-    default: return hass?.locale?.language || hass?.language || undefined;
+    case "comma_decimal":
+      return ["en-US", "en"];
+    case "decimal_comma":
+      return ["de", "es", "it"];
+    case "space_comma":
+      return ["fr", "sv", "cs"];
+    case "quote_decimal":
+      return ["de-CH"];
+    case "system":
+      return void 0;
+    default:
+      return hass?.locale?.language || hass?.language || void 0;
   }
 };
-
-const formatConvertedTemperature = (hass, stateObj, value, sourceUnit, targetUnit, fallbackPrecision = 1) => {
+var formatConvertedTemperature = (hass, stateObj, value, sourceUnit, targetUnit, fallbackPrecision = 1) => {
   const target = normalizeTemperatureUnit(targetUnit);
   const converted = convertTemperatureValue(value, sourceUnit, target);
   if (converted == null) return "";
   const configuredPrecision = hass?.entities?.[stateObj?.entity_id]?.display_precision;
   const registryPrecision = configuredPrecision == null ? NaN : Number(configuredPrecision);
-  const precision = Number.isInteger(registryPrecision) && registryPrecision >= 0
-    ? Math.min(registryPrecision, 6)
-    : fallbackPrecision;
+  const precision = Number.isInteger(registryPrecision) && registryPrecision >= 0 ? Math.min(registryPrecision, 6) : fallbackPrecision;
   const fixedValue = converted.toFixed(precision);
   const syntheticState = {
-    ...(stateObj || {}),
+    ...stateObj || {},
     entity_id: "sensor.room_card_temperature",
     state: fixedValue,
     attributes: {
-      ...(stateObj?.attributes || {}),
+      ...stateObj?.attributes || {},
       device_class: "temperature",
       unit_of_measurement: target
     }
   };
   try {
     if (typeof hass?.formatEntityState === "function") return hass.formatEntityState(syntheticState);
-  } catch (_e) { }
+  } catch (_e) {
+  }
   const noGrouping = hass?.locale?.number_format === "none";
   const formatted = new Intl.NumberFormat(noGrouping ? "en-US" : temperatureNumberLocale(hass), {
     minimumFractionDigits: precision,
     maximumFractionDigits: precision,
     useGrouping: !noGrouping
   }).format(converted);
-  return `${formatted}\u00a0${target}`;
+  return `${formatted} ${target}`;
 };
-
-const formatTemperatureStateForDisplay = (hass, stateObj, targetUnit, fallbackSourceUnit = "°C") => {
+var formatTemperatureStateForDisplay = (hass, stateObj, targetUnit, fallbackSourceUnit = "°C") => {
   if (!stateObj) return "";
   const target = normalizeTemperatureUnit(targetUnit);
-  const source = normalizeTemperatureUnit(stateObj.attributes?.unit_of_measurement)
-    || normalizeTemperatureUnit(fallbackSourceUnit);
+  const source = normalizeTemperatureUnit(stateObj.attributes?.unit_of_measurement) || normalizeTemperatureUnit(fallbackSourceUnit);
   if (!target || !source || target === source) {
     return formatEntityStateForDisplay(hass, stateObj, source || fallbackSourceUnit);
   }
-  return formatConvertedTemperature(hass, stateObj, stateObj.state, source, target, 1)
-    || formatEntityStateForDisplay(hass, stateObj, source || fallbackSourceUnit);
+  return formatConvertedTemperature(hass, stateObj, stateObj.state, source, target, 1) || formatEntityStateForDisplay(hass, stateObj, source || fallbackSourceUnit);
 };
-
-const formatTemperatureAttributeForDisplay = (hass, stateObj, attribute, value, targetUnit, fallbackSourceUnit = "°C") => {
-  const source = normalizeTemperatureUnit(hass?.config?.unit_system?.temperature)
-    || normalizeTemperatureUnit(fallbackSourceUnit);
+var formatTemperatureAttributeForDisplay = (hass, stateObj, attribute, value, targetUnit, fallbackSourceUnit = "°C") => {
+  const source = normalizeTemperatureUnit(hass?.config?.unit_system?.temperature) || normalizeTemperatureUnit(fallbackSourceUnit);
   const target = normalizeTemperatureUnit(targetUnit);
   if (!target || !source || target === source) {
     return formatEntityAttributeForDisplay(hass, stateObj, attribute, value, source || fallbackSourceUnit);
   }
-  return formatConvertedTemperature(hass, stateObj, value, source, target, 1)
-    || formatEntityAttributeForDisplay(hass, stateObj, attribute, value, source || fallbackSourceUnit);
+  return formatConvertedTemperature(hass, stateObj, value, source, target, 1) || formatEntityAttributeForDisplay(hass, stateObj, attribute, value, source || fallbackSourceUnit);
 };
-
-const hexToRgba = (hex, alpha = 0.35) => {
+var hexToRgba = (hex, alpha = 0.35) => {
   const m = /^#?([0-9a-f]{6})$/i.exec(trimStr(hex) || "");
   if (!m) return "";
   const raw = m[1];
@@ -974,20 +1660,16 @@ const hexToRgba = (hex, alpha = 0.35) => {
   const b = parseInt(raw.slice(4, 6), 16);
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 };
-
-const readableTextForHex = (hex) => {
+var readableTextForHex = (hex) => {
   const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(trimStr(hex) || "");
   if (!m) return "";
-  const raw = m[1].length === 3
-    ? m[1].split("").map((ch) => ch + ch).join("")
-    : m[1];
+  const raw = m[1].length === 3 ? m[1].split("").map((ch) => ch + ch).join("") : m[1];
   const r = parseInt(raw.slice(0, 2), 16);
   const g = parseInt(raw.slice(2, 4), 16);
   const b = parseInt(raw.slice(4, 6), 16);
-  return ((r * 299 + g * 587 + b * 114) / 1000) >= 140 ? "#000000" : "#ffffff";
+  return (r * 299 + g * 587 + b * 114) / 1e3 >= 140 ? "#000000" : "#ffffff";
 };
-
-const parseColorToPickerHex = (color) => {
+var parseColorToPickerHex = (color) => {
   const value = trimStr(color) || "";
   const hex = /^#([0-9a-f]{6})$/i.exec(value);
   if (hex) return `#${hex[1]}`;
@@ -996,13 +1678,12 @@ const parseColorToPickerHex = (color) => {
   const clamp = (n) => Math.max(0, Math.min(255, Number(n) || 0)).toString(16).padStart(2, "0");
   return `#${clamp(rgba[1])}${clamp(rgba[2])}${clamp(rgba[3])}`;
 };
-
-const STATE_DEFINITIONS = Object.freeze({
-  OFFLINE_STATES: new Set(["unavailable", "unknown"]),
+var STATE_DEFINITIONS = Object.freeze({
+  OFFLINE_STATES: /* @__PURE__ */ new Set(["unavailable", "unknown"]),
   ACTIVE_STATES: {
-    default: new Set(["on", "open", "playing", "heat", "cool", "auto", "drying", "fan_only", "cleaning", "manual", "boost", "unlocked", "home"]),
-    climate: new Set(["heat", "cool", "auto", "drying", "fan_only"]),
-    media_player: new Set(["playing"])
+    default: /* @__PURE__ */ new Set(["on", "open", "playing", "heat", "cool", "auto", "drying", "fan_only", "cleaning", "manual", "boost", "unlocked", "home"]),
+    climate: /* @__PURE__ */ new Set(["heat", "cool", "auto", "drying", "fan_only"]),
+    media_player: /* @__PURE__ */ new Set(["playing"])
   },
   INACTIVE_STATES: Object.freeze({
     off: "off",
@@ -1010,36 +1691,29 @@ const STATE_DEFINITIONS = Object.freeze({
   }),
   ON_STATE: "on"
 });
-
-// Built-in state-dependent icon maps per domain — used when no static icon is configured
-const DOMAIN_STATE_ICON_MAPS = Object.freeze({
+var DOMAIN_STATE_ICON_MAPS = Object.freeze({
   light: { on: "mdi:lightbulb", off: "mdi:lightbulb-outline" },
   switch: { on: "mdi:toggle-switch", off: "mdi:toggle-switch-off-outline" },
   input_boolean: { on: "mdi:toggle-switch", off: "mdi:toggle-switch-off-outline" },
   fan: { on: "mdi:fan", off: "mdi:fan-off" },
   lock: { locked: "mdi:lock", unlocked: "mdi:lock-open-outline" },
   cover: {
-    open: "mdi:window-shutter-open", closed: "mdi:window-shutter",
-    opening: "mdi:window-shutter-open", closing: "mdi:window-shutter"
+    open: "mdi:window-shutter-open",
+    closed: "mdi:window-shutter",
+    opening: "mdi:window-shutter-open",
+    closing: "mdi:window-shutter"
   },
-  media_player: { playing: "mdi:cast-connected", paused: "mdi:cast-connected", idle: "mdi:cast", off: "mdi:cast-off" },
+  media_player: { playing: "mdi:cast-connected", paused: "mdi:cast-connected", idle: "mdi:cast", off: "mdi:cast-off" }
 });
-
-const getEntityDomain = (entityId) => (typeof entityId === "string" && entityId.includes(".") ? entityId.split(".")[0] : "");
-
-const getEntityStateValue = (stateObj) => stateObj?.state;
-
-const isOfflineStateValue = (stateValue) => STATE_DEFINITIONS.OFFLINE_STATES.has(stateValue);
-
-const isEntityOffline = (stateObj) => isOfflineStateValue(getEntityStateValue(stateObj));
-
-const isEntityOn = (stateObj) => getEntityStateValue(stateObj) === STATE_DEFINITIONS.ON_STATE;
-
-const isEntityOff = (stateObj) => getEntityStateValue(stateObj) === STATE_DEFINITIONS.INACTIVE_STATES.off;
-
-const isEntityActive = (stateObj, entityId) => {
+var getEntityDomain = (entityId) => typeof entityId === "string" && entityId.includes(".") ? entityId.split(".")[0] : "";
+var getEntityStateValue = (stateObj) => stateObj?.state;
+var isOfflineStateValue = (stateValue) => STATE_DEFINITIONS.OFFLINE_STATES.has(stateValue);
+var isEntityOffline = (stateObj) => isOfflineStateValue(getEntityStateValue(stateObj));
+var isEntityOn = (stateObj) => getEntityStateValue(stateObj) === STATE_DEFINITIONS.ON_STATE;
+var isEntityOff = (stateObj) => getEntityStateValue(stateObj) === STATE_DEFINITIONS.INACTIVE_STATES.off;
+var isEntityActive = (stateObj, entityId) => {
   const stateValue = getEntityStateValue(stateObj);
-  if (stateValue === undefined || stateValue === null) return false;
+  if (stateValue === void 0 || stateValue === null) return false;
   const domain = getEntityDomain(entityId);
   const domainActive = STATE_DEFINITIONS.ACTIVE_STATES[domain];
   if (domainActive?.has(stateValue)) return true;
@@ -1048,31 +1722,22 @@ const isEntityActive = (stateObj, entityId) => {
   if (domain === "climate") return stateValue !== STATE_DEFINITIONS.INACTIVE_STATES.off && !isOfflineStateValue(stateValue);
   return false;
 };
-
-const isHeaderManualColorEnabled = (config) => !!trimStr(config?.color);
-
-const resolveLabelPosition = (btn, config) => {
+var isHeaderManualColorEnabled = (config) => !!trimStr(config?.color);
+var resolveLabelPosition = (btn, config) => {
   const globalPos = config?.global_label_position ?? config?.buttons_label_position ?? "right";
   const per = btn?.label_position;
   if (!per || per === "global") return globalPos;
   return per;
 };
-
-const setAlignmentClass = (el, pos) => {
+var setAlignmentClass = (el, pos) => {
   if (!el) return;
   el.classList.remove("label-right", "label-left", "label-bottom", "label-top");
   el.classList.add(
-    pos === "bottom"
-      ? "label-bottom"
-      : (pos === "left"
-        ? "label-left"
-        : (pos === "top" ? "label-top" : "label-right"))
+    pos === "bottom" ? "label-bottom" : pos === "left" ? "label-left" : pos === "top" ? "label-top" : "label-right"
   );
 };
-
-const applyLabelPosition = (layoutEl, pos) => {
+var applyLabelPosition = (layoutEl, pos) => {
   if (!layoutEl) return;
-  // Reset layout element inline styles
   layoutEl.style.flexDirection = "";
   layoutEl.style.alignItems = "";
   layoutEl.style.justifyContent = "";
@@ -1081,8 +1746,6 @@ const applyLabelPosition = (layoutEl, pos) => {
   layoutEl.style.padding = "";
   layoutEl.style.overflow = "";
   layoutEl.style.flexWrap = "";
-
-  // Reset common child inline styles if any
   const txt = layoutEl.querySelector(".btn-txt");
   if (txt) {
     txt.style.textAlign = "";
@@ -1115,13 +1778,11 @@ const applyLabelPosition = (layoutEl, pos) => {
     stateEl.style.lineHeight = "";
     stateEl.style.fontSize = "";
   }
-
   layoutEl.classList.remove("label-right", "label-left", "label-bottom", "label-top");
   setAlignmentClass(layoutEl, pos);
 };
-
-const evalTemplateString = (tpl, h, ctrl) => {
-  if (tpl === undefined || tpl === null) return "";
+var evalTemplateString = (tpl, h, ctrl) => {
+  if (tpl === void 0 || tpl === null) return "";
   const str = String(tpl);
   if (!str.includes("${")) return str;
   try {
@@ -1130,10 +1791,9 @@ const evalTemplateString = (tpl, h, ctrl) => {
     const attr = (id, name) => states[id]?.attributes?.[name];
     return replaceTemplateExpressions(str, (expr) => {
       try {
-        // eslint-disable-next-line no-new-func
         const fn = new Function("hass", "states", "entity", "attr", "ctrl", `return (${expr});`);
         const res = fn(h, states, entity, attr, ctrl);
-        return res === undefined || res === null ? "" : String(res);
+        return res === void 0 || res === null ? "" : String(res);
       } catch (err) {
         return "";
       }
@@ -1142,23 +1802,19 @@ const evalTemplateString = (tpl, h, ctrl) => {
     return "";
   }
 };
-
-const resolveTemplateCtrl = (ctrl, h) => {
+var resolveTemplateCtrl = (ctrl, h) => {
   const content = evalTemplateString(ctrl.content, h, ctrl);
   const icon = trimStr(evalTemplateString(ctrl.icon, h, ctrl));
   const color = trimStr(evalTemplateString(ctrl.color, h, ctrl));
   const state = evalTemplateString(ctrl.state, h, ctrl);
   return { content, icon, color, state };
 };
-
-const resolveSubChipPresentations = (ctrl, h) => {
+var resolveSubChipPresentations = (ctrl, h) => {
   const presentations = [];
-  for (const chip of (Array.isArray(ctrl?.sub_chips) ? ctrl.sub_chips : [])) {
+  for (const chip of Array.isArray(ctrl?.sub_chips) ? ctrl.sub_chips : []) {
     if (!chip?.entity || !h?.states?.[chip.entity]) continue;
     const chipState = h.states[chip.entity];
-    const value = chip.attribute
-      ? chipState.attributes?.[chip.attribute]
-      : (h.formatEntityState ? h.formatEntityState(chipState) : chipState.state);
+    const value = chip.attribute ? chipState.attributes?.[chip.attribute] : h.formatEntityState ? h.formatEntityState(chipState) : chipState.state;
     const displayValue = value != null ? String(value) : "";
     let label = chip.label || "";
     if (label.includes("{state}")) label = label.replace("{state}", displayValue);
@@ -1168,17 +1824,15 @@ const resolveSubChipPresentations = (ctrl, h) => {
   }
   return presentations;
 };
-
-const TEMPLATE_VALUE_KEYS = Object.freeze(["content", "icon", "color", "state"]);
-
-const getTemplateEntityDependencies = (ctrl) => {
-  const dependencies = new Set();
+var TEMPLATE_VALUE_KEYS = Object.freeze(["content", "icon", "color", "state"]);
+var getTemplateEntityDependencies = (ctrl) => {
+  const dependencies = /* @__PURE__ */ new Set();
   const add = (entityId) => {
     const value = trimStr(entityId);
     if (/^[a-z0-9_]+\.[a-z0-9_]+$/i.test(value || "")) dependencies.add(value);
   };
   const declared = ctrl?.template_entities ?? ctrl?.dependencies;
-  (Array.isArray(declared) ? declared : (typeof declared === "string" ? declared.split(",") : [])).forEach(add);
+  (Array.isArray(declared) ? declared : typeof declared === "string" ? declared.split(",") : []).forEach(add);
   const source = TEMPLATE_VALUE_KEYS.map((key) => String(ctrl?.[key] ?? "")).join("\n");
   const patterns = [
     /(?:entity|attr)\(\s*["']([^"']+)["']/g,
@@ -1190,14 +1844,12 @@ const getTemplateEntityDependencies = (ctrl) => {
   });
   return Array.from(dependencies);
 };
-
-const templateNeedsEveryHassUpdate = (ctrl) => {
+var templateNeedsEveryHassUpdate = (ctrl) => {
   const source = TEMPLATE_VALUE_KEYS.map((key) => String(ctrl?.[key] ?? "")).join("\n");
   return source.includes("${") && getTemplateEntityDependencies(ctrl).length === 0;
 };
-
-const getConditionEntityDependencies = (conditions) => {
-  const ids = new Set();
+var getConditionEntityDependencies = (conditions) => {
+  const ids = /* @__PURE__ */ new Set();
   const visit = (condition) => {
     if (!condition || typeof condition !== "object") return;
     if (typeof condition.entity === "string" && condition.entity.trim()) ids.add(condition.entity.trim());
@@ -1209,15 +1861,12 @@ const getConditionEntityDependencies = (conditions) => {
   (Array.isArray(conditions) ? conditions : [conditions]).forEach(visit);
   return Array.from(ids);
 };
-
-const evaluateRoomModeCondition = (condition, hass) => {
+var evaluateRoomModeCondition = (condition, hass) => {
   if (!condition || typeof condition !== "object") return { valid: false, active: false };
   const type = condition.condition;
   if (type === "state") {
     const entity = trimStr(condition.entity);
-    const expected = (Array.isArray(condition.state) ? condition.state : [condition.state])
-      .filter((value) => value !== undefined && trimStr(String(value)) !== "")
-      .map(String);
+    const expected = (Array.isArray(condition.state) ? condition.state : [condition.state]).filter((value) => value !== void 0 && trimStr(String(value)) !== "").map(String);
     if (!entity || expected.length === 0) return { valid: false, active: false };
     const stateObj = hass?.states?.[entity];
     if (!stateObj || isEntityOffline(stateObj)) return { valid: false, active: false };
@@ -1225,9 +1874,9 @@ const evaluateRoomModeCondition = (condition, hass) => {
   }
   if (type === "numeric_state") {
     const entity = trimStr(condition.entity);
-    const hasAbove = condition.above !== undefined && trimStr(String(condition.above)) !== "" && Number.isFinite(Number(condition.above));
-    const hasBelow = condition.below !== undefined && trimStr(String(condition.below)) !== "" && Number.isFinite(Number(condition.below));
-    if (!entity || (!hasAbove && !hasBelow)) return { valid: false, active: false };
+    const hasAbove = condition.above !== void 0 && trimStr(String(condition.above)) !== "" && Number.isFinite(Number(condition.above));
+    const hasBelow = condition.below !== void 0 && trimStr(String(condition.below)) !== "" && Number.isFinite(Number(condition.below));
+    if (!entity || !hasAbove && !hasBelow) return { valid: false, active: false };
     const stateObj = hass?.states?.[entity];
     if (!stateObj || isEntityOffline(stateObj)) return { valid: false, active: false };
     const value = Number(stateObj.state);
@@ -1247,9 +1896,8 @@ const evaluateRoomModeCondition = (condition, hass) => {
   }
   return { valid: false, active: false };
 };
-
-const evaluateRoomModeActiveWhen = (activeWhen, hass) => {
-  const conditions = Array.isArray(activeWhen) ? activeWhen : (activeWhen ? [activeWhen] : []);
+var evaluateRoomModeActiveWhen = (activeWhen, hass) => {
+  const conditions = Array.isArray(activeWhen) ? activeWhen : activeWhen ? [activeWhen] : [];
   if (conditions.length === 0) return { valid: false, active: false };
   const results = conditions.map((condition) => evaluateRoomModeCondition(condition, hass));
   return {
@@ -1257,16 +1905,12 @@ const evaluateRoomModeActiveWhen = (activeWhen, hass) => {
     active: results.every((result) => result.valid && result.active)
   };
 };
-
-const SHARED_SPARKLINE_CACHE = new Map();
-const SHARED_SPARKLINE_PENDING = new Map();
-const SHARED_SPARKLINE_CACHE_LIMIT = 100;
-const SHARED_SPARKLINE_MAX_AGE_MS = 4 * 60 * 60 * 1000;
-
-const normalizeSparklineSamples = (samples) => {
-  const valid = (Array.isArray(samples) ? samples : [])
-    .filter((sample) => Number.isFinite(sample?.timestamp) && Number.isFinite(sample?.value))
-    .sort((a, b) => a.timestamp - b.timestamp);
+var SHARED_SPARKLINE_CACHE = /* @__PURE__ */ new Map();
+var SHARED_SPARKLINE_PENDING = /* @__PURE__ */ new Map();
+var SHARED_SPARKLINE_CACHE_LIMIT = 100;
+var SHARED_SPARKLINE_MAX_AGE_MS = 4 * 60 * 60 * 1e3;
+var normalizeSparklineSamples = (samples) => {
+  const valid = (Array.isArray(samples) ? samples : []).filter((sample) => Number.isFinite(sample?.timestamp) && Number.isFinite(sample?.value)).sort((a, b) => a.timestamp - b.timestamp);
   if (valid.length === 0) return [];
   if (valid.length === 1) return [{ x: 0, y: valid[0].value }, { x: 1, y: valid[0].value }];
   const startTime = valid[0].timestamp;
@@ -1276,11 +1920,8 @@ const normalizeSparklineSamples = (samples) => {
     y: sample.value
   }));
 };
-
-const getSparklineStats = (samples) => {
-  const values = (Array.isArray(samples) ? samples : [])
-    .map((sample) => sample?.value)
-    .filter(Number.isFinite);
+var getSparklineStats = (samples) => {
+  const values = (Array.isArray(samples) ? samples : []).map((sample) => sample?.value).filter(Number.isFinite);
   if (values.length === 0) return null;
   return {
     min: Math.min(...values),
@@ -1288,8 +1929,7 @@ const getSparklineStats = (samples) => {
     average: values.reduce((sum, value) => sum + value, 0) / values.length
   };
 };
-
-const pruneSharedSparklineCache = (now = Date.now()) => {
+var pruneSharedSparklineCache = (now = Date.now()) => {
   for (const [key, entry] of SHARED_SPARKLINE_CACHE.entries()) {
     if (!entry || now - entry.lastAccess > SHARED_SPARKLINE_MAX_AGE_MS) SHARED_SPARKLINE_CACHE.delete(key);
   }
@@ -1297,13 +1937,9 @@ const pruneSharedSparklineCache = (now = Date.now()) => {
     SHARED_SPARKLINE_CACHE.delete(SHARED_SPARKLINE_CACHE.keys().next().value);
   }
 };
-
-// =============================================================================
-// LAST CHANGED HELPER
-// =============================================================================
 function formatLastChanged(lastChanged, hass) {
   if (!lastChanged) return "";
-  const elapsedSec = Math.floor((Date.now() - new Date(lastChanged)) / 1000);
+  const elapsedSec = Math.floor((Date.now() - new Date(lastChanged)) / 1e3);
   if (elapsedSec < 60) return getTranslation(hass, "lc_just_now");
   const elapsedMin = Math.floor(elapsedSec / 60);
   if (elapsedMin < 60) return `${elapsedMin} min`;
@@ -1313,23 +1949,19 @@ function formatLastChanged(lastChanged, hass) {
   const elapsedDays = Math.floor(elapsedHours / 24);
   return `${elapsedDays}d`;
 }
-
-// =============================================================================
-// MAIN CARD CLASS
-// =============================================================================
-class OneLineRoomCard extends HTMLElement {
+var OneLineRoomCard = class extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: "open" });
     this._quickAddOpen = false;
-    this._lastStates = new Map();
+    this._lastStates = /* @__PURE__ */ new Map();
     this._lastRenderMetaSig = "";
     this._cachedEntityIds = null;
     this._templateDependencyEntityIds = null;
-    this._activeTimers = new Set();
+    this._activeTimers = /* @__PURE__ */ new Set();
     this._lastChangedInterval = null;
-    this._sparklineCache = new Map();
-    this._sparklinePending = new Map();
+    this._sparklineCache = /* @__PURE__ */ new Map();
+    this._sparklinePending = /* @__PURE__ */ new Map();
     this._sparklineInterval = null;
     this._sparklineRefreshSec = 300;
     this._sparklineVisible = true;
@@ -1340,7 +1972,6 @@ class OneLineRoomCard extends HTMLElement {
     this._headerImageRequest = 0;
     this._adaptiveMediaQueries = [];
   }
-
   connectedCallback() {
     document.addEventListener("visibilitychange", this._boundPageVisibilityChange);
     this._setupSparklineVisibilityObserver();
@@ -1348,12 +1979,9 @@ class OneLineRoomCard extends HTMLElement {
       this._setupAdaptiveMediaQueries();
       this._setupLastChangedInterval();
       this._setupSparklineInterval();
-      // HA may configure the card while detached, when header image commits are
-      // intentionally ignored. Retry on connection, even with unchanged state.
       this.updateContent();
     }
   }
-
   disconnectedCallback() {
     this._closeDialog?.();
     this._closeDialog = null;
@@ -1375,7 +2003,6 @@ class OneLineRoomCard extends HTMLElement {
     this._sparklinePending.clear();
     this._clearAdaptiveMediaQueries();
   }
-
   _setupSparklineVisibilityObserver() {
     this._sparklineObserver?.disconnect();
     this._sparklineObserver = null;
@@ -1386,18 +2013,16 @@ class OneLineRoomCard extends HTMLElement {
     this._sparklineVisible = false;
     this._sparklineObserver = new IntersectionObserver((entries) => {
       const entry = entries.find((candidate) => candidate.target === this) || entries[0];
-      const visible = !!entry?.isIntersecting && (entry.intersectionRatio === undefined || entry.intersectionRatio > 0);
+      const visible = !!entry?.isIntersecting && (entry.intersectionRatio === void 0 || entry.intersectionRatio > 0);
       if (visible === this._sparklineVisible) return;
       this._sparklineVisible = visible;
       this._setupSparklineInterval();
     });
     this._sparklineObserver.observe(this);
   }
-
   _isSparklinePollingActive() {
     return this.isConnected && this._sparklineVisible && document.hidden !== true;
   }
-
   set hass(hass) {
     this._hass = hass;
     if (!this.content) this.render();
@@ -1405,14 +2030,12 @@ class OneLineRoomCard extends HTMLElement {
     this._updateContentState();
     this._captureStateSnapshot(hass);
   }
-
   _getCollapseUniqueId(config) {
     if (config.entity) return config.entity;
     if (config.name) return config.name;
-    const sig = (config.controls || []).map(c => c.entity || "").join("");
+    const sig = (config.controls || []).map((c) => c.entity || "").join("");
     return sig || "default";
   }
-
   setConfig(config) {
     const prevKey = this._collapseKey;
     this.config = config;
@@ -1420,10 +2043,10 @@ class OneLineRoomCard extends HTMLElement {
     this._collapseKey = `oneline-room-card-collapsed:${this._getCollapseUniqueId(config)}`;
     if (this._collapseKey !== prevKey) {
       const stored = config.remember_state !== false ? localStorage.getItem(this._collapseKey) : null;
-      this._collapsed = stored !== null ? stored === "1" : (config.default_state === "collapsed");
+      this._collapsed = stored !== null ? stored === "1" : config.default_state === "collapsed";
     }
     this._configChanged = true;
-    this._lastStates = new Map();
+    this._lastStates = /* @__PURE__ */ new Map();
     this._lastRenderMetaSig = "";
     this._cachedEntityIds = null;
     this._templateDependencyEntityIds = null;
@@ -1433,19 +2056,19 @@ class OneLineRoomCard extends HTMLElement {
     this._setupLastChangedInterval();
     this._setupSparklineInterval();
   }
-
   _setupLastChangedInterval() {
     if (this._lastChangedInterval) {
       clearInterval(this._lastChangedInterval);
       this._lastChangedInterval = null;
     }
-    const hasLastChanged = (this.config?.controls || []).some(c => c.show_last_changed === true);
+    const hasLastChanged = (this.config?.controls || []).some((c) => c.show_last_changed === true);
     const hasCardLastActivity = this.config?.show_card_last_activity === true;
     if (hasLastChanged || hasCardLastActivity) {
-      this._lastChangedInterval = setInterval(() => { this.updateContent(); }, 60000);
+      this._lastChangedInterval = setInterval(() => {
+        this.updateContent();
+      }, 6e4);
     }
   }
-
   _clearAdaptiveMediaQueries() {
     (this._adaptiveMediaQueries || []).forEach(({ query, listener }) => {
       if (typeof query.removeEventListener === "function") query.removeEventListener("change", listener);
@@ -1453,18 +2076,16 @@ class OneLineRoomCard extends HTMLElement {
     });
     this._adaptiveMediaQueries = [];
   }
-
   _setupAdaptiveMediaQueries() {
     this._clearAdaptiveMediaQueries();
     if (typeof window.matchMedia !== "function") return;
-    const queries = new Set();
+    const queries = /* @__PURE__ */ new Set();
     const visit = (condition) => {
       if (!condition || typeof condition !== "object") return;
       if (condition.condition === "screen" && trimStr(condition.media_query)) queries.add(trimStr(condition.media_query));
       if (Array.isArray(condition.conditions)) condition.conditions.forEach(visit);
     };
-    (Array.isArray(this.config?.adaptive_images) ? this.config.adaptive_images : [])
-      .forEach((rule) => (Array.isArray(rule?.conditions) ? rule.conditions : []).forEach(visit));
+    (Array.isArray(this.config?.adaptive_images) ? this.config.adaptive_images : []).forEach((rule) => (Array.isArray(rule?.conditions) ? rule.conditions : []).forEach(visit));
     (Array.isArray(this.config?.status_groups) ? this.config.status_groups : []).forEach((group) => {
       (Array.isArray(group?.conditions) ? group.conditions : []).forEach(visit);
       (Array.isArray(group?.entities) ? group.entities : []).forEach((entry) => {
@@ -1478,17 +2099,16 @@ class OneLineRoomCard extends HTMLElement {
         if (typeof query.addEventListener === "function") query.addEventListener("change", listener);
         else query.addListener?.(listener);
         this._adaptiveMediaQueries.push({ query, listener });
-      } catch (_error) { }
+      } catch (_error) {
+      }
     });
   }
-
   _hasSparklineControls() {
     return (this.config?.controls || []).some((ctrl) => {
       const domain = ctrl?.entity?.split?.(".")?.[0];
       return domain === "sensor" && ctrl.show_sparkline === true;
     });
   }
-
   _setupSparklineInterval() {
     if (this._sparklineInterval) {
       clearInterval(this._sparklineInterval);
@@ -1497,21 +2117,19 @@ class OneLineRoomCard extends HTMLElement {
     if (!this._hasSparklineControls() || !this._isSparklinePollingActive()) return;
     this._sparklineInterval = setInterval(() => {
       this._refreshSparklineData();
-    }, this._sparklineRefreshSec * 1000);
+    }, this._sparklineRefreshSec * 1e3);
     this._refreshSparklineData();
   }
-
   _getSparklineCacheKey(entity, hours) {
     return `${entity}|${hours}`;
   }
-
   async _fetchSparklineData(entity, hours) {
     if (!entity || !this._hass) return { samples: [], error: "unavailable" };
     const key = this._getSparklineCacheKey(entity, hours);
     if (this._sparklinePending.has(key)) return this._sparklinePending.get(key);
     const now = Date.now();
     const sharedEntry = SHARED_SPARKLINE_CACHE.get(key);
-    if (sharedEntry && now - sharedEntry.fetchedAt < this._sparklineRefreshSec * 1000) {
+    if (sharedEntry && now - sharedEntry.fetchedAt < this._sparklineRefreshSec * 1e3) {
       sharedEntry.lastAccess = now;
       SHARED_SPARKLINE_CACHE.delete(key);
       SHARED_SPARKLINE_CACHE.set(key, sharedEntry);
@@ -1523,12 +2141,12 @@ class OneLineRoomCard extends HTMLElement {
     if (!promise) {
       promise = (async () => {
         try {
-          const start = new Date(Date.now() - hours * 3600000);
+          const start = new Date(Date.now() - hours * 36e5);
           const result = await this._hass.callWS({
             type: "history/history_during_period",
             entity_ids: [entity],
             start_time: start.toISOString(),
-            end_time: new Date().toISOString(),
+            end_time: (/* @__PURE__ */ new Date()).toISOString(),
             minimal_response: true,
             no_attributes: true
           });
@@ -1536,14 +2154,15 @@ class OneLineRoomCard extends HTMLElement {
           const samples = [];
           for (const item of raw) {
             if (!item) continue;
-            let state; let ts;
+            let state;
+            let ts;
             if (Array.isArray(item)) {
               state = item[0];
               ts = item[1] ? new Date(item[1]) : null;
             } else if (typeof item === "object") {
               state = item.state ?? item.s;
               const timeVal = item.last_changed ?? item.last_updated ?? item.lu ?? item.lc;
-              if (typeof timeVal === "number") ts = new Date(timeVal * 1000);
+              if (typeof timeVal === "number") ts = new Date(timeVal * 1e3);
               else if (timeVal) ts = new Date(timeVal);
             }
             if (!ts || state == null) continue;
@@ -1576,7 +2195,6 @@ class OneLineRoomCard extends HTMLElement {
       if (this._sparklinePending.get(key) === promise) this._sparklinePending.delete(key);
     }
   }
-
   async _refreshSparklineData() {
     if (!this._hasSparklineControls() || !this._hass || !this._isSparklinePollingActive()) return;
     const requests = [];
@@ -1591,24 +2209,23 @@ class OneLineRoomCard extends HTMLElement {
     }
     await Promise.all(requests);
   }
-
   _updateSparklineElements(key, data) {
     const wrappers = this.shadowRoot?.querySelectorAll?.(`.btn-sparkline[data-sparkline-key="${key}"]`) || [];
-    wrappers.forEach(wrapper => {
+    wrappers.forEach((wrapper) => {
       const btn = wrapper.closest(".btn");
       if (!btn) return;
       const stroke = getComputedStyle(btn).getPropertyValue("--icon-color") || "currentColor";
       const points = normalizeSparklineSamples(data?.samples);
       if (points.length === 0) {
         wrapper.style.display = "none";
-        const svg = wrapper.querySelector("svg"); if (svg) svg.replaceChildren();
+        const svg = wrapper.querySelector("svg");
+        if (svg) svg.replaceChildren();
       } else {
         wrapper.style.display = "block";
         this._drawSparkline(wrapper, points, stroke.trim() || "currentColor");
       }
     });
   }
-
   _drawSparkline(wrapper, normalizedPoints, stroke) {
     const svg = wrapper.querySelector("svg");
     if (!svg) return;
@@ -1616,29 +2233,24 @@ class OneLineRoomCard extends HTMLElement {
       svg.replaceChildren();
       return;
     }
-    const points = normalizedPoints.map(p => ({
+    const points = normalizedPoints.map((p) => ({
       x: Math.max(0, Math.min(100, p.x * 100)),
       y: Number.isFinite(p.y) ? p.y : 0
     }));
-    const maxVal = Math.max(...points.map(p => p.y));
-    const minVal = Math.min(...points.map(p => p.y));
+    const maxVal = Math.max(...points.map((p) => p.y));
+    const minVal = Math.min(...points.map((p) => p.y));
     const range = maxVal - minVal;
-    const scaled = points.map(p => {
-      const y = range === 0
-        ? 11
-        : Math.max(2, Math.min(20, 20 - ((p.y - minVal) / range) * 18));
+    const scaled = points.map((p) => {
+      const y = range === 0 ? 11 : Math.max(2, Math.min(20, 20 - (p.y - minVal) / range * 18));
       return `${p.x.toFixed(1)},${y.toFixed(1)}`;
     }).join(" ");
     const svgNs = "http://www.w3.org/2000/svg";
     const baseline = document.createElementNS(svgNs, "line");
-    Object.entries({ x1: "0", y1: "20", x2: "100", y2: "20", stroke, "stroke-opacity": "0.2", "stroke-width": "1", "vector-effect": "non-scaling-stroke" })
-      .forEach(([name, value]) => baseline.setAttribute(name, String(value)));
+    Object.entries({ x1: "0", y1: "20", x2: "100", y2: "20", stroke, "stroke-opacity": "0.2", "stroke-width": "1", "vector-effect": "non-scaling-stroke" }).forEach(([name, value]) => baseline.setAttribute(name, String(value)));
     const polyline = document.createElementNS(svgNs, "polyline");
-    Object.entries({ points: scaled, fill: "none", stroke, "stroke-opacity": "0.95", "stroke-width": "2", "stroke-linecap": "round", "stroke-linejoin": "round" })
-      .forEach(([name, value]) => polyline.setAttribute(name, String(value)));
+    Object.entries({ points: scaled, fill: "none", stroke, "stroke-opacity": "0.95", "stroke-width": "2", "stroke-linecap": "round", "stroke-linejoin": "round" }).forEach(([name, value]) => polyline.setAttribute(name, String(value)));
     svg.replaceChildren(baseline, polyline);
   }
-
   _renderBtnSparkline(btn, ctrl, color) {
     const entityId = ctrl.entity;
     const domain = entityId?.split?.(".")?.[0];
@@ -1652,7 +2264,7 @@ class OneLineRoomCard extends HTMLElement {
       return;
     }
     const interactive = ctrl.sparkline_detail === true;
-    if (wrapper && ((interactive && wrapper.tagName !== "BUTTON") || (!interactive && wrapper.tagName === "BUTTON"))) {
+    if (wrapper && (interactive && wrapper.tagName !== "BUTTON" || !interactive && wrapper.tagName === "BUTTON")) {
       wrapper.remove();
       wrapper = null;
     }
@@ -1686,7 +2298,7 @@ class OneLineRoomCard extends HTMLElement {
       const name = ctrl.name || stateObj?.attributes?.friendly_name || entityId;
       wrapper.setAttribute("aria-label", `${getTranslation(this._hass, "sparkline_detail")}: ${name}`);
     }
-    const data = this._sparklineCache.has(key) ? this._sparklineCache.get(key) : undefined;
+    const data = this._sparklineCache.has(key) ? this._sparklineCache.get(key) : void 0;
     const points = normalizeSparklineSamples(data?.samples);
     if (points.length === 0) {
       wrapper.style.display = "none";
@@ -1698,14 +2310,12 @@ class OneLineRoomCard extends HTMLElement {
       this._fetchSparklineData(entityId, hours);
     }
   }
-
   _formatSparklineValue(entityId, value) {
     const stateObj = this._hass?.states?.[entityId];
     const numericState = Number(value).toFixed(6).replace(/\.?0+$/, "");
     if (!stateObj) return numericState;
     return formatEntityStateForDisplay(this._hass, { ...stateObj, state: numericState });
   }
-
   _showSparklineDialog(entityId, initialHours = 24, trigger) {
     if (!entityId || !this._hass) return;
     const stateObj = this._hass.states?.[entityId];
@@ -1798,8 +2408,9 @@ class OneLineRoomCard extends HTMLElement {
       .sparkline-dialog button:focus-visible { outline:2px solid var(--primary-color, #03a9f4); outline-offset:2px; }
     `;
     container.appendChild(style);
-    this._openDialog(container, panel, closeButton, previouslyFocused, () => { this._sparklineDialogRequest += 1; });
-
+    this._openDialog(container, panel, closeButton, previouslyFocused, () => {
+      this._sparklineDialogRequest += 1;
+    });
     const loadRange = async (hours) => {
       const requestId = ++this._sparklineDialogRequest;
       panel.setAttribute("aria-busy", "true");
@@ -1832,18 +2443,14 @@ class OneLineRoomCard extends HTMLElement {
     const supportedInitialHours = rangeOptions.some((option) => option.hours === Number(initialHours)) ? Number(initialHours) : 24;
     loadRange(supportedInitialHours);
   }
-
   getCardSize() {
     const c = this.config?.controls;
-    const hasRoomModes = (Array.isArray(this.config?.room_modes) ? this.config.room_modes : [])
-      .some((mode) => ["scene", "script"].includes(getEntityDomain(mode?.entity)));
+    const hasRoomModes = (Array.isArray(this.config?.room_modes) ? this.config.room_modes : []).some((mode) => ["scene", "script"].includes(getEntityDomain(mode?.entity)));
     return 3 + (hasRoomModes ? 1 : 0) + Math.ceil((Array.isArray(c) ? c.length : 0) / 2.5);
   }
-
   static getStubConfig(hass) {
     return { name: "", entity: "", collapsible: true, controls: [] };
   }
-
   render() {
     if (!this.config) return;
     const actOpts = [
@@ -1852,8 +2459,6 @@ class OneLineRoomCard extends HTMLElement {
       { value: "navigate", label: getTranslation(this._hass, "act_navigate") || "Navigate" },
       { value: "none", label: getTranslation(this._hass, "act_none") || "None" }
     ];
-    // Static runtime scaffold: interpolations below are package-owned labels/options,
-    // never entity states, attributes, template output, or user-provided text.
     this.shadowRoot.innerHTML = `
       <style>
         ha-card { position: relative; overflow: hidden; border-radius: 16px; background: none; border: none; cursor: default; }
@@ -2017,7 +2622,6 @@ class OneLineRoomCard extends HTMLElement {
           <div id="ctrls" class="controls"></div>
         </div>
       </ha-card>`;
-
     this.content = this.shadowRoot.querySelector(".container");
     this.controls = this.shadowRoot.getElementById("ctrls");
     const imageBox = this.shadowRoot.querySelector(".img-box");
@@ -2032,56 +2636,48 @@ class OneLineRoomCard extends HTMLElement {
         this._toggleCollapse();
       });
     }
-
     if (this.config) {
       this._configChanged = true;
       this.updateContent();
     }
   }
-
   updateContent() {
     if (!this.config || !this._hass || !this.content) return;
     this._updateContentState();
     this._captureStateSnapshot(this._hass);
   }
-
   _hasVisibleTemplateControl() {
     const controls = Array.isArray(this.config?.controls) ? this.config.controls : [];
     return controls.some((ctrl) => !ctrl?.hide && ctrl?.type === "template" && templateNeedsEveryHassUpdate(ctrl));
   }
-
   _hasAdaptiveEnvironmentCondition() {
     const visit = (condition) => {
       if (!condition || typeof condition !== "object") return false;
       if (["time", "screen", "user"].includes(condition.condition)) return true;
       return Array.isArray(condition.conditions) && condition.conditions.some(visit);
     };
-    const adaptive = (Array.isArray(this.config?.adaptive_images) ? this.config.adaptive_images : [])
-      .some((rule) => Array.isArray(rule?.conditions) && rule.conditions.some(visit));
+    const adaptive = (Array.isArray(this.config?.adaptive_images) ? this.config.adaptive_images : []).some((rule) => Array.isArray(rule?.conditions) && rule.conditions.some(visit));
     if (adaptive) return true;
     return (Array.isArray(this.config?.status_groups) ? this.config.status_groups : []).some((group) => {
       if (Array.isArray(group?.conditions) && group.conditions.some(visit)) return true;
-      return (Array.isArray(group?.entities) ? group.entities : []).some((entry) =>
-        entry && typeof entry === "object" && Array.isArray(entry.conditions) && entry.conditions.some(visit));
+      return (Array.isArray(group?.entities) ? group.entities : []).some((entry) => entry && typeof entry === "object" && Array.isArray(entry.conditions) && entry.conditions.some(visit));
     });
   }
-
   _getTemplateDependencyEntityIds() {
-    const ids = new Set();
+    const ids = /* @__PURE__ */ new Set();
     const add = (entityId) => {
       if (typeof entityId === "string" && entityId.trim()) ids.add(entityId.trim());
     };
-    for (const ctrl of (Array.isArray(this.config?.controls) ? this.config.controls : [])) {
+    for (const ctrl of Array.isArray(this.config?.controls) ? this.config.controls : []) {
       if (ctrl?.type !== "template") continue;
       getTemplateEntityDependencies(ctrl).forEach(add);
       (Array.isArray(ctrl.sub_chips) ? ctrl.sub_chips : []).forEach((chip) => add(chip?.entity));
     }
     return ids;
   }
-
   _getRelevantEntityIds() {
     const cfg = this.config || {};
-    const ids = new Set();
+    const ids = /* @__PURE__ */ new Set();
     const add = (id) => {
       if (typeof id === "string" && id.trim()) ids.add(id.trim());
     };
@@ -2113,7 +2709,7 @@ class OneLineRoomCard extends HTMLElement {
       if (ctrl?.type === "template") getTemplateEntityDependencies(ctrl).forEach(add);
       if (Array.isArray(ctrl.visibility)) {
         const extract = (conds) => {
-          conds.forEach(c => {
+          conds.forEach((c) => {
             if (c.entity) add(c.entity);
             if (Array.isArray(c.conditions)) extract(c.conditions);
           });
@@ -2121,13 +2717,12 @@ class OneLineRoomCard extends HTMLElement {
         extract(ctrl.visibility);
       }
       if (Array.isArray(ctrl.sub_chips)) {
-        ctrl.sub_chips.forEach(chip => add(chip.entity));
+        ctrl.sub_chips.forEach((chip) => add(chip.entity));
       }
     });
     (Array.isArray(cfg.header_badges) ? cfg.header_badges : []).forEach((b) => add(b?.entity));
     return Array.from(ids);
   }
-
   _getStateSignature(entityId, stateObj, hass, trackFullState = false) {
     if (!stateObj) return "__missing__";
     const attrs = stateObj.attributes || {};
@@ -2174,22 +2769,20 @@ class OneLineRoomCard extends HTMLElement {
       rgb
     ].join("|");
   }
-
   _normalizeAlertSensorConfig(cfg) {
     if (!cfg) return null;
     if (typeof cfg === "string") return { entity: cfg };
     if (typeof cfg === "object") {
       const normalized = { ...cfg };
       if (normalized.state && typeof normalized.state === "string") {
-        normalized.state = normalized.state.split(",").map(s => String(s).toLowerCase().trim()).filter(Boolean);
+        normalized.state = normalized.state.split(",").map((s) => String(s).toLowerCase().trim()).filter(Boolean);
       } else if (Array.isArray(normalized.state)) {
-        normalized.state = normalized.state.map(s => String(s).toLowerCase().trim()).filter(Boolean);
+        normalized.state = normalized.state.map((s) => String(s).toLowerCase().trim()).filter(Boolean);
       }
       return normalized;
     }
     return null;
   }
-
   _isAlertSensorActive(alertCfg, stateObj) {
     if (!alertCfg || !stateObj) return false;
     const current = String(stateObj.state).toLowerCase().trim();
@@ -2208,7 +2801,6 @@ class OneLineRoomCard extends HTMLElement {
     const activeStates = ["on", "open", "true", "active", "alarm", "warning", "detected", "triggered", "problem", "motion", "error"];
     return activeStates.includes(current);
   }
-
   _openDialog(container, panel, closeButton, previouslyFocused, onClose) {
     this._closeDialog?.(false);
     this.shadowRoot.appendChild(container);
@@ -2238,9 +2830,7 @@ class OneLineRoomCard extends HTMLElement {
       const focusable = Array.from(panel.querySelectorAll("button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])"));
       if (focusable.length === 0) return;
       const currentIndex = focusable.indexOf(this.shadowRoot.activeElement);
-      const nextIndex = event.shiftKey
-        ? (currentIndex <= 0 ? focusable.length - 1 : currentIndex - 1)
-        : (currentIndex < 0 || currentIndex === focusable.length - 1 ? 0 : currentIndex + 1);
+      const nextIndex = event.shiftKey ? currentIndex <= 0 ? focusable.length - 1 : currentIndex - 1 : currentIndex < 0 || currentIndex === focusable.length - 1 ? 0 : currentIndex + 1;
       event.preventDefault();
       focusable[nextIndex].focus();
     };
@@ -2251,23 +2841,19 @@ class OneLineRoomCard extends HTMLElement {
     closeButton.focus();
     return closeDialog;
   }
-
   _showAlertDialog(alerts, dialogTitle = getTranslation(this._hass, "active_alerts"), accentColor = "#FF5252") {
     const previouslyFocused = this.shadowRoot.activeElement || document.activeElement;
     const container = document.createElement("div");
     container.className = "alert-dialog-container";
-
     const backdrop = document.createElement("div");
     backdrop.className = "alert-dialog-backdrop";
     backdrop.dataset.dialogBackdrop = "";
     backdrop.setAttribute("aria-hidden", "true");
-
     const panel = document.createElement("div");
     panel.className = "alert-dialog";
     panel.setAttribute("role", "dialog");
     panel.setAttribute("aria-modal", "true");
     panel.setAttribute("aria-labelledby", "alert-dialog-title");
-
     const header = document.createElement("div");
     header.className = "alert-dialog-header";
     const heading = document.createElement("h2");
@@ -2279,7 +2865,6 @@ class OneLineRoomCard extends HTMLElement {
     closeButton.setAttribute("aria-label", getTranslation(this._hass, "a11y_close"));
     closeButton.textContent = "✕";
     header.append(heading, closeButton);
-
     const content = document.createElement("div");
     content.className = "alert-dialog-content";
     const list = document.createElement("div");
@@ -2305,7 +2890,6 @@ class OneLineRoomCard extends HTMLElement {
     content.appendChild(list);
     panel.append(header, content);
     container.append(backdrop, panel);
-
     const style = document.createElement("style");
     style.textContent = `
       .alert-dialog-container { position: fixed; inset: 0; z-index: 10000; display: flex; align-items: center; justify-content: center; }
@@ -2326,7 +2910,7 @@ class OneLineRoomCard extends HTMLElement {
     `;
     container.appendChild(style);
     const closeDialog = this._openDialog(container, panel, closeButton, previouslyFocused);
-    list.querySelectorAll(".alert-entity-row").forEach(row => {
+    list.querySelectorAll(".alert-entity-row").forEach((row) => {
       row.addEventListener("click", () => {
         const entityId = row.dataset.entity;
         if (entityId && this._hass) {
@@ -2336,7 +2920,6 @@ class OneLineRoomCard extends HTMLElement {
       });
     });
   }
-
   _renderStatusGroups(container, config, hass) {
     if (!container) return;
     (Array.isArray(config?.status_groups) ? config.status_groups : []).forEach((group, index) => {
@@ -2348,7 +2931,7 @@ class OneLineRoomCard extends HTMLElement {
       chip.className = "chip status-group-chip";
       chip.dataset.statusGroup = String(index);
       const icon = document.createElement("ha-icon");
-      icon.setAttribute("icon", result.error ? "mdi:alert-circle-outline" : (trimStr(group?.icon) || "mdi:information-outline"));
+      icon.setAttribute("icon", result.error ? "mdi:alert-circle-outline" : trimStr(group?.icon) || "mdi:information-outline");
       icon.style.setProperty("--mdc-icon-size", "14px");
       const name = trimStr(group?.name) || getTranslation(hass, "status_groups");
       const text = group?.show_name === true ? `${name}: ${result.value}` : result.value;
@@ -2370,33 +2953,27 @@ class OneLineRoomCard extends HTMLElement {
       container.appendChild(chip);
     });
   }
-
   _getRenderMetaSignature(hass) {
     const lang = hass?.language || "";
     const localeLanguage = hass?.locale?.language || "";
     const numberFormat = hass?.locale?.number_format || "";
     const unitSystem = hass?.config?.unit_system || {};
-    const unitSystemSignature = Object.keys(unitSystem)
-      .sort()
-      .map((key) => `${key}:${unitSystem[key] ?? ""}`)
-      .join(",");
+    const unitSystemSignature = Object.keys(unitSystem).sort().map((key) => `${key}:${unitSystem[key] ?? ""}`).join(",");
     return `${lang}|${localeLanguage}|${numberFormat}|${unitSystemSignature}`;
   }
-
   _buildStateSnapshot(hass) {
     const states = hass?.states || {};
     if (!this._cachedEntityIds) this._cachedEntityIds = this._getRelevantEntityIds();
     if (!this._templateDependencyEntityIds) {
       this._templateDependencyEntityIds = this._getTemplateDependencyEntityIds();
     }
-    const next = new Map();
+    const next = /* @__PURE__ */ new Map();
     this._cachedEntityIds.forEach((id) => next.set(
       id,
       this._getStateSignature(id, states[id], hass, this._templateDependencyEntityIds.has(id))
     ));
     return next;
   }
-
   _isSameSnapshot(nextStates, nextMetaSig) {
     if (this._lastRenderMetaSig !== nextMetaSig) return false;
     if (!this._lastStates || this._lastStates.size !== nextStates.size) return false;
@@ -2405,7 +2982,6 @@ class OneLineRoomCard extends HTMLElement {
     }
     return true;
   }
-
   _shouldUpdateFromHass(hass) {
     if (!this.config || !this.content) return false;
     if (this._configChanged) return true;
@@ -2415,13 +2991,11 @@ class OneLineRoomCard extends HTMLElement {
     const nextStates = this._buildStateSnapshot(hass);
     return !this._isSameSnapshot(nextStates, nextMetaSig);
   }
-
   _captureStateSnapshot(hass) {
     if (!this.config || !hass) return;
     this._lastRenderMetaSig = this._getRenderMetaSignature(hass);
     this._lastStates = this._buildStateSnapshot(hass);
   }
-
   _syncCollapseUI() {
     const config = this.config || {};
     const isCollapsible = config.collapsible === true;
@@ -2435,7 +3009,6 @@ class OneLineRoomCard extends HTMLElement {
       collapseButton.setAttribute("aria-expanded", isCollapsed ? "false" : "true");
       collapseButton.tabIndex = isCollapsible ? 0 : -1;
     }
-
     if (this.controls) {
       this.controls.classList.toggle("collapsed", isCollapsed);
       if (isCollapsed) {
@@ -2446,19 +3019,15 @@ class OneLineRoomCard extends HTMLElement {
         this.controls.removeAttribute("aria-hidden");
       }
     }
-
     const imageBox = this.shadowRoot.querySelector(".img-box");
     if (!imageBox) return;
-    const hasExplicitTap = config.tap_action !== undefined;
+    const hasExplicitTap = config.tap_action !== void 0;
     const headerTogglesCollapse = isCollapsible && !hasExplicitTap;
-    const hasExplicitAction = [config.tap_action, config.hold_action, config.double_tap_action]
-      .some((action) => action?.action && action.action !== "none");
+    const hasExplicitAction = [config.tap_action, config.hold_action, config.double_tap_action].some((action) => action?.action && action.action !== "none");
     if (headerTogglesCollapse || hasExplicitAction) {
       imageBox.setAttribute("role", "button");
       imageBox.tabIndex = 0;
-      imageBox.setAttribute("aria-label", headerTogglesCollapse
-        ? collapseLabel
-        : (config.name || getTranslation(this._hass, "a11y_activate").replace("{name}", "RoomCard")));
+      imageBox.setAttribute("aria-label", headerTogglesCollapse ? collapseLabel : config.name || getTranslation(this._hass, "a11y_activate").replace("{name}", "RoomCard"));
       if (headerTogglesCollapse) imageBox.setAttribute("aria-expanded", isCollapsed ? "false" : "true");
       else imageBox.removeAttribute("aria-expanded");
     } else {
@@ -2468,7 +3037,6 @@ class OneLineRoomCard extends HTMLElement {
       imageBox.removeAttribute("aria-expanded");
     }
   }
-
   _applyHeaderImage(image, selection) {
     if (!image) return;
     const targetUrl = selection?.url || "/static/images/card_media/cover.png";
@@ -2489,10 +3057,10 @@ class OneLineRoomCard extends HTMLElement {
     }
     const preload = new Image();
     preload.onload = commit;
-    preload.onerror = () => {};
+    preload.onerror = () => {
+    };
     preload.src = targetUrl;
   }
-
   _updateContentState() {
     if (!this.config || !this._hass || !this.content) return;
     const h = this._hass, c = this.config;
@@ -2503,7 +3071,6 @@ class OneLineRoomCard extends HTMLElement {
     const effectiveBatterySensors = c.battery_sensors || [];
     const systemTempUnit = normalizeTemperatureUnit(h.config.unit_system.temperature) || "°C";
     const configuredTempUnit = normalizeTemperatureUnit(c.temp_unit);
-
     const bgEl = this.shadowRoot.getElementById("bg");
     this._applyHeaderImage(bgEl, resolveAdaptiveRoomImage(c, h));
     if (c.image_entity && h.states[c.image_entity]) {
@@ -2514,7 +3081,7 @@ class OneLineRoomCard extends HTMLElement {
     }
     const imgBox = this.shadowRoot.querySelector(".img-box");
     if (imgBox) {
-      const hh = c.header_height !== undefined ? Number(c.header_height) : NaN;
+      const hh = c.header_height !== void 0 ? Number(c.header_height) : NaN;
       const hideImg = c.show_image === false;
       if (Number.isFinite(hh) && hh >= 0) imgBox.style.height = hh + "px";
       else if (hideImg) imgBox.style.height = "auto";
@@ -2526,7 +3093,6 @@ class OneLineRoomCard extends HTMLElement {
     nameEl.style.display = c.show_name === false ? "none" : "";
     const ico = this.shadowRoot.getElementById("icon");
     ico.icon = c.icon || "mdi:home";
-    // Priority: force/manual > dynamic state color > default/theme fallback.
     const headerManualColor = isHeaderManualColorEnabled(c);
     const headerColors = this._resolveEntityIconColors(effectiveEntity, h, {
       defaultColor: "",
@@ -2535,46 +3101,38 @@ class OneLineRoomCard extends HTMLElement {
     });
     if (headerColors.color) ico.style.setProperty("--icon-color", headerColors.color);
     else ico.style.removeProperty("--icon-color");
-
     const climateState = effectiveEntity ? h.states[effectiveEntity] : null;
     let t = null, hm = null, tar = null;
     let tempState = null, humidState = null, targetTempState = null;
     if (effectiveTempSensor && h.states[effectiveTempSensor]) {
       tempState = h.states[effectiveTempSensor];
       t = tempState.state;
-    } else if (climateState?.attributes?.current_temperature !== undefined) {
+    } else if (climateState?.attributes?.current_temperature !== void 0) {
       t = climateState.attributes.current_temperature;
     }
-
-    if (climateState?.attributes?.temperature !== undefined) tar = climateState.attributes.temperature;
+    if (climateState?.attributes?.temperature !== void 0) tar = climateState.attributes.temperature;
     if (c.target_temp_sensor && h.states[c.target_temp_sensor]) {
       targetTempState = h.states[c.target_temp_sensor];
       tar = targetTempState.state;
     }
-
     if (effectiveHumidSensor && h.states[effectiveHumidSensor]) {
       humidState = h.states[effectiveHumidSensor];
       hm = humidState.state;
-    } else if (climateState?.attributes?.current_humidity !== undefined) {
+    } else if (climateState?.attributes?.current_humidity !== void 0) {
       hm = climateState.attributes.current_humidity;
     }
-
     const infoPos = c.info_line_position || "header";
     const infoEl = this.shadowRoot.getElementById("info");
     const infoBarEl = this.shadowRoot.getElementById("info-bar");
     const infoParts = [];
     const standardHeaderBadgeBackground = trimStr(c.header_info_background);
     if (t != null && t !== "-" && !isNaN(parseFloat(t))) {
-      let tStr = tempState
-        ? formatTemperatureStateForDisplay(h, tempState, configuredTempUnit, systemTempUnit)
-        : formatTemperatureAttributeForDisplay(h, climateState, "current_temperature", t, configuredTempUnit, systemTempUnit);
+      let tStr = tempState ? formatTemperatureStateForDisplay(h, tempState, configuredTempUnit, systemTempUnit) : formatTemperatureAttributeForDisplay(h, climateState, "current_temperature", t, configuredTempUnit, systemTempUnit);
       const tempDisplayLabel = trimStr(c.temp_sensor_label);
       const targetTempDisplayLabel = trimStr(c.target_temp_sensor_label);
       if (tempDisplayLabel) tStr = `${tempDisplayLabel}: ${tStr}`;
       if (tar != null && tar !== "-") {
-        const targetValue = targetTempState
-          ? formatTemperatureStateForDisplay(h, targetTempState, configuredTempUnit, systemTempUnit)
-          : formatTemperatureAttributeForDisplay(h, climateState, "temperature", tar, configuredTempUnit, systemTempUnit);
+        const targetValue = targetTempState ? formatTemperatureStateForDisplay(h, targetTempState, configuredTempUnit, systemTempUnit) : formatTemperatureAttributeForDisplay(h, climateState, "temperature", tar, configuredTempUnit, systemTempUnit);
         const tarStr = targetTempDisplayLabel ? `${targetTempDisplayLabel}: ${targetValue}` : targetValue;
         tStr += " (" + tarStr + ")";
       }
@@ -2582,14 +3140,11 @@ class OneLineRoomCard extends HTMLElement {
     }
     if (hm != null && hm !== "-" && !isNaN(parseFloat(hm))) {
       const humidDisplayLabel = trimStr(c.humid_sensor_label);
-      const humidValue = humidState
-        ? formatEntityStateForDisplay(h, humidState, "%")
-        : formatEntityAttributeForDisplay(h, climateState, "current_humidity", hm, "%");
+      const humidValue = humidState ? formatEntityStateForDisplay(h, humidState, "%") : formatEntityAttributeForDisplay(h, climateState, "current_humidity", hm, "%");
       const hmStr = humidDisplayLabel ? `${humidDisplayLabel}: ${humidValue}` : humidValue;
       infoParts.push({ text: hmStr, background: standardHeaderBadgeBackground });
     }
-
-    (Array.isArray(c.header_badges) ? c.header_badges : []).forEach(badge => {
+    (Array.isArray(c.header_badges) ? c.header_badges : []).forEach((badge) => {
       if (!badge?.entity) return;
       const st = h.states[badge.entity];
       if (!st) return;
@@ -2600,9 +3155,7 @@ class OneLineRoomCard extends HTMLElement {
       const isLastChanged = badge.show_last_changed === true && st.last_changed;
       const displayVal = isLastChanged ? formatLastChanged(st.last_changed, h) : formatEntityStateForDisplay(h, st);
       infoParts.push({
-        text: showBadgeName
-          ? `${displayLabel}${isLastChanged ? " · " : ": "}${displayVal}`
-          : displayVal,
+        text: showBadgeName ? `${displayLabel}${isLastChanged ? " · " : ": "}${displayVal}` : displayVal,
         background: trimStr(badge.background) || standardHeaderBadgeBackground
       });
     });
@@ -2610,23 +3163,24 @@ class OneLineRoomCard extends HTMLElement {
       const controls = Array.isArray(c.controls) ? c.controls : [];
       let latestChanged = null;
       let latestTime = 0;
-      controls.forEach(ctrl => {
+      controls.forEach((ctrl) => {
         if (!ctrl?.entity) return;
         const st = h.states[ctrl.entity];
         if (!st?.last_changed) return;
-        const t = new Date(st.last_changed).getTime();
-        if (t > latestTime) { latestTime = t; latestChanged = st; }
+        const t2 = new Date(st.last_changed).getTime();
+        if (t2 > latestTime) {
+          latestTime = t2;
+          latestChanged = st;
+        }
       });
       if (latestChanged) {
         const elapsed = formatLastChanged(latestChanged.last_changed, h);
         infoParts.push({ text: elapsed, background: standardHeaderBadgeBackground });
       }
     }
-
     infoEl.replaceChildren();
     if (infoBarEl) infoBarEl.replaceChildren();
-
-    const target = (infoPos === "below_header" && infoBarEl) ? infoBarEl : infoEl;
+    const target = infoPos === "below_header" && infoBarEl ? infoBarEl : infoEl;
     infoParts.forEach((part, idx) => {
       const span = document.createElement("span");
       span.className = `info-item${part.background ? " badge" : ""}`;
@@ -2640,20 +3194,13 @@ class OneLineRoomCard extends HTMLElement {
         target.appendChild(sep);
       }
     });
-
     if (infoBarEl) infoBarEl.classList.toggle("active", infoPos === "below_header" && infoParts.length > 0);
-
     const textEl = this.shadowRoot.querySelector(".text");
     const nameOffset = Number(c.header_name_offset ?? 0);
     const infoOffset = infoPos === "header" ? Number(c.header_info_offset ?? 0) : 0;
-    if (textEl) textEl.style.flex = (nameOffset > 0 || infoOffset > 0) ? "1" : "";
-
-    // Title horizontal offset
+    if (textEl) textEl.style.flex = nameOffset > 0 || infoOffset > 0 ? "1" : "";
     this._applyHeaderOffset(nameEl, nameOffset, textEl);
-
-    // Info line horizontal offset (only relevant when inside the header)
     if (infoPos === "header") this._applyHeaderOffset(infoEl, infoOffset, textEl);
-
     const ch = this.shadowRoot.getElementById("chips");
     ch.replaceChildren();
     const createHeaderChip = (className, iconName, text, tagName = "div") => {
@@ -2666,18 +3213,17 @@ class OneLineRoomCard extends HTMLElement {
       return chip;
     };
     let al = null;
-    (Array.isArray(effectiveBatterySensors) ? effectiveBatterySensors : []).forEach(s => {
-      const st = h.states[s]; if (!st) return;
+    (Array.isArray(effectiveBatterySensors) ? effectiveBatterySensors : []).forEach((s) => {
+      const st = h.states[s];
+      if (!st) return;
       if (isEntityOn(st)) al = getTranslation(h, "empty");
       else if (!isNaN(parseFloat(st.state))) {
         if (st.state <= 5) al = getTranslation(h, "critical");
         else if (st.state <= 15 && !al) al = getTranslation(h, "low");
       }
     });
-
     const batteryWarn = !!al;
     if (batteryWarn) ch.appendChild(createHeaderChip("chip alert", "mdi:battery-alert", al));
-
     const humidNum = hm != null ? parseFloat(hm) : NaN;
     const thresholdRaw = c.humidity_warning_threshold ?? 60;
     const humidThreshold = Number.isFinite(Number(thresholdRaw)) ? Number(thresholdRaw) : 60;
@@ -2696,12 +3242,8 @@ class OneLineRoomCard extends HTMLElement {
         const presenceColor = trimStr(c.presence_chip_color) || "#4CAF50";
         const solidPresenceBackground = c.presence_solid_background === true;
         const isHex = /^#[0-9A-F]{6}$/i.test(presenceColor);
-        const presenceBackground = solidPresenceBackground
-          ? presenceColor
-          : (isHex ? hexToRgba(presenceColor, 0.15) : `color-mix(in srgb, ${presenceColor} 15%, transparent)`);
-        const presenceTextColor = solidPresenceBackground
-          ? (readableTextForHex(presenceColor) || "var(--primary-text-color)")
-          : presenceColor;
+        const presenceBackground = solidPresenceBackground ? presenceColor : isHex ? hexToRgba(presenceColor, 0.15) : `color-mix(in srgb, ${presenceColor} 15%, transparent)`;
+        const presenceTextColor = solidPresenceBackground ? readableTextForHex(presenceColor) || "var(--primary-text-color)" : presenceColor;
         const chip = document.createElement("div");
         chip.className = "chip";
         chip.style.background = presenceBackground;
@@ -2715,12 +3257,10 @@ class OneLineRoomCard extends HTMLElement {
       }
     }
     const effectiveAlertSensors = Array.isArray(c.alert_sensors) ? c.alert_sensors : [];
-    const normalizedAlertSensors = effectiveAlertSensors
-      .map(s => this._normalizeAlertSensorConfig(s))
-      .filter(Boolean);
+    const normalizedAlertSensors = effectiveAlertSensors.map((s) => this._normalizeAlertSensorConfig(s)).filter(Boolean);
     let alertSensorWarn = false;
     const activeAlerts = [];
-    normalizedAlertSensors.forEach(cfg => {
+    normalizedAlertSensors.forEach((cfg) => {
       const st = h.states[cfg.entity];
       if (!st) return;
       if (this._isAlertSensorActive(cfg, st)) {
@@ -2742,38 +3282,28 @@ class OneLineRoomCard extends HTMLElement {
       chip.addEventListener("click", () => this._showAlertDialog(activeAlerts));
       ch.appendChild(chip);
     } else if (alertChipMode === "expanded" && activeAlerts.length > 0) {
-      activeAlerts.forEach(alert => {
+      activeAlerts.forEach((alert) => {
         ch.appendChild(createHeaderChip("chip alert", alert.icon, alert.friendly_name));
       });
     }
-
     const windowAlwaysShow = c.window_always_show === true;
     const windowOpenColor = trimStr(c.window_open_color) || "#FFA000";
     const windowClosedColor = trimStr(c.window_closed_color) || "#9E9E9E";
-    // Configurable open states — "on" is always included for backward compatibility
-    const windowOpenStates = Array.isArray(c.window_open_states) && c.window_open_states.length > 0
-      ? [...new Set(["on", ...c.window_open_states.map(s => String(s).toLowerCase().trim())])]
-      : ["on", "open"];
-    // Optional per-state color overrides (object: { stateName: "#color" })
-    const windowStateColors = (c.window_state_colors && typeof c.window_state_colors === "object") ? c.window_state_colors : {};
-    const windowLabels = (c.window_labels && typeof c.window_labels === "object") ? c.window_labels : {};
+    const windowOpenStates = Array.isArray(c.window_open_states) && c.window_open_states.length > 0 ? [.../* @__PURE__ */ new Set(["on", ...c.window_open_states.map((s) => String(s).toLowerCase().trim())])] : ["on", "open"];
+    const windowStateColors = c.window_state_colors && typeof c.window_state_colors === "object" ? c.window_state_colors : {};
+    const windowLabels = c.window_labels && typeof c.window_labels === "object" ? c.window_labels : {};
     const windowSolidBackground = c.window_solid_background === true;
-    (Array.isArray(effectiveWindowSensors) ? effectiveWindowSensors : []).forEach(s => {
+    (Array.isArray(effectiveWindowSensors) ? effectiveWindowSensors : []).forEach((s) => {
       const st = h.states[s];
       if (!st) return;
       const stateVal = String(st.state).toLowerCase().trim();
       const isOpen = windowOpenStates.includes(stateVal);
       if (!isOpen && !windowAlwaysShow) return;
-      // Per-state color override takes priority, then open/closed default
       const perStateColor = windowStateColors[st.state] || windowStateColors[stateVal];
       const chipColor = perStateColor || (isOpen ? windowOpenColor : windowClosedColor);
       const isHex = /^#[0-9A-F]{6}$/i.test(chipColor);
-      const chipBg = windowSolidBackground
-        ? chipColor
-        : (isHex ? chipColor + "33" : `color-mix(in srgb, ${chipColor} 20%, transparent)`);
-      const chipTextColor = windowSolidBackground
-        ? (readableTextForHex(chipColor) || "var(--primary-text-color)")
-        : chipColor;
+      const chipBg = windowSolidBackground ? chipColor : isHex ? chipColor + "33" : `color-mix(in srgb, ${chipColor} 20%, transparent)`;
+      const chipTextColor = windowSolidBackground ? readableTextForHex(chipColor) || "var(--primary-text-color)" : chipColor;
       const icon = isOpen ? "mdi:window-open-variant" : "mdi:window-shutter";
       const label = trimStr(windowLabels[s]) || st.attributes.friendly_name || getTranslation(h, "window");
       const chip = document.createElement("div");
@@ -2787,9 +3317,7 @@ class OneLineRoomCard extends HTMLElement {
       chip.appendChild(document.createTextNode(` ${label}`));
       ch.appendChild(chip);
     });
-
     this._renderStatusGroups(ch, c, h);
-
     const cardEl = this.shadowRoot.querySelector("ha-card");
     if (cardEl) {
       const showStatusBorder = c.show_status_border !== false;
@@ -2800,16 +3328,15 @@ class OneLineRoomCard extends HTMLElement {
       cardEl.classList.toggle("alert-sensor", showStatusBorder && !batteryWarn && !humidityWarn && alertSensorWarn);
       if (trimStr(c.alert_border_color)) cardEl.style.setProperty("--rc-alert-border-color", trimStr(c.alert_border_color));
       else cardEl.style.removeProperty("--rc-alert-border-color");
-
       const setPxProp = (k, v, def) => {
-        if (v !== undefined && v !== null && v !== "") {
+        if (v !== void 0 && v !== null && v !== "") {
           const num = Number(v);
           cardEl.style.setProperty(k, Number.isFinite(num) ? num + "px" : String(v));
         } else {
           cardEl.style.setProperty(k, def);
         }
       };
-      const setStrProp = (k, v, def) => cardEl.style.setProperty(k, (v !== undefined && v !== null && v !== "") ? String(v) : def);
+      const setStrProp = (k, v, def) => cardEl.style.setProperty(k, v !== void 0 && v !== null && v !== "" ? String(v) : def);
       setPxProp("--rc-header-name-size", c.header_name_size, "14px");
       setStrProp("--rc-header-name-weight", c.header_name_weight, "bold");
       setStrProp("--rc-header-name-style", c.header_name_style, "normal");
@@ -2819,32 +3346,27 @@ class OneLineRoomCard extends HTMLElement {
       setStrProp("--rc-header-info-style", c.header_info_style, "normal");
       setStrProp("--rc-header-info-color", c.header_info_color, "white");
     }
-
     this._renderRoomModes(c, h);
     this._syncCollapseUI();
-
-    let visibleCtrls = (c.controls || []).filter(ctrl => {
+    let visibleCtrls = (c.controls || []).filter((ctrl) => {
       if (ctrl.hide) return false;
       if (Array.isArray(ctrl.visibility) && ctrl.visibility.length > 0) {
         if (!this._checkConditions(ctrl.visibility, h)) return false;
       }
-      return (ctrl.entity || ctrl.type === "template");
+      return ctrl.entity || ctrl.type === "template";
     });
-
     if (c.auto_climate_button && c.entity && getEntityDomain(c.entity) === "climate") {
-      const alreadyPresent = visibleCtrls.some(ctrl => ctrl.entity === c.entity);
+      const alreadyPresent = visibleCtrls.some((ctrl) => ctrl.entity === c.entity);
       if (!alreadyPresent) {
-        const climateState = h.states[c.entity];
-        visibleCtrls = [{ entity: c.entity, name: climateState?.attributes?.friendly_name || "", width: 60, height: 60 }, ...visibleCtrls];
+        const climateState2 = h.states[c.entity];
+        visibleCtrls = [{ entity: c.entity, name: climateState2?.attributes?.friendly_name || "", width: 60, height: 60 }, ...visibleCtrls];
       }
     }
-
-    const controlsSig = JSON.stringify(visibleCtrls.map(ct => ct.entity + (ct.type || "")));
-
+    const controlsSig = JSON.stringify(visibleCtrls.map((ct) => ct.entity + (ct.type || "")));
     if (this._configChanged || this._lastControlsSig !== controlsSig) {
       this._lastControlsSig = controlsSig;
       this.controls.replaceChildren();
-      visibleCtrls.forEach(ctrl => {
+      visibleCtrls.forEach((ctrl) => {
         const btn = this._createBtn(ctrl);
         this.controls.appendChild(btn);
         this._updateBtnState(btn, ctrl, h);
@@ -2857,27 +3379,23 @@ class OneLineRoomCard extends HTMLElement {
       });
     }
   }
-
   _createBtn(ctrl) {
     const btn = document.createElement("div");
     btn.className = "btn";
     if (ctrl.entity) btn.setAttribute("data-entity", ctrl.entity);
-    btn.style.setProperty("--btn-flex-basis", `calc(${(clampNum(ctrl.width, 1, 60, 15) / 60) * 100}% - 6px)`);
+    btn.style.setProperty("--btn-flex-basis", `calc(${clampNum(ctrl.width, 1, 60, 15) / 60 * 100}% - 6px)`);
     btn.style.setProperty("--btn-height", `${clampNum(ctrl.height, 40, 250, 60)}px`);
     let justify = "center";
     if (ctrl.align === "left") justify = "flex-start";
     if (ctrl.align === "right") justify = "flex-end";
     btn.style.setProperty("--btn-justify", justify);
     this._attachActions(btn, ctrl);
-
     return btn;
   }
-
   _isEntityUnavailable(entityId, hass = this._hass) {
     if (!entityId || !hass?.states) return false;
     return isEntityOffline(hass.states[entityId]);
   }
-
   _resolveEntityIconColors(entityId, hass, opts = {}) {
     const defaultColor = opts.defaultColor ?? "grey";
     const defaultBg = opts.defaultBg ?? "rgba(128,128,128,0.1)";
@@ -2893,10 +3411,8 @@ class OneLineRoomCard extends HTMLElement {
         isUnavailable
       };
     }
-
     let color = defaultColor;
     let bg = defaultBg;
-
     if (st && isEntityActive(st, entityId)) {
       if (st.attributes.rgb_color) {
         const rgb = st.attributes.rgb_color.join(",");
@@ -2904,29 +3420,33 @@ class OneLineRoomCard extends HTMLElement {
         bg = `rgba(${rgb}, 0.2)`;
       } else if (domain === "climate" && st.attributes.hvac_action) {
         const act = st.attributes.hvac_action;
-        if (act === "heating") { color = "#FF5722"; bg = "rgba(255,87,34,0.2)"; }
-        else if (act === "cooling") { color = "#2196F3"; bg = "rgba(33,150,243,0.2)"; }
-        else { color = "#4CAF50"; bg = "rgba(76,175,80,0.2)"; }
+        if (act === "heating") {
+          color = "#FF5722";
+          bg = "rgba(255,87,34,0.2)";
+        } else if (act === "cooling") {
+          color = "#2196F3";
+          bg = "rgba(33,150,243,0.2)";
+        } else {
+          color = "#4CAF50";
+          bg = "rgba(76,175,80,0.2)";
+        }
       } else {
         const themeVar = `var(--state-${domain}-active-color, var(--state-active-color, #ff9800))`;
         color = themeVar;
         bg = `color-mix(in srgb, ${themeVar} 20%, transparent)`;
       }
     }
-
     return { color, bg, isUnavailable };
   }
-
   _getSafeHeaderOffset(requestedPercent, containerEl, itemEl) {
     const requested = clampNum(requestedPercent, 0, 100, 0);
     if (!containerEl || !itemEl || requested <= 0) return 0;
     const containerWidth = containerEl.clientWidth || 0;
     const itemWidth = Math.ceil(itemEl.scrollWidth || itemEl.getBoundingClientRect().width || 0);
     if (containerWidth <= 0 || itemWidth <= 0) return 0;
-    const maxPercent = Math.max(0, ((containerWidth - itemWidth) / containerWidth) * 100);
-    return (requested / 100) * maxPercent;
+    const maxPercent = Math.max(0, (containerWidth - itemWidth) / containerWidth * 100);
+    return requested / 100 * maxPercent;
   }
-
   _applyHeaderOffset(itemEl, requestedPercent, containerEl) {
     if (!itemEl) return;
     const apply = () => {
@@ -2943,12 +3463,10 @@ class OneLineRoomCard extends HTMLElement {
     apply();
     requestAnimationFrame(() => requestAnimationFrame(apply));
   }
-
   _renderRoomModes(config, hass) {
     const container = this.shadowRoot.getElementById("room-modes");
     if (!container) return;
-    const modes = (Array.isArray(config?.room_modes) ? config.room_modes : [])
-      .filter((mode) => ["scene", "script"].includes(getEntityDomain(mode?.entity)));
+    const modes = (Array.isArray(config?.room_modes) ? config.room_modes : []).filter((mode) => ["scene", "script"].includes(getEntityDomain(mode?.entity)));
     const signature = JSON.stringify(modes.map((mode) => ({
       entity: mode.entity,
       name: mode.name || "",
@@ -3004,71 +3522,59 @@ class OneLineRoomCard extends HTMLElement {
       else button.style.removeProperty("--room-mode-color");
     });
   }
-
   _checkConditions(conditions, h) {
     if (!Array.isArray(conditions) || conditions.length === 0) return true;
-    return conditions.every(c => this._checkCondition(c, h));
+    return conditions.every((c) => this._checkCondition(c, h));
   }
-
   _checkCondition(c, h) {
     if (!c || !c.condition) return true;
     const type = c.condition;
-
     if (type === "state") {
-      if (!c.entity) return true; // Incomplete condition — treat as always visible
+      if (!c.entity) return true;
       const st = h.states[c.entity]?.state;
-      if (c.state_not !== undefined) return st !== c.state_not;
+      if (c.state_not !== void 0) return st !== c.state_not;
       return st === c.state;
     }
-
     if (type === "numeric_state") {
-      if (!c.entity) return true; // Incomplete condition
+      if (!c.entity) return true;
       const val = parseFloat(h.states[c.entity]?.state);
       if (isNaN(val)) return false;
-      if (c.above !== undefined && val <= parseFloat(c.above)) return false;
-      if (c.below !== undefined && val >= parseFloat(c.below)) return false;
+      if (c.above !== void 0 && val <= parseFloat(c.above)) return false;
+      if (c.below !== void 0 && val >= parseFloat(c.below)) return false;
       return true;
     }
-
     if (type === "screen") {
       if (!c.media_query) return true;
       return window.matchMedia(c.media_query).matches;
     }
-
     if (type === "user") {
       if (!Array.isArray(c.users) || !h.user) return true;
       return c.users.includes(h.user.id);
     }
-
     if (type === "and") {
       if (!Array.isArray(c.conditions)) return true;
-      return c.conditions.every(cond => this._checkCondition(cond, h));
+      return c.conditions.every((cond) => this._checkCondition(cond, h));
     }
-
     if (type === "or") {
       if (!Array.isArray(c.conditions)) return true;
-      return c.conditions.some(cond => this._checkCondition(cond, h));
+      return c.conditions.some((cond) => this._checkCondition(cond, h));
     }
-
     if (type === "not") {
       if (!Array.isArray(c.conditions)) return true;
-      return c.conditions.every(cond => !this._checkCondition(cond, h));
+      return c.conditions.every((cond) => !this._checkCondition(cond, h));
     }
-
     return true;
   }
-
   _getSliderCapabilities(domain, st, ctrl) {
     let supported = false, min = 0, max = 100, step = 1, value = 0, pct = 0, action = null;
     if (!st || this._isEntityUnavailable(ctrl.entity)) return { supported };
-
     if (domain === "light") {
       const supp = st.attributes?.supported_color_modes || [];
-      const hasColorTemp = supp.includes("color_temp") || st.attributes?.color_temp !== undefined || st.attributes?.color_temp_kelvin !== undefined;
+      const hasColorTemp = supp.includes("color_temp") || st.attributes?.color_temp !== void 0 || st.attributes?.color_temp_kelvin !== void 0;
       const isColorTemp = ctrl.slider_mode === "color_temp" && hasColorTemp;
       supported = true;
       if (isColorTemp) {
-        if (st.attributes?.min_color_temp_kelvin !== undefined) {
+        if (st.attributes?.min_color_temp_kelvin !== void 0) {
           min = st.attributes.min_color_temp_kelvin;
           max = st.attributes.max_color_temp_kelvin;
           value = st.attributes.color_temp_kelvin ?? min;
@@ -3080,8 +3586,10 @@ class OneLineRoomCard extends HTMLElement {
           action = "color_temp";
         }
       } else {
-        value = st.attributes?.brightness != null ? Math.round((st.attributes.brightness / 255) * 100) : 0;
-        min = 0; max = 100; step = 1;
+        value = st.attributes?.brightness != null ? Math.round(st.attributes.brightness / 255 * 100) : 0;
+        min = 0;
+        max = 100;
+        step = 1;
         action = "brightness";
       }
     } else if (domain === "cover") {
@@ -3112,10 +3620,9 @@ class OneLineRoomCard extends HTMLElement {
       value = parseFloat(st.state) || min;
       action = "value";
     }
-    pct = ((Math.max(min, Math.min(max, value)) - min) / (max - min)) * 100;
+    pct = (Math.max(min, Math.min(max, value)) - min) / (max - min) * 100;
     return { supported, min, max, step, value, pct, action };
   }
-
   _getInlineButtons(domain) {
     if (domain === "cover") return [
       { icon: "mdi:arrow-up-bold", action: "service", service: "cover.open_cover" },
@@ -3148,13 +3655,11 @@ class OneLineRoomCard extends HTMLElement {
     ];
     return [];
   }
-
   _supportsMediaFeature(stateObj, feature) {
     const supported = stateObj?.attributes?.supported_features;
     if (!Number.isFinite(Number(supported))) return true;
     return (Number(supported) & feature) !== 0;
   }
-
   _updateBtnState(btn, ctrl, h) {
     const systemTempUnit = normalizeTemperatureUnit(h.config.unit_system.temperature) || "°C";
     const configuredTempUnit = normalizeTemperatureUnit(this.config?.temp_unit);
@@ -3164,19 +3669,14 @@ class OneLineRoomCard extends HTMLElement {
     const isTemplate = ctrl.type === "template";
     const subChipPresentations = resolveSubChipPresentations(ctrl, h);
     const activeElement = this.shadowRoot.activeElement;
-    const focusedControlKey = activeElement && btn.contains(activeElement)
-      ? activeElement.dataset?.rcFocusKey || ""
-      : "";
-
+    const focusedControlKey = activeElement && btn.contains(activeElement) ? activeElement.dataset?.rcFocusKey || "" : "";
     let typ = "default";
     if (domain === "cover") typ = "shutter";
     else if (domain === "climate") typ = "climate";
     else if (domain === "switch") typ = "socket";
     else if (domain === "light") typ = "light";
-
     let col = "grey", bg = "rgba(128,128,128,0.1)";
     let isUnavail = false;
-
     let tpl = null;
     if (isTemplate) {
       tpl = resolveTemplateCtrl(ctrl, h);
@@ -3197,11 +3697,11 @@ class OneLineRoomCard extends HTMLElement {
       col = resolved.color;
       bg = resolved.bg;
       isUnavail = resolved.isUnavailable;
-      // color_map: per-state color override (lower priority than manual color)
       if (!ctrl.color && ctrl.color_map && !isUnavail) {
         const normMap = Object.fromEntries(
           Object.entries(ctrl.color_map).map(([k, v]) => [
-            k === true ? "on" : k === false ? "off" : String(k), v
+            k === true ? "on" : k === false ? "off" : String(k),
+            v
           ])
         );
         const mappedColor = trimStr(normMap[s] ?? normMap.default ?? "");
@@ -3212,17 +3712,10 @@ class OneLineRoomCard extends HTMLElement {
         }
       }
     }
-
-    // Override with manual background configuration if provided
     const manualBg = ctrl.button_background || this.config?.global_button_background || "";
     if (manualBg) bg = manualBg;
-
-    const nameTxt = isTemplate
-      ? (tpl?.content || ctrl.name || "")
-      : (ctrl.name !== undefined ? ctrl.name : "Dev");
+    const nameTxt = isTemplate ? tpl?.content || ctrl.name || "" : ctrl.name !== void 0 ? ctrl.name : "Dev";
     const unavailableText = getTranslation(h, "device_unavailable");
-
-    // --- NEW: USE DYNAMIC UNIT IN TEMPLATE ---
     const climateHasSlider = typ === "climate" && (ctrl.control_mode === "slider" || ctrl.control_mode === "full");
     const mediaTitleText = (() => {
       if (domain !== "media_player" || !st) return "";
@@ -3233,37 +3726,22 @@ class OneLineRoomCard extends HTMLElement {
       if (title && album) return `${title} · ${album}`;
       return title || artist || album || "";
     })();
-    const stateText = isTemplate
-      ? (tpl?.state || "")
-      : (mediaTitleText || (typ === "climate"
-        ? (() => {
-          const cur = st?.attributes?.current_temperature;
-          const tar = st?.attributes?.temperature;
-          const curDisplay = cur != null
-            ? formatTemperatureAttributeForDisplay(h, st, "current_temperature", cur, configuredTempUnit, systemTempUnit)
-            : "";
-          const tarDisplay = tar != null
-            ? formatTemperatureAttributeForDisplay(h, st, "temperature", tar, configuredTempUnit, systemTempUnit)
-            : "";
-          if (climateHasSlider && cur != null && tar != null) return `${curDisplay} → ${tarDisplay}`;
-          if (climateHasSlider && tar != null) return tarDisplay;
-          if (cur != null) return curDisplay;
-          return s;
-        })()
-        : typ === "shutter" && st?.attributes?.current_position != null
-          ? `${100 - Math.round(st.attributes.current_position)}% closed`
-        : typ === "light" && s === "on" && ctrl.show_brightness_value !== false && st?.attributes?.brightness != null
-          ? `${s} · ${Math.round((st.attributes.brightness / 255) * 100)} %`
-          : domain === "sensor" && st
-            ? formatEntityStateForDisplay(h, st)
-            : s));
+    const stateText = isTemplate ? tpl?.state || "" : mediaTitleText || (typ === "climate" ? (() => {
+      const cur = st?.attributes?.current_temperature;
+      const tar = st?.attributes?.temperature;
+      const curDisplay = cur != null ? formatTemperatureAttributeForDisplay(h, st, "current_temperature", cur, configuredTempUnit, systemTempUnit) : "";
+      const tarDisplay = tar != null ? formatTemperatureAttributeForDisplay(h, st, "temperature", tar, configuredTempUnit, systemTempUnit) : "";
+      if (climateHasSlider && cur != null && tar != null) return `${curDisplay} → ${tarDisplay}`;
+      if (climateHasSlider && tar != null) return tarDisplay;
+      if (cur != null) return curDisplay;
+      return s;
+    })() : typ === "shutter" && st?.attributes?.current_position != null ? `${100 - Math.round(st.attributes.current_position)}% closed` : typ === "light" && s === "on" && ctrl.show_brightness_value !== false && st?.attributes?.brightness != null ? `${s} · ${Math.round(st.attributes.brightness / 255 * 100)} %` : domain === "sensor" && st ? formatEntityStateForDisplay(h, st) : s);
     const showState = isTemplate ? ctrl.show_state === true : ctrl.show_state !== false;
     const showLabel = ctrl.show_label !== false;
     const showLastChanged = ctrl.show_last_changed === true && !isTemplate && !!st?.last_changed;
     const elapsedText = showLastChanged ? formatLastChanged(st.last_changed, h) : "";
     const showIcon = ctrl.show_icon !== false;
     const stateFirst = ctrl.state_first === true;
-
     const per = ctrl.label_position;
     const globalPos = this.config?.global_label_position;
     const pos = resolveLabelPosition(ctrl, this.config);
@@ -3271,22 +3749,19 @@ class OneLineRoomCard extends HTMLElement {
     btn.dataset.lpGlobal = globalPos ?? "";
     btn.dataset.lpEff = pos ?? "";
     applyLabelPosition(btn, pos);
-
-    const resolvedIcon = isTemplate
-      ? (tpl?.icon || ctrl.icon || "mdi:circle")
-      : (() => {
-        if (ctrl.icon_map) {
-          // YAML parses unquoted `on`/`off` as booleans — normalise keys to strings
-          const normMap = Object.fromEntries(
-            Object.entries(ctrl.icon_map).map(([k, v]) => [
-              k === true ? "on" : k === false ? "off" : String(k), v
-            ])
-          );
-          const mapped = normMap[s] ?? normMap.default;
-          if (mapped) return mapped;
-        }
-        return ctrl.icon || DOMAIN_STATE_ICON_MAPS[domain]?.[s] || st?.attributes?.icon || "mdi:circle";
-      })();
+    const resolvedIcon = isTemplate ? tpl?.icon || ctrl.icon || "mdi:circle" : (() => {
+      if (ctrl.icon_map) {
+        const normMap = Object.fromEntries(
+          Object.entries(ctrl.icon_map).map(([k, v]) => [
+            k === true ? "on" : k === false ? "off" : String(k),
+            v
+          ])
+        );
+        const mapped = normMap[s] ?? normMap.default;
+        if (mapped) return mapped;
+      }
+      return ctrl.icon || DOMAIN_STATE_ICON_MAPS[domain]?.[s] || st?.attributes?.icon || "mdi:circle";
+    })();
     const iconSizePx = (() => {
       const raw = trimStr(ctrl.icon_size) || trimStr(this.config?.global_icon_size) || "";
       if (!raw) return "20px";
@@ -3315,7 +3790,6 @@ class OneLineRoomCard extends HTMLElement {
       }
       if (chipsEl.childElementCount === 0) chipsEl = null;
     }
-
     btn.replaceChildren();
     if (showIcon) {
       const iconBox = document.createElement("div");
@@ -3332,16 +3806,13 @@ class OneLineRoomCard extends HTMLElement {
     const labelEl = showLabel ? document.createElement("span") : null;
     if (labelEl) {
       labelEl.className = "btn-name";
-      // Explicit compatibility boundary: only trusted template configuration may opt in to HTML.
       if (isTemplate && ctrl.trusted_html === true) labelEl.innerHTML = String(nameTxt);
       else labelEl.textContent = String(nameTxt);
     }
-    const stateEl = (showState || showLastChanged) ? document.createElement("span") : null;
+    const stateEl = showState || showLastChanged ? document.createElement("span") : null;
     if (stateEl) {
       stateEl.className = "btn-state";
-      stateEl.textContent = showState && showLastChanged
-        ? `${stateText} · ${elapsedText}`
-        : (showState ? String(stateText) : elapsedText);
+      stateEl.textContent = showState && showLastChanged ? `${stateText} · ${elapsedText}` : showState ? String(stateText) : elapsedText;
     }
     if (stateFirst) {
       if (stateEl) textEl.appendChild(stateEl);
@@ -3359,7 +3830,6 @@ class OneLineRoomCard extends HTMLElement {
       warning.title = unavailableText;
       btn.appendChild(warning);
     }
-
     btn.classList.toggle("state-unavailable", isUnavail);
     if (!isTemplate) {
       btn.style.cursor = isUnavail ? "default" : "pointer";
@@ -3375,29 +3845,23 @@ class OneLineRoomCard extends HTMLElement {
     }
     if (isUnavail) btn.title = unavailableText;
     else btn.removeAttribute("title");
-
-    // Apply dynamic colors via CSS custom properties
     btn.style.setProperty("--icon-color", col);
     btn.style.setProperty("--btn-bg", bg);
-
     this._renderBtnSparkline(btn, ctrl, col);
-
-    // Inline controls
     const controlMode = ctrl.control_mode;
     const sliderCaps = this._getSliderCapabilities(domain, st, ctrl);
     const inlineBtns = this._getInlineButtons(domain);
     const isFullControl = controlMode === "full";
     const isSelectDomain = domain === "select" || domain === "input_select";
     const isBgSlider = controlMode === "slider" && ctrl.slider_style === "background" && !isUnavail && sliderCaps.supported && !isSelectDomain;
-    const isInlineSlider = ((controlMode === "slider" && ctrl.slider_style !== "background") || isFullControl) && !isUnavail && sliderCaps.supported && !isSelectDomain;
-    const hasInlineBtns = (controlMode === "buttons" || (isFullControl && !isSelectDomain)) && !isUnavail && inlineBtns.length > 0;
+    const isInlineSlider = (controlMode === "slider" && ctrl.slider_style !== "background" || isFullControl) && !isUnavail && sliderCaps.supported && !isSelectDomain;
+    const hasInlineBtns = (controlMode === "buttons" || isFullControl && !isSelectDomain) && !isUnavail && inlineBtns.length > 0;
     const hasCoverPresets = ctrl.show_cover_presets === true && domain === "cover" && !isUnavail;
     const hasClimatePresets = ctrl.show_climate_presets === true && domain === "climate" && !isUnavail;
     const hasBrightnessPresets = ctrl.show_brightness_presets === true && domain === "light" && !isUnavail;
     const hasColorFavorites = ctrl.show_color_favorites === true && domain === "light" && !isUnavail;
     const hasSelectOptions = isSelectDomain && !isUnavail && Array.isArray(st?.attributes?.options) && st.attributes.options.length > 0;
     const isMediaFull = domain === "media_player" && !isUnavail && (controlMode === "full" || !controlMode || controlMode === "default");
-
     if (isBgSlider) {
       btn.style.position = "relative";
       btn.style.overflow = "hidden";
@@ -3419,29 +3883,26 @@ class OneLineRoomCard extends HTMLElement {
       } else {
         bgSlider.style.background = "var(--icon-color)";
       }
-      Array.from(btn.children).forEach(c => { c.style.position = "relative"; c.style.zIndex = "1"; });
+      Array.from(btn.children).forEach((c) => {
+        c.style.position = "relative";
+        c.style.zIndex = "1";
+      });
       btn.insertBefore(bgSlider, btn.firstChild);
     }
-
     if (isInlineSlider || hasInlineBtns || hasCoverPresets || hasClimatePresets || hasBrightnessPresets || hasColorFavorites || hasSelectOptions || isMediaFull) {
       btn.classList.add("has-inline-ctrl");
       const topDiv = document.createElement("div");
       topDiv.className = "btn-top";
       while (btn.firstChild) {
-        if (btn.firstChild.className === "bg-slider-fill") break; // Keep background behind topDiv if they somehow co-exist
+        if (btn.firstChild.className === "bg-slider-fill") break;
         topDiv.appendChild(btn.firstChild);
       }
       btn.appendChild(topDiv);
-
       if (isMediaFull) {
-        // Layout: [Thumbnail] [Name + Title + Controls]
         const thumbUrl = st?.attributes?.entity_picture;
-        // Remove the icon-box from topDiv (we use thumbnail or keep icon as fallback)
         const iconBox = topDiv.querySelector(".icon-box");
-
         const layout = document.createElement("div");
         layout.className = "media-full-layout";
-
         if (thumbUrl) {
           const img = document.createElement("img");
           img.className = "media-thumb";
@@ -3452,14 +3913,10 @@ class OneLineRoomCard extends HTMLElement {
         } else if (iconBox) {
           iconBox.remove();
         }
-
-        // Right side: text + control bar
         const rightDiv = document.createElement("div");
         rightDiv.className = "media-right";
-        // Move text content from topDiv into rightDiv
         const txtDiv = topDiv.querySelector(".btn-txt");
         if (txtDiv) rightDiv.appendChild(txtDiv);
-
         const createMediaButton = (className, icon, label, service) => {
           const button = document.createElement("button");
           button.type = "button";
@@ -3469,8 +3926,8 @@ class OneLineRoomCard extends HTMLElement {
           const buttonIcon = document.createElement("ha-icon");
           buttonIcon.setAttribute("icon", icon);
           button.appendChild(buttonIcon);
-          button.addEventListener("pointerdown", e => e.stopPropagation());
-          button.addEventListener("click", e => {
+          button.addEventListener("pointerdown", (e) => e.stopPropagation());
+          button.addEventListener("click", (e) => {
             e.stopPropagation();
             if (!this._isEntityUnavailable(ctrl.entity)) {
               this._hass.callService("media_player", service, { entity_id: ctrl.entity });
@@ -3478,8 +3935,6 @@ class OneLineRoomCard extends HTMLElement {
           });
           return button;
         };
-
-        // Transport row: [Previous] [Play/Pause] [Next]
         const transportRow = document.createElement("div");
         transportRow.className = "media-transport-row";
         if (this._supportsMediaFeature(st, MEDIA_PLAYER_FEATURES.PREVIOUS_TRACK)) {
@@ -3492,8 +3947,6 @@ class OneLineRoomCard extends HTMLElement {
           transportRow.appendChild(createMediaButton("media-ctrl-btn media-next", "mdi:skip-next", getTranslation(h, "a11y_next_track"), "media_next_track"));
         }
         if (transportRow.childElementCount > 0) rightDiv.appendChild(transportRow);
-
-        // Volume row: [Mute] [---Slider---] [Percentage]
         const volumeRow = document.createElement("div");
         volumeRow.className = "media-volume-row";
         let currentMuted = st?.attributes?.is_volume_muted === true;
@@ -3506,19 +3959,17 @@ class OneLineRoomCard extends HTMLElement {
         const muteIcon = document.createElement("ha-icon");
         muteIcon.setAttribute("icon", currentMuted ? "mdi:volume-off" : "mdi:volume-high");
         muteBtn.appendChild(muteIcon);
-        muteBtn.addEventListener("pointerdown", e => e.stopPropagation());
-        muteBtn.addEventListener("click", e => {
+        muteBtn.addEventListener("pointerdown", (e) => e.stopPropagation());
+        muteBtn.addEventListener("click", (e) => {
           e.stopPropagation();
           if (!this._isEntityUnavailable(ctrl.entity)) {
             const newMuted = !currentMuted;
             currentMuted = newMuted;
             this._hass.callService("media_player", "volume_mute", { entity_id: ctrl.entity, is_volume_muted: newMuted });
             if (!newMuted) {
-              // Also restore volume explicitly for players that don't handle unmute well
               const vol = st?.attributes?.volume_level ?? sliderCaps.value / 100;
               this._hass.callService("media_player", "volume_set", { entity_id: ctrl.entity, volume_level: vol });
             }
-            // Immediate visual feedback
             muteBtn.querySelector("ha-icon").setAttribute("icon", newMuted ? "mdi:volume-off" : "mdi:volume-high");
             muteBtn.classList.toggle("muted", newMuted);
             muteBtn.setAttribute("aria-pressed", newMuted ? "true" : "false");
@@ -3527,7 +3978,7 @@ class OneLineRoomCard extends HTMLElement {
               volLabel.textContent = "0%";
             } else {
               const vol = sliderCaps.value;
-              const pct = ((vol - sliderCaps.min) / (sliderCaps.max - sliderCaps.min)) * 100;
+              const pct = (vol - sliderCaps.min) / (sliderCaps.max - sliderCaps.min) * 100;
               slider.value = vol;
               slider.style.setProperty("--slider-pct", `${pct}%`);
               volLabel.textContent = `${Math.round(vol)}%`;
@@ -3535,30 +3986,32 @@ class OneLineRoomCard extends HTMLElement {
           }
         });
         if (this._supportsMediaFeature(st, MEDIA_PLAYER_FEATURES.VOLUME_MUTE)) volumeRow.appendChild(muteBtn);
-        // Volume slider
         const wrap = document.createElement("div");
         wrap.className = "btn-slider-wrap";
         const slider = document.createElement("input");
         slider.type = "range";
         slider.className = "btn-slider";
         slider.dataset.rcFocusKey = "volume_level";
-        slider.min = sliderCaps.min; slider.max = sliderCaps.max; slider.step = sliderCaps.step; slider.value = sliderCaps.value;
+        slider.min = sliderCaps.min;
+        slider.max = sliderCaps.max;
+        slider.step = sliderCaps.step;
+        slider.value = sliderCaps.value;
         slider.setAttribute("aria-label", getTranslation(h, "a11y_volume"));
         slider.setAttribute("aria-valuetext", `${Math.round(sliderCaps.value)}%`);
         slider.style.setProperty("--slider-pct", `${sliderCaps.pct}%`);
         const volLabel = document.createElement("span");
         volLabel.className = "vol-label";
         volLabel.textContent = `${Math.round(sliderCaps.value)}%`;
-        slider.addEventListener("pointerdown", e => e.stopPropagation());
-        slider.addEventListener("click", e => e.stopPropagation());
-        slider.addEventListener("input", e => {
+        slider.addEventListener("pointerdown", (e) => e.stopPropagation());
+        slider.addEventListener("click", (e) => e.stopPropagation());
+        slider.addEventListener("input", (e) => {
           const v = +e.target.value;
-          const pct = ((v - sliderCaps.min) / (sliderCaps.max - sliderCaps.min)) * 100;
+          const pct = (v - sliderCaps.min) / (sliderCaps.max - sliderCaps.min) * 100;
           e.target.style.setProperty("--slider-pct", `${pct}%`);
           e.target.setAttribute("aria-valuetext", `${Math.round(v)}%`);
           volLabel.textContent = `${Math.round(v)}%`;
         });
-        slider.addEventListener("change", e => {
+        slider.addEventListener("change", (e) => {
           const v = +e.target.value;
           this._hass.callService("media_player", "volume_set", { entity_id: ctrl.entity, volume_level: v / 100 });
         });
@@ -3569,7 +4022,6 @@ class OneLineRoomCard extends HTMLElement {
         }
         if (volumeRow.childElementCount > 0) rightDiv.appendChild(volumeRow);
         layout.appendChild(rightDiv);
-        // Replace topDiv content with the full layout
         topDiv.replaceChildren();
         topDiv.appendChild(layout);
       } else if (isInlineSlider) {
@@ -3578,7 +4030,10 @@ class OneLineRoomCard extends HTMLElement {
         const slider = document.createElement("input");
         slider.type = "range";
         slider.className = "btn-slider";
-        slider.min = sliderCaps.min; slider.max = sliderCaps.max; slider.step = sliderCaps.step; slider.value = sliderCaps.value;
+        slider.min = sliderCaps.min;
+        slider.max = sliderCaps.max;
+        slider.step = sliderCaps.step;
+        slider.value = sliderCaps.value;
         slider.setAttribute("aria-label", getTranslation(h, "a11y_set_value").replace("{name}", nameTxt));
         slider.style.setProperty("--slider-pct", `${sliderCaps.pct}%`);
         if (sliderCaps.action === "color_temp") {
@@ -3588,43 +4043,41 @@ class OneLineRoomCard extends HTMLElement {
           slider.style.background = `linear-gradient(to right, #ffcf91 0%, #a2c8ff 100%)`;
           slider.style.boxShadow = `inset 0 0 0 1px rgba(128,128,128,0.2)`;
         }
-        slider.addEventListener("pointerdown", e => e.stopPropagation());
-        slider.addEventListener("click", e => e.stopPropagation());
-        slider.addEventListener("input", e => {
+        slider.addEventListener("pointerdown", (e) => e.stopPropagation());
+        slider.addEventListener("click", (e) => e.stopPropagation());
+        slider.addEventListener("input", (e) => {
           const v = +e.target.value;
-          const pct = ((v - sliderCaps.min) / (sliderCaps.max - sliderCaps.min)) * 100;
+          const pct = (v - sliderCaps.min) / (sliderCaps.max - sliderCaps.min) * 100;
           e.target.style.setProperty("--slider-pct", `${pct}%`);
           if (domain === "climate") {
-            const stateEl = topDiv.querySelector(".btn-state");
-            if (stateEl) {
+            const stateEl2 = topDiv.querySelector(".btn-state");
+            if (stateEl2) {
               const cur = st?.attributes?.current_temperature;
-              const curDisplay = cur != null
-                ? formatTemperatureAttributeForDisplay(h, st, "current_temperature", cur, configuredTempUnit, systemTempUnit)
-                : "";
+              const curDisplay = cur != null ? formatTemperatureAttributeForDisplay(h, st, "current_temperature", cur, configuredTempUnit, systemTempUnit) : "";
               const targetDisplay = formatTemperatureAttributeForDisplay(h, st, "temperature", v, configuredTempUnit, systemTempUnit);
-              stateEl.textContent = cur != null ? `${curDisplay} → ${targetDisplay}` : targetDisplay;
+              stateEl2.textContent = cur != null ? `${curDisplay} → ${targetDisplay}` : targetDisplay;
             }
           } else if (sliderCaps.action === "color_temp") {
-            const stateEl = topDiv.querySelector(".btn-state");
-            if (stateEl) {
-              const k = Math.round(1000000 / v);
-              stateEl.textContent = `${k} K`;
+            const stateEl2 = topDiv.querySelector(".btn-state");
+            if (stateEl2) {
+              const k = Math.round(1e6 / v);
+              stateEl2.textContent = `${k} K`;
             }
           } else if (sliderCaps.action === "color_temp_kelvin") {
-            const stateEl = topDiv.querySelector(".btn-state");
-            if (stateEl) stateEl.textContent = `${Math.round(v)} K`;
+            const stateEl2 = topDiv.querySelector(".btn-state");
+            if (stateEl2) stateEl2.textContent = `${Math.round(v)} K`;
           } else if (sliderCaps.action === "brightness" && ctrl.show_brightness_value !== false) {
-            const stateEl = topDiv.querySelector(".btn-state");
-            if (stateEl) stateEl.textContent = `${s} · ${Math.round(v)} %`;
+            const stateEl2 = topDiv.querySelector(".btn-state");
+            if (stateEl2) stateEl2.textContent = `${s} · ${Math.round(v)} %`;
           } else if (sliderCaps.action === "position") {
-            const stateEl = topDiv.querySelector(".btn-state");
-            if (stateEl) stateEl.textContent = `${100 - Math.round(v)}% closed`;
+            const stateEl2 = topDiv.querySelector(".btn-state");
+            if (stateEl2) stateEl2.textContent = `${100 - Math.round(v)}% closed`;
           }
         });
-        slider.addEventListener("change", e => {
+        slider.addEventListener("change", (e) => {
           const v = +e.target.value;
           if (sliderCaps.action === "color_temp") {
-            this._hass.callService("light", "turn_on", { entity_id: ctrl.entity, color_temp_kelvin: Math.round(1000000 / v) });
+            this._hass.callService("light", "turn_on", { entity_id: ctrl.entity, color_temp_kelvin: Math.round(1e6 / v) });
           } else if (sliderCaps.action === "color_temp_kelvin") {
             this._hass.callService("light", "turn_on", { entity_id: ctrl.entity, color_temp_kelvin: Math.round(v) });
           } else if (sliderCaps.action === "brightness") {
@@ -3644,7 +4097,6 @@ class OneLineRoomCard extends HTMLElement {
         wrap.appendChild(slider);
         btn.appendChild(wrap);
       }
-
       if (hasInlineBtns && !isMediaFull) {
         const actDiv = document.createElement("div");
         actDiv.className = "btn-cover-actions";
@@ -3656,13 +4108,13 @@ class OneLineRoomCard extends HTMLElement {
           const actionIcon = document.createElement("ha-icon");
           actionIcon.setAttribute("icon", icon);
           b.appendChild(actionIcon);
-          b.addEventListener("pointerdown", e => e.stopPropagation());
-          b.addEventListener("click", e => {
+          b.addEventListener("pointerdown", (e) => e.stopPropagation());
+          b.addEventListener("click", (e) => {
             e.stopPropagation();
             if (this._isEntityUnavailable(ctrl.entity)) return;
             if (action === "service") {
-              const [d, s] = service.split(".");
-              this._hass.callService(d, s, { entity_id: ctrl.entity });
+              const [d, s2] = service.split(".");
+              this._hass.callService(d, s2, { entity_id: ctrl.entity });
             } else if (action === "custom") {
               if (custom === "dim_down") this._hass.callService("light", "turn_on", { entity_id: ctrl.entity, brightness_step_pct: -10 });
               else if (custom === "dim_up") this._hass.callService("light", "turn_on", { entity_id: ctrl.entity, brightness_step_pct: 10 });
@@ -3675,8 +4127,7 @@ class OneLineRoomCard extends HTMLElement {
                   const nextIdx = currentIdx >= 0 ? (currentIdx + delta + options.length) % options.length : fallbackIdx;
                   this._hass.callService(domain, "select_option", { entity_id: ctrl.entity, option: options[nextIdx] });
                 }
-              }
-              else if (custom === "temp_down") this._hass.callService("climate", "set_temperature", { entity_id: ctrl.entity, temperature: (st?.attributes?.temperature || 20) - 0.5 });
+              } else if (custom === "temp_down") this._hass.callService("climate", "set_temperature", { entity_id: ctrl.entity, temperature: (st?.attributes?.temperature || 20) - 0.5 });
               else if (custom === "temp_up") this._hass.callService("climate", "set_temperature", { entity_id: ctrl.entity, temperature: (st?.attributes?.temperature || 20) + 0.5 });
               else if (custom === "toggle_hvac") {
                 const isOff = ["off", "idle"].includes(st?.state);
@@ -3688,51 +4139,42 @@ class OneLineRoomCard extends HTMLElement {
         });
         btn.appendChild(actDiv);
       }
-
-      // Cover position presets
       if (domain === "cover" && ctrl.show_cover_presets === true) {
-        const rawPresets = Array.isArray(ctrl.cover_presets) ? ctrl.cover_presets
-          : typeof ctrl.cover_presets === "string" ? ctrl.cover_presets.split(",").map(v => parseFloat(v.trim())).filter(v => !isNaN(v))
-            : [0, 50, 100];
+        const rawPresets = Array.isArray(ctrl.cover_presets) ? ctrl.cover_presets : typeof ctrl.cover_presets === "string" ? ctrl.cover_presets.split(",").map((v) => parseFloat(v.trim())).filter((v) => !isNaN(v)) : [0, 50, 100];
         const currentPos = st?.attributes?.current_position ?? -1;
         const presetsDiv = document.createElement("div");
         presetsDiv.className = "btn-cover-presets";
-        rawPresets.forEach(pos => {
+        rawPresets.forEach((pos2) => {
           const pb = document.createElement("button");
           pb.type = "button";
           pb.className = "preset-btn";
-          pb.textContent = `${pos}%`;
-          pb.setAttribute("aria-label", `${getTranslation(h, "a11y_set_value").replace("{name}", nameTxt)}: ${pos}%`);
-          const isActive = Math.abs(currentPos - pos) < 2;
+          pb.textContent = `${pos2}%`;
+          pb.setAttribute("aria-label", `${getTranslation(h, "a11y_set_value").replace("{name}", nameTxt)}: ${pos2}%`);
+          const isActive = Math.abs(currentPos - pos2) < 2;
           if (isActive) pb.classList.add("active");
-          pb.addEventListener("pointerdown", e => e.stopPropagation());
-          pb.addEventListener("click", e => {
+          pb.addEventListener("pointerdown", (e) => e.stopPropagation());
+          pb.addEventListener("click", (e) => {
             e.stopPropagation();
             if (!this._isEntityUnavailable(ctrl.entity)) {
-              this._hass.callService("cover", "set_cover_position", { entity_id: ctrl.entity, position: pos });
+              this._hass.callService("cover", "set_cover_position", { entity_id: ctrl.entity, position: pos2 });
             }
           });
           presetsDiv.appendChild(pb);
         });
         btn.appendChild(presetsDiv);
       }
-
-      // Climate temperature presets
       if (domain === "climate" && ctrl.show_climate_presets === true) {
-        const rawPresets = Array.isArray(ctrl.climate_presets) ? ctrl.climate_presets
-          : typeof ctrl.climate_presets === "string"
-            ? ctrl.climate_presets.split(",").map(v => {
-              const t = v.trim().toLowerCase();
-              if (t === "auto" || t === "max") return t;
-              const n = parseFloat(t);
-              return isNaN(n) ? null : n;
-            }).filter(v => v !== null)
-            : [0, 18, 20, 22];
+        const rawPresets = Array.isArray(ctrl.climate_presets) ? ctrl.climate_presets : typeof ctrl.climate_presets === "string" ? ctrl.climate_presets.split(",").map((v) => {
+          const t = v.trim().toLowerCase();
+          if (t === "auto" || t === "max") return t;
+          const n = parseFloat(t);
+          return isNaN(n) ? null : n;
+        }).filter((v) => v !== null) : [0, 18, 20, 22];
         const currentTarget = st?.attributes?.temperature ?? -999;
         const maxTemp = st?.attributes?.max_temp ?? null;
         const presetsDiv = document.createElement("div");
         presetsDiv.className = "btn-cover-presets";
-        rawPresets.forEach(val => {
+        rawPresets.forEach((val) => {
           const pb = document.createElement("button");
           pb.type = "button";
           pb.className = "preset-btn";
@@ -3753,8 +4195,8 @@ class OneLineRoomCard extends HTMLElement {
           pb.textContent = label;
           pb.setAttribute("aria-label", `${getTranslation(h, "a11y_set_value").replace("{name}", nameTxt)}: ${label}`);
           if (isActive) pb.classList.add("active");
-          pb.addEventListener("pointerdown", e => e.stopPropagation());
-          pb.addEventListener("click", e => {
+          pb.addEventListener("pointerdown", (e) => e.stopPropagation());
+          pb.addEventListener("click", (e) => {
             e.stopPropagation();
             if (!this._isEntityUnavailable(ctrl.entity)) {
               if (val === "auto") {
@@ -3772,8 +4214,6 @@ class OneLineRoomCard extends HTMLElement {
         });
         btn.appendChild(presetsDiv);
       }
-
-      // Climate HVAC mode chips
       if (domain === "climate" && ctrl.show_hvac_modes === true) {
         const modes = Array.isArray(st?.attributes?.hvac_modes) ? st.attributes.hvac_modes : [];
         if (modes.length > 0) {
@@ -3781,10 +4221,15 @@ class OneLineRoomCard extends HTMLElement {
           const div = document.createElement("div");
           div.className = "btn-cover-presets";
           const iconForMode = {
-            off: "mdi:power", auto: "mdi:thermostat-auto", heat: "mdi:fire", cool: "mdi:snowflake",
-            heat_cool: "mdi:sun-snowflake", dry: "mdi:water-percent", fan_only: "mdi:fan"
+            off: "mdi:power",
+            auto: "mdi:thermostat-auto",
+            heat: "mdi:fire",
+            cool: "mdi:snowflake",
+            heat_cool: "mdi:sun-snowflake",
+            dry: "mdi:water-percent",
+            fan_only: "mdi:fan"
           };
-          modes.forEach(mode => {
+          modes.forEach((mode) => {
             const pb = document.createElement("button");
             pb.type = "button";
             pb.className = "preset-btn";
@@ -3799,8 +4244,8 @@ class OneLineRoomCard extends HTMLElement {
             }
             pb.setAttribute("aria-label", `${getTranslation(h, "a11y_select_option").replace("{name}", nameTxt)}: ${mode}`);
             if (String(mode).toLowerCase() === current) pb.classList.add("active");
-            pb.addEventListener("pointerdown", e => e.stopPropagation());
-            pb.addEventListener("click", e => {
+            pb.addEventListener("pointerdown", (e) => e.stopPropagation());
+            pb.addEventListener("click", (e) => {
               e.stopPropagation();
               if (!this._isEntityUnavailable(ctrl.entity)) {
                 this._hass.callService("climate", "set_hvac_mode", { entity_id: ctrl.entity, hvac_mode: mode });
@@ -3811,15 +4256,13 @@ class OneLineRoomCard extends HTMLElement {
           btn.appendChild(div);
         }
       }
-
-      // Climate fan mode chips
       if (domain === "climate" && ctrl.show_fan_modes === true) {
         const modes = Array.isArray(st?.attributes?.fan_modes) ? st.attributes.fan_modes : [];
         if (modes.length > 0) {
           const current = String(st?.attributes?.fan_mode || "").toLowerCase();
           const div = document.createElement("div");
           div.className = "btn-cover-presets";
-          modes.forEach(mode => {
+          modes.forEach((mode) => {
             const pb = document.createElement("button");
             pb.type = "button";
             pb.className = "preset-btn";
@@ -3829,8 +4272,8 @@ class OneLineRoomCard extends HTMLElement {
             pb.append(icon, document.createTextNode(` ${mode}`));
             pb.setAttribute("aria-label", `${getTranslation(h, "a11y_select_option").replace("{name}", nameTxt)}: ${mode}`);
             if (String(mode).toLowerCase() === current) pb.classList.add("active");
-            pb.addEventListener("pointerdown", e => e.stopPropagation());
-            pb.addEventListener("click", e => {
+            pb.addEventListener("pointerdown", (e) => e.stopPropagation());
+            pb.addEventListener("click", (e) => {
               e.stopPropagation();
               if (!this._isEntityUnavailable(ctrl.entity)) {
                 this._hass.callService("climate", "set_fan_mode", { entity_id: ctrl.entity, fan_mode: mode });
@@ -3841,22 +4284,13 @@ class OneLineRoomCard extends HTMLElement {
           btn.appendChild(div);
         }
       }
-
-      // Light brightness presets
       if (domain === "light" && ctrl.show_brightness_presets === true) {
-        const rawPresets = Array.isArray(ctrl.brightness_presets) ? ctrl.brightness_presets
-          : typeof ctrl.brightness_presets === "string"
-            ? ctrl.brightness_presets.split(",").map(v => parseFloat(v.trim())).filter(v => !isNaN(v))
-            : [25, 50, 75, 100];
-        const presets = [...new Set(rawPresets
-          .map(v => Math.max(1, Math.min(100, Math.round(Number(v)))))
-          .filter(v => Number.isFinite(v)))];
-        const currentBrightness = st?.attributes?.brightness != null
-          ? Math.round((st.attributes.brightness / 255) * 100)
-          : 0;
+        const rawPresets = Array.isArray(ctrl.brightness_presets) ? ctrl.brightness_presets : typeof ctrl.brightness_presets === "string" ? ctrl.brightness_presets.split(",").map((v) => parseFloat(v.trim())).filter((v) => !isNaN(v)) : [25, 50, 75, 100];
+        const presets = [...new Set(rawPresets.map((v) => Math.max(1, Math.min(100, Math.round(Number(v))))).filter((v) => Number.isFinite(v)))];
+        const currentBrightness = st?.attributes?.brightness != null ? Math.round(st.attributes.brightness / 255 * 100) : 0;
         const presetsDiv = document.createElement("div");
         presetsDiv.className = "btn-cover-presets";
-        presets.forEach(pct => {
+        presets.forEach((pct) => {
           const pb = document.createElement("button");
           pb.type = "button";
           pb.className = "preset-btn";
@@ -3864,8 +4298,8 @@ class OneLineRoomCard extends HTMLElement {
           pb.setAttribute("aria-label", `${getTranslation(h, "a11y_set_value").replace("{name}", nameTxt)}: ${pct}%`);
           const isActive = st?.state === "on" && Math.abs(currentBrightness - pct) < 2;
           if (isActive) pb.classList.add("active");
-          pb.addEventListener("pointerdown", e => e.stopPropagation());
-          pb.addEventListener("click", e => {
+          pb.addEventListener("pointerdown", (e) => e.stopPropagation());
+          pb.addEventListener("click", (e) => {
             e.stopPropagation();
             if (!this._isEntityUnavailable(ctrl.entity)) {
               this._hass.callService("light", "turn_on", { entity_id: ctrl.entity, brightness_pct: pct });
@@ -3875,10 +4309,7 @@ class OneLineRoomCard extends HTMLElement {
         });
         btn.appendChild(presetsDiv);
       }
-
-      // Light color favorites
       if (domain === "light" && ctrl.show_color_favorites === true) {
-        // Read from HA entity attribute first, then fall back to manual config
         const entityFavorites = st?.attributes?.light_color_favorites;
         const manualFavorites = ctrl.color_favorites;
         let favorites = [];
@@ -3889,7 +4320,7 @@ class OneLineRoomCard extends HTMLElement {
               const r = parseInt(t.slice(1, 3), 16), g = parseInt(t.slice(3, 5), 16), b = parseInt(t.slice(5, 7), 16);
               return [r, g, b];
             }
-            const parts = t.split(",").map(v => parseInt(v.trim())).filter(v => !isNaN(v) && v >= 0 && v <= 255);
+            const parts = t.split(",").map((v) => parseInt(v.trim())).filter((v) => !isNaN(v) && v >= 0 && v <= 255);
             if (parts.length === 3) return parts;
           } else if (Array.isArray(raw) && raw.length === 3) {
             return raw.map(Number);
@@ -3903,25 +4334,22 @@ class OneLineRoomCard extends HTMLElement {
           favorites = manualFavorites.map(parseColor).filter(Boolean);
         }
         if (!favorites.length && typeof manualFavorites === "string") {
-          favorites = manualFavorites.split(";").map(s => parseColor(s.trim())).filter(Boolean);
+          favorites = manualFavorites.split(";").map((s2) => parseColor(s2.trim())).filter(Boolean);
         }
         if (favorites.length) {
           const currentRgb = st?.attributes?.rgb_color;
           const swatchRow = document.createElement("div");
           swatchRow.className = "btn-color-favorites";
-          favorites.forEach(rgb => {
+          favorites.forEach((rgb) => {
             const sw = document.createElement("button");
             sw.type = "button";
             sw.className = "color-swatch";
             sw.style.background = `rgb(${rgb.join(",")})`;
             sw.setAttribute("aria-label", `${getTranslation(h, "a11y_set_value").replace("{name}", nameTxt)}: RGB ${rgb.join(", ")}`);
-            const isActive = Array.isArray(currentRgb)
-              && Math.abs(currentRgb[0] - rgb[0]) < 8
-              && Math.abs(currentRgb[1] - rgb[1]) < 8
-              && Math.abs(currentRgb[2] - rgb[2]) < 8;
+            const isActive = Array.isArray(currentRgb) && Math.abs(currentRgb[0] - rgb[0]) < 8 && Math.abs(currentRgb[1] - rgb[1]) < 8 && Math.abs(currentRgb[2] - rgb[2]) < 8;
             if (isActive) sw.classList.add("active");
-            sw.addEventListener("pointerdown", e => e.stopPropagation());
-            sw.addEventListener("click", e => {
+            sw.addEventListener("pointerdown", (e) => e.stopPropagation());
+            sw.addEventListener("click", (e) => {
               e.stopPropagation();
               if (!this._isEntityUnavailable(ctrl.entity)) {
                 this._hass.callService("light", "turn_on", { entity_id: ctrl.entity, rgb_color: rgb });
@@ -3932,17 +4360,14 @@ class OneLineRoomCard extends HTMLElement {
           btn.appendChild(swatchRow);
         }
       }
-
-      // Select: dropdown (default/buttons) or option chips (full mode)
       if (isSelectDomain && !isUnavail) {
         const options = Array.isArray(st?.attributes?.options) ? st.attributes.options : [];
         if (options.length > 0) {
           const currentOption = st?.state;
           if (controlMode === "full") {
-            // Full mode: show all options as tappable chips
             const optionsDiv = document.createElement("div");
             optionsDiv.className = "btn-cover-presets btn-select-options";
-            options.forEach(option => {
+            options.forEach((option) => {
               const pb = document.createElement("button");
               pb.type = "button";
               pb.className = "preset-btn";
@@ -3950,32 +4375,31 @@ class OneLineRoomCard extends HTMLElement {
               pb.title = option;
               pb.setAttribute("aria-label", `${getTranslation(h, "a11y_select_option").replace("{name}", nameTxt)}: ${option}`);
               if (currentOption === option) pb.classList.add("active");
-              pb.addEventListener("pointerdown", e => e.stopPropagation());
-              pb.addEventListener("click", e => {
+              pb.addEventListener("pointerdown", (e) => e.stopPropagation());
+              pb.addEventListener("click", (e) => {
                 e.stopPropagation();
                 if (!this._isEntityUnavailable(ctrl.entity)) {
-                  this._hass.callService(domain, "select_option", { entity_id: ctrl.entity, option: option });
+                  this._hass.callService(domain, "select_option", { entity_id: ctrl.entity, option });
                 }
               });
               optionsDiv.appendChild(pb);
             });
             btn.appendChild(optionsDiv);
           } else {
-            // Default / buttons: native dropdown
             const wrapDiv = document.createElement("div");
             wrapDiv.className = "btn-select-dropdown";
             const sel = document.createElement("select");
             sel.setAttribute("aria-label", getTranslation(h, "a11y_select_option").replace("{name}", nameTxt));
-            options.forEach(option => {
+            options.forEach((option) => {
               const opt = document.createElement("option");
               opt.value = option;
               opt.textContent = option;
               if (option === currentOption) opt.selected = true;
               sel.appendChild(opt);
             });
-            sel.addEventListener("pointerdown", e => e.stopPropagation());
-            sel.addEventListener("click", e => e.stopPropagation());
-            sel.addEventListener("change", e => {
+            sel.addEventListener("pointerdown", (e) => e.stopPropagation());
+            sel.addEventListener("click", (e) => e.stopPropagation());
+            sel.addEventListener("change", (e) => {
               e.stopPropagation();
               if (!this._isEntityUnavailable(ctrl.entity)) {
                 this._hass.callService(domain, "select_option", { entity_id: ctrl.entity, option: sel.value });
@@ -3986,26 +4410,22 @@ class OneLineRoomCard extends HTMLElement {
           }
         }
       }
-
-      // Move sub-chips out of btn-top to top or bottom of button based on chips_position
-      const chipsEl = topDiv.querySelector(".btn-chips");
-      if (chipsEl) {
+      const chipsEl2 = topDiv.querySelector(".btn-chips");
+      if (chipsEl2) {
         if (chipsPos === "top") {
-          btn.insertBefore(chipsEl, topDiv);
+          btn.insertBefore(chipsEl2, topDiv);
         } else {
-          btn.appendChild(chipsEl);
+          btn.appendChild(chipsEl2);
         }
       }
     } else {
       btn.classList.remove("has-inline-ctrl");
     }
     if (focusedControlKey && !this.controls?.hasAttribute("inert")) {
-      const replacement = Array.from(btn.querySelectorAll("[data-rc-focus-key]"))
-        .find((element) => element.dataset.rcFocusKey === focusedControlKey);
+      const replacement = Array.from(btn.querySelectorAll("[data-rc-focus-key]")).find((element) => element.dataset.rcFocusKey === focusedControlKey);
       replacement?.focus();
     }
   }
-
   _attachActions(node, ctrl) {
     if (ctrl.type === "template") {
       node.style.cursor = "default";
@@ -4023,34 +4443,53 @@ class OneLineRoomCard extends HTMLElement {
     let timer = null, held = false, holdTimer = null;
     let startX = 0, isDragging = false;
     const trackTimeout = (fn, ms) => {
-      const id = setTimeout(() => { this._activeTimers.delete(id); fn(); }, ms);
+      const id = setTimeout(() => {
+        this._activeTimers.delete(id);
+        fn();
+      }, ms);
       this._activeTimers.add(id);
       return id;
     };
-    const cancelTimeout = (id) => { clearTimeout(id); this._activeTimers.delete(id); };
+    const cancelTimeout = (id) => {
+      clearTimeout(id);
+      this._activeTimers.delete(id);
+    };
     const triggerTap = () => {
       if (this._isEntityUnavailable(ctrl.entity) || held) return;
       if (config.double_tap_action.action !== "none") {
-        if (timer) { cancelTimeout(timer); timer = null; this._fireAction("double_tap", config); }
-        else { timer = trackTimeout(() => { timer = null; this._fireAction("tap", config); }, 250); }
-      } else { this._fireAction("tap", config); }
+        if (timer) {
+          cancelTimeout(timer);
+          timer = null;
+          this._fireAction("double_tap", config);
+        } else {
+          timer = trackTimeout(() => {
+            timer = null;
+            this._fireAction("tap", config);
+          }, 250);
+        }
+      } else {
+        this._fireAction("tap", config);
+      }
     };
     node.addEventListener("pointerdown", (e) => {
       if (this._isEntityUnavailable(ctrl.entity)) return;
       startX = e.clientX;
       isDragging = false;
       held = false;
-      holdTimer = trackTimeout(() => { if (!isDragging) { held = true; this._fireAction("hold", config); } }, 500);
+      holdTimer = trackTimeout(() => {
+        if (!isDragging) {
+          held = true;
+          this._fireAction("hold", config);
+        }
+      }, 500);
     });
     node.addEventListener("pointermove", (e) => {
       if (!startX || !this._hass || this._isEntityUnavailable(ctrl.entity)) return;
-      const domain = ctrl.entity.split(".")[0];
+      const domain2 = ctrl.entity.split(".")[0];
       const st = this._hass.states[ctrl.entity];
-      const sliderCaps = this._getSliderCapabilities(domain, st, ctrl);
+      const sliderCaps = this._getSliderCapabilities(domain2, st, ctrl);
       const isBgSlider = ctrl.control_mode === "slider" && ctrl.slider_style === "background" && sliderCaps.supported;
-
       if (!isBgSlider) return;
-
       const dx = Math.abs(e.clientX - startX);
       if (dx > 10) {
         if (!isDragging) {
@@ -4059,28 +4498,29 @@ class OneLineRoomCard extends HTMLElement {
           if (holdTimer) cancelTimeout(holdTimer);
         }
         const rect = node.getBoundingClientRect();
-        let pct = ((e.clientX - rect.left) / rect.width) * 100;
+        let pct = (e.clientX - rect.left) / rect.width * 100;
         pct = Math.max(0, Math.min(100, pct));
         const bgNode = node.querySelector(".bg-slider-fill");
         if (bgNode) bgNode.style.width = `${pct}%`;
       }
     });
-
     const cancel = (e) => {
-      if (holdTimer) { cancelTimeout(holdTimer); holdTimer = null; }
+      if (holdTimer) {
+        cancelTimeout(holdTimer);
+        holdTimer = null;
+      }
       if (isDragging && e && e.type === "pointerup" && this._hass && ctrl.control_mode === "slider" && ctrl.slider_style === "background") {
-        const domain = ctrl.entity.split(".")[0];
+        const domain2 = ctrl.entity.split(".")[0];
         const st = this._hass.states[ctrl.entity];
-        const sliderCaps = this._getSliderCapabilities(domain, st, ctrl);
+        const sliderCaps = this._getSliderCapabilities(domain2, st, ctrl);
         if (sliderCaps.supported) {
           const rect = node.getBoundingClientRect();
-          let pct = ((e.clientX - rect.left) / rect.width);
+          let pct = (e.clientX - rect.left) / rect.width;
           pct = Math.max(0, Math.min(1, pct));
           let v = sliderCaps.min + pct * (sliderCaps.max - sliderCaps.min);
           v = Math.round(v / sliderCaps.step) * sliderCaps.step;
-
           if (sliderCaps.action === "color_temp") {
-            this._hass.callService("light", "turn_on", { entity_id: ctrl.entity, color_temp_kelvin: Math.round(1000000 / v) });
+            this._hass.callService("light", "turn_on", { entity_id: ctrl.entity, color_temp_kelvin: Math.round(1e6 / v) });
           } else if (sliderCaps.action === "color_temp_kelvin") {
             this._hass.callService("light", "turn_on", { entity_id: ctrl.entity, color_temp_kelvin: Math.round(v) });
           } else if (sliderCaps.action === "brightness") {
@@ -4094,7 +4534,7 @@ class OneLineRoomCard extends HTMLElement {
           } else if (sliderCaps.action === "volume_level") {
             this._hass.callService("media_player", "volume_set", { entity_id: ctrl.entity, volume_level: v / 100 });
           } else if (sliderCaps.action === "value") {
-            this._hass.callService(domain, "set_value", { entity_id: ctrl.entity, value: v });
+            this._hass.callService(domain2, "set_value", { entity_id: ctrl.entity, value: v });
           }
         }
       }
@@ -4114,19 +4554,27 @@ class OneLineRoomCard extends HTMLElement {
       e.preventDefault();
       held = false;
       if (config.hold_action.action !== "none") {
-        holdTimer = trackTimeout(() => { held = true; this._fireAction("hold", config); }, 500);
+        holdTimer = trackTimeout(() => {
+          held = true;
+          this._fireAction("hold", config);
+        }, 500);
       }
     });
     node.addEventListener("keyup", (e) => {
       if (e.target !== node || !["Enter", " "].includes(e.key) || this._isEntityUnavailable(ctrl.entity)) return;
       e.preventDefault();
-      if (holdTimer) { cancelTimeout(holdTimer); holdTimer = null; }
-      if (held) { held = false; return; }
+      if (holdTimer) {
+        cancelTimeout(holdTimer);
+        holdTimer = null;
+      }
+      if (held) {
+        held = false;
+        return;
+      }
       triggerTap();
     });
     node.addEventListener("blur", cancel);
   }
-
   _attachHeaderActions(node) {
     const getActionContext = () => {
       const config = this.config || {};
@@ -4138,40 +4586,68 @@ class OneLineRoomCard extends HTMLElement {
           hold_action: config.hold_action || { action: "none" },
           double_tap_action: config.double_tap_action || { action: "none" }
         },
-        hasExplicitTap: config.tap_action !== undefined
+        hasExplicitTap: config.tap_action !== void 0
       };
     };
     node.style.touchAction = "manipulation";
     let timer = null, held = false, holdTimer = null;
     const trackTimeout = (fn, ms) => {
-      const id = setTimeout(() => { this._activeTimers.delete(id); fn(); }, ms);
+      const id = setTimeout(() => {
+        this._activeTimers.delete(id);
+        fn();
+      }, ms);
       this._activeTimers.add(id);
       return id;
     };
-    const cancelTimeout = (id) => { clearTimeout(id); this._activeTimers.delete(id); };
+    const cancelTimeout = (id) => {
+      clearTimeout(id);
+      this._activeTimers.delete(id);
+    };
     const handleTap = () => {
       const { cardConfig, actionConfig, hasExplicitTap } = getActionContext();
-      if (!hasExplicitTap && cardConfig.collapsible === true) { this._toggleCollapse(); return; }
+      if (!hasExplicitTap && cardConfig.collapsible === true) {
+        this._toggleCollapse();
+        return;
+      }
       this._fireAction("tap", actionConfig);
     };
     const cancel = () => {
-      if (holdTimer) { cancelTimeout(holdTimer); holdTimer = null; }
+      if (holdTimer) {
+        cancelTimeout(holdTimer);
+        holdTimer = null;
+      }
     };
     node.addEventListener("pointerdown", () => {
       held = false;
       const { actionConfig } = getActionContext();
       if (actionConfig.hold_action?.action !== "none") {
-        holdTimer = trackTimeout(() => { held = true; this._fireAction("hold", actionConfig); }, 500);
+        holdTimer = trackTimeout(() => {
+          held = true;
+          this._fireAction("hold", actionConfig);
+        }, 500);
       }
     });
     node.addEventListener("pointerup", (e) => {
       if (holdTimer) cancelTimeout(holdTimer);
-      if (held) { held = false; return; }
+      if (held) {
+        held = false;
+        return;
+      }
       const { actionConfig } = getActionContext();
       if (actionConfig.double_tap_action.action !== "none") {
-        if (timer) { cancelTimeout(timer); timer = null; this._fireAction("double_tap", actionConfig); }
-        else { timer = trackTimeout(() => { timer = null; handleTap(); }, 250); }
-      } else { handleTap(); }
+        if (timer) {
+          cancelTimeout(timer);
+          timer = null;
+          this._fireAction("double_tap", actionConfig);
+        } else {
+          timer = trackTimeout(() => {
+            timer = null;
+            handleTap();
+          }, 250);
+        }
+      } else {
+        handleTap();
+      }
     });
     node.addEventListener("pointerleave", cancel);
     node.addEventListener("pointercancel", cancel);
@@ -4181,28 +4657,46 @@ class OneLineRoomCard extends HTMLElement {
       held = false;
       const { actionConfig } = getActionContext();
       if (actionConfig.hold_action?.action !== "none") {
-        holdTimer = trackTimeout(() => { held = true; this._fireAction("hold", actionConfig); }, 500);
+        holdTimer = trackTimeout(() => {
+          held = true;
+          this._fireAction("hold", actionConfig);
+        }, 500);
       }
     });
     node.addEventListener("keyup", (e) => {
       if (e.target !== node || !["Enter", " "].includes(e.key)) return;
       e.preventDefault();
-      if (holdTimer) { cancelTimeout(holdTimer); holdTimer = null; }
-      if (held) { held = false; return; }
+      if (holdTimer) {
+        cancelTimeout(holdTimer);
+        holdTimer = null;
+      }
+      if (held) {
+        held = false;
+        return;
+      }
       const { actionConfig } = getActionContext();
       if (actionConfig.double_tap_action.action !== "none") {
-        if (timer) { cancelTimeout(timer); timer = null; this._fireAction("double_tap", actionConfig); }
-        else { timer = trackTimeout(() => { timer = null; handleTap(); }, 250); }
-      } else { handleTap(); }
+        if (timer) {
+          cancelTimeout(timer);
+          timer = null;
+          this._fireAction("double_tap", actionConfig);
+        } else {
+          timer = trackTimeout(() => {
+            timer = null;
+            handleTap();
+          }, 250);
+        }
+      } else {
+        handleTap();
+      }
     });
     node.addEventListener("blur", cancel);
   }
-
   _fireAction(type, config) {
     if (config.entity && this._isEntityUnavailable(config.entity)) return;
     const actionKey = `${type}_action`;
     let actionConfig = config[actionKey] || {};
-    if (!actionConfig || typeof actionConfig !== 'object') actionConfig = { action: 'none' };
+    if (!actionConfig || typeof actionConfig !== "object") actionConfig = { action: "none" };
     if (!actionConfig.action) actionConfig.action = "none";
     if (actionConfig.action === "toggle" && config.entity) {
       const targetEntity = actionConfig.target?.entity_id || config.entity;
@@ -4210,13 +4704,11 @@ class OneLineRoomCard extends HTMLElement {
       if (domain === "climate" && this._hass) {
         const state = this._hass.states[targetEntity];
         if (state) {
-          actionConfig = !isEntityOff(state)
-            ? { action: "call-service", service: "climate.set_hvac_mode", data: { hvac_mode: STATE_DEFINITIONS.INACTIVE_STATES.off }, target: { entity_id: targetEntity } }
-            : { action: "call-service", service: "climate.turn_on", target: { entity_id: targetEntity } };
+          actionConfig = !isEntityOff(state) ? { action: "call-service", service: "climate.set_hvac_mode", data: { hvac_mode: STATE_DEFINITIONS.INACTIVE_STATES.off }, target: { entity_id: targetEntity } } : { action: "call-service", service: "climate.turn_on", target: { entity_id: targetEntity } };
         }
       }
     }
-const eventDetail = {
+    const eventDetail = {
       config: {
         entity: actionConfig.target?.entity_id || config.entity,
         [actionKey]: actionConfig
@@ -4225,33 +4717,27 @@ const eventDetail = {
     };
     this.dispatchEvent(new CustomEvent("hass-action", { bubbles: true, composed: true, detail: eventDetail }));
   }
-
   _toggleCollapse() {
     this._collapsed = !this._collapsed;
     if (this._collapseKey && this.config?.remember_state !== false) localStorage.setItem(this._collapseKey, this._collapsed ? "1" : "0");
     this._syncCollapseUI();
   }
-
   _iconForBadgeDomain(entityId) {
     const domain = entityId?.split(".")[0] || "";
     const defaults = { light: "mdi:lightbulb", switch: "mdi:toggle-switch", binary_sensor: "mdi:checkbox-marked-circle-outline", motion: "mdi:motion-sensor", door: "mdi:door", window: "mdi:window-open-variant", sensor: "mdi:gauge", lock: "mdi:lock", cover: "mdi:window-shutter" };
     return defaults[domain] || "mdi:information-outline";
   }
-
   _nav() {
     if (this.config.tap_action?.action === "navigate" && this.config.tap_action?.navigation_path) {
       history.pushState(null, "", this.config.tap_action.navigation_path);
       window.dispatchEvent(new Event("location-changed", { bubbles: true, composed: true }));
     }
   }
-
-  static getConfigElement() { return document.createElement("oneline-room-card-editor"); }
-}
-
-// =============================================================================
-// EDITOR CLASS
-// =============================================================================
-class OneLineRoomCardEditor extends HTMLElement {
+  static getConfigElement() {
+    return document.createElement("oneline-room-card-editor");
+  }
+};
+var OneLineRoomCardEditor = class extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: "open" });
@@ -4280,28 +4766,16 @@ class OneLineRoomCardEditor extends HTMLElement {
     this._uploading = false;
     this._boundHandlePrimarySave = (ev) => this._handlePrimarySave(ev);
   }
-
-connectedCallback() {
+  connectedCallback() {
     document.addEventListener("click", this._boundHandlePrimarySave, true);
-    
-    // FIX: Dropdowns zwingen, den neuen Wert optisch zu behalten
     this.addEventListener("value-changed", (ev) => {
-      // ev.composedPath()[0] findet das ECHTE Element, auch tief im Shadow-DOM
       const target = ev.composedPath()[0];
-      
       if (target && target.tagName) {
         const tag = target.tagName.toUpperCase();
-        
-        // Gilt für alle Selektoren und Picker in deiner Card
         if (tag === "HA-SELECTOR" || tag === "HA-ENTITY-PICKER" || tag === "HA-ICON-PICKER") {
-          if (ev.detail && ev.detail.value !== undefined) {
+          if (ev.detail && ev.detail.value !== void 0) {
             const newVal = ev.detail.value;
-            
-            // 1. Wert sofort hart setzen
             target.value = newVal;
-            
-            // 2. Den Wert im nächsten Frame nochmal setzen, 
-            // falls das Lit-Framework ihn im Hintergrund überschreiben wollte
             requestAnimationFrame(() => {
               if (target.value !== newVal) {
                 target.value = newVal;
@@ -4310,29 +4784,24 @@ connectedCallback() {
           }
         }
       }
-    }, true); // "true" fängt das Event ab, BEVOR es verarbeitet wird
+    }, true);
   }
-
   disconnectedCallback() {
     document.removeEventListener("click", this._boundHandlePrimarySave, true);
     clearTimeout(this._tm);
   }
-
   _ensureEditorState() {
     if (typeof this._livePreview !== "boolean") this._livePreview = true;
-    if (this._pendingConfig === undefined) this._pendingConfig = null;
+    if (this._pendingConfig === void 0) this._pendingConfig = null;
   }
-
   setConfig(config) {
     this._ensureEditorState();
     const incoming = config || {};
     const incomingSig = JSON.stringify(incoming);
-    // Skip re-render if the config hasn't actually changed
     if (this._lastFiredConfigSig && incomingSig === this._lastFiredConfigSig) {
       this._config = incoming;
       if (!Array.isArray(this._config.controls)) this._config = { ...this._config, controls: [] };
       this._syncControlIds();
-
       this.updVal();
       return;
     }
@@ -4341,13 +4810,17 @@ connectedCallback() {
     this._syncControlIds();
     this.render();
   }
-
   set hass(hass) {
     const upd = this._hass?.language !== hass?.language;
     this._hass = hass;
-    if (upd) { this._controlTemplatesCache = null; this._navOptionsLoaded = false; this.render(); return; }
+    if (upd) {
+      this._controlTemplatesCache = null;
+      this._navOptionsLoaded = false;
+      this.render();
+      return;
+    }
     if (this.shadowRoot) {
-      this.shadowRoot.querySelectorAll("ha-selector,ha-entity-picker,ha-icon-picker,oneline-room-card-textfield,ha-switch,ha-card-conditions-editor").forEach(e => {
+      this.shadowRoot.querySelectorAll("ha-selector,ha-entity-picker,ha-icon-picker,oneline-room-card-textfield,ha-switch,ha-card-conditions-editor").forEach((e) => {
         if (e.hass !== hass) e.hass = hass;
       });
       this.updPreview();
@@ -4358,7 +4831,6 @@ connectedCallback() {
       }
     }
   }
-
   _fire(config) {
     this._ensureEditorState();
     this._config = config;
@@ -4373,12 +4845,10 @@ connectedCallback() {
       this.dispatchEvent(new CustomEvent("config-changed", { detail: { config }, bubbles: true, composed: true }));
     }, 100);
   }
-
   _emitConfigNow(config) {
     clearTimeout(this._tm);
     this.dispatchEvent(new CustomEvent("config-changed", { detail: { config }, bubbles: true, composed: true }));
   }
-
   _flushPendingConfig() {
     this._ensureEditorState();
     if (!this._pendingConfig) return;
@@ -4386,7 +4856,6 @@ connectedCallback() {
     this._pendingConfig = null;
     this._emitConfigNow(cfg);
   }
-
   _handlePrimarySave(ev) {
     if (this._livePreview) return;
     const path = typeof ev.composedPath === "function" ? ev.composedPath() : [ev.target];
@@ -4396,19 +4865,16 @@ connectedCallback() {
     if (!saveBtn || saveBtn.disabled) return;
     this._flushPendingConfig();
   }
-
   _makeControlId() {
     const id = `c${this._nextControlId}`;
     this._nextControlId += 1;
     return id;
   }
-
   _syncControlIds() {
     const len = Array.isArray(this._config?.controls) ? this._config.controls.length : 0;
     while (this._controlIds.length < len) this._controlIds.push(this._makeControlId());
     if (this._controlIds.length > len) this._controlIds.length = len;
   }
-
   _areAllButtonsExpanded() {
     const controls = Array.isArray(this._config?.controls) ? this._config.controls : [];
     if (controls.length === 0) return false;
@@ -4419,7 +4885,6 @@ connectedCallback() {
       return this._collapsedState[key] !== true;
     });
   }
-
   _toggleAllButtonsExpanded(expand) {
     const controls = Array.isArray(this._config?.controls) ? this._config.controls : [];
     this._collapsedState = this._collapsedState || {};
@@ -4430,7 +4895,6 @@ connectedCallback() {
     this.renBtn();
     this._updateBulkToggleButton();
   }
-
   _updateBulkToggleButton() {
     const btn = this.shadowRoot?.getElementById("bulk-toggle");
     if (!btn) return;
@@ -4443,7 +4907,6 @@ connectedCallback() {
     if (ic) ic.setAttribute("icon", icon);
     btn.setAttribute("title", label);
   }
-
   _setUploadStatus(key = "", { error = false, status = "" } = {}) {
     const button = this.shadowRoot?.getElementById("upload-btn");
     const statusNode = this.shadowRoot?.getElementById("upload-status");
@@ -4457,14 +4920,12 @@ connectedCallback() {
       statusNode.classList.toggle("error", error);
     }
   }
-
   async _decodeImageFile(file) {
     if (typeof createImageBitmap === "function") {
       try {
         const bitmap = await createImageBitmap(file);
         return { source: bitmap, width: bitmap.width, height: bitmap.height, close: () => bitmap.close?.() };
       } catch (_err) {
-        // Fall back to an object URL for browsers without full ImageBitmap support.
       }
     }
     const objectUrl = URL.createObjectURL(file);
@@ -4482,13 +4943,11 @@ connectedCallback() {
       throw error;
     }
   }
-
   _canvasToBlob(canvas, type, quality) {
     return new Promise((resolve, reject) => {
       canvas.toBlob((blob) => blob ? resolve(blob) : reject(new Error("encode")), type, quality);
     });
   }
-
   async _prepareImageUpload(file) {
     const validationError = validateImageUpload(file);
     if (validationError) throw Object.assign(new Error(validationError), { translationKey: validationError });
@@ -4519,7 +4978,6 @@ connectedCallback() {
       decoded?.close?.();
     }
   }
-
   async _handleUpload(e) {
     const file = e.target.files?.[0];
     if (!file || !this._hass || this._uploading) return;
@@ -4540,11 +4998,13 @@ connectedCallback() {
       this._setUploadStatus(err?.translationKey || "upload_failed", { error: true, status: err?.status || "unknown" });
     } finally {
       this._uploading = false;
-      if (fileInput) { fileInput.disabled = false; fileInput.value = ""; }
+      if (fileInput) {
+        fileInput.disabled = false;
+        fileInput.value = "";
+      }
       this._setUploadStatus(null);
     }
   }
-
   async _uploadImageFile(file) {
     const prepared = await this._prepareImageUpload(file);
     const formData = new FormData();
@@ -4555,7 +5015,6 @@ connectedCallback() {
     if (!data?.id) throw Object.assign(new Error("upload"), { translationKey: "upload_failed", status: "invalid response" });
     return { url: `/api/image/serve/${data.id}/original`, optimized: prepared.optimized };
   }
-
   _applyNavSelectorOptions() {
     const options = Array.isArray(this._navOptions) ? this._navOptions : [];
     const applyTo = (id, value) => {
@@ -4569,7 +5028,6 @@ connectedCallback() {
     applyTo("hold-nav-path", this._config?.hold_action?.navigation_path);
     applyTo("dbl-nav-path", this._config?.double_tap_action?.navigation_path);
   }
-
   _defaultIconForDomain(domain) {
     const map = {
       light: "mdi:lightbulb",
@@ -4589,7 +5047,6 @@ connectedCallback() {
     };
     return map[domain] || "mdi:help-circle-outline";
   }
-
   _getControlTemplates() {
     const lang = this._hass?.language?.split("-")[0] || "en";
     if (this._controlTemplatesCache?.lang === lang) return this._controlTemplatesCache.templates;
@@ -4701,20 +5158,16 @@ connectedCallback() {
     this._controlTemplatesCache = { lang, templates };
     return templates;
   }
-
   _getTemplateById(templateId) {
     const templates = this._getControlTemplates();
     return templates.find((t) => t.id === templateId);
   }
-
   _buildControlFromTemplate(template, entityId) {
     const st = this._hass?.states?.[entityId];
     const name = st?.attributes?.friendly_name || "";
     const domain = entityId?.split(".")[0] || "";
     const defaults = template?.defaults || {};
-    const iconField = DOMAIN_STATE_ICON_MAPS[domain]
-      ? {}
-      : { icon: st?.attributes?.icon || template?.defaults?.icon || this._iconForEntity(entityId) };
+    const iconField = DOMAIN_STATE_ICON_MAPS[domain] ? {} : { icon: st?.attributes?.icon || template?.defaults?.icon || this._iconForEntity(entityId) };
     return {
       entity: entityId || "",
       name,
@@ -4730,7 +5183,6 @@ connectedCallback() {
       double_tap_action: defaults.double_tap_action || { action: "none" }
     };
   }
-
   async _getAreaEntities(areaId) {
     if (!this._hass || !areaId) return [];
     try {
@@ -4738,7 +5190,7 @@ connectedCallback() {
       const areaDevices = (Array.isArray(devices) ? devices : []).filter(
         (d) => d.area_id === areaId && !d.disabled_by
       );
-      const deviceIds = new Set(areaDevices.map(d => d.id));
+      const deviceIds = new Set(areaDevices.map((d) => d.id));
       const entries = await this._hass.callWS({ type: "config/entity_registry/list" });
       return (Array.isArray(entries) ? entries : []).filter(
         (e) => !e.disabled_by && (e.area_id === areaId || deviceIds.has(e.device_id))
@@ -4748,15 +5200,13 @@ connectedCallback() {
       return [];
     }
   }
-
   _findFirstEntityByDomain(entities, domain) {
     if (!Array.isArray(entities)) return null;
-    return entities.find(e => e.entity_id?.startsWith(`${domain}.`)) || null;
+    return entities.find((e) => e.entity_id?.startsWith(`${domain}.`)) || null;
   }
-
   _groupEntitiesByDomain(entities) {
     const grouped = {};
-    (Array.isArray(entities) ? entities : []).forEach(e => {
+    (Array.isArray(entities) ? entities : []).forEach((e) => {
       const domain = e.entity_id?.split(".")?.[0];
       if (!domain) return;
       if (!grouped[domain]) grouped[domain] = [];
@@ -4764,7 +5214,6 @@ connectedCallback() {
     });
     return grouped;
   }
-
   _buildControlsFromEntities(entitiesByDomain) {
     if (!entitiesByDomain || typeof entitiesByDomain !== "object") return [];
     const preferredDomainOrder = ["light", "switch", "cover", "fan", "media_player", "lock"];
@@ -4780,35 +5229,27 @@ connectedCallback() {
     }
     return controls;
   }
-
   _resolveTemperatureSensor(climateEntity, entities) {
     if (!Array.isArray(entities)) return null;
-    const tempSensors = entities.filter(e =>
-      (e.entity_id?.startsWith("sensor.") || e.entity_id?.startsWith("input_number.")) &&
-      (e.device_class === "temperature" || e.entity_id?.toLowerCase().includes("temp"))
+    const tempSensors = entities.filter(
+      (e) => (e.entity_id?.startsWith("sensor.") || e.entity_id?.startsWith("input_number.")) && (e.device_class === "temperature" || e.entity_id?.toLowerCase().includes("temp"))
     );
     return tempSensors[0] || null;
   }
-
   _resolveHumiditySensor(climateEntity, entities) {
     if (!Array.isArray(entities)) return null;
-    const humidSensors = entities.filter(e =>
-      (e.entity_id?.startsWith("sensor.") || e.entity_id?.startsWith("input_number.")) &&
-      (e.device_class === "humidity" || e.entity_id?.toLowerCase().includes("humid"))
+    const humidSensors = entities.filter(
+      (e) => (e.entity_id?.startsWith("sensor.") || e.entity_id?.startsWith("input_number.")) && (e.device_class === "humidity" || e.entity_id?.toLowerCase().includes("humid"))
     );
     return humidSensors[0] || null;
   }
-
   _findSensorsByDeviceClass(entities, deviceClasses, domains = ["binary_sensor", "sensor"]) {
     if (!Array.isArray(entities) || !Array.isArray(deviceClasses)) return [];
-    return entities
-      .filter(e => {
-        const eDomain = e.entity_id?.split(".")?.[0];
-        return domains.includes(eDomain) && deviceClasses.includes(e.device_class);
-      })
-      .map(e => e.entity_id);
+    return entities.filter((e) => {
+      const eDomain = e.entity_id?.split(".")?.[0];
+      return domains.includes(eDomain) && deviceClasses.includes(e.device_class);
+    }).map((e) => e.entity_id);
   }
-
   async _generateFromArea(areaId) {
     if (!areaId || !this._hass) return;
     try {
@@ -4829,23 +5270,21 @@ connectedCallback() {
         entity: climateEntity?.entity_id || (this._config.entity || ""),
         temp_sensor: tempSensor?.entity_id || (this._config.temp_sensor || ""),
         humid_sensor: humidSensor?.entity_id || (this._config.humid_sensor || ""),
-        window_sensors: windowSensors.length > 0 ? windowSensors : (this._config.window_sensors || []),
-        battery_sensors: batterySensors.length > 0 ? batterySensors : (this._config.battery_sensors || []),
-        controls: [...(this._config.controls || []), ...controls]
+        window_sensors: windowSensors.length > 0 ? windowSensors : this._config.window_sensors || [],
+        battery_sensors: batterySensors.length > 0 ? batterySensors : this._config.battery_sensors || [],
+        controls: [...this._config.controls || [], ...controls]
       };
       this._fire(newConfig);
     } catch (err) {
       console.error("Error generating from area:", err);
     }
   }
-
   _ensureAreaOptions() {
     const areaPicker = this.shadowRoot?.getElementById("area-picker");
     if (!areaPicker) return;
     areaPicker.hass = this._hass;
     if (!areaPicker.selector) areaPicker.selector = { area: {} };
   }
-
   _updateAreaSetupUI() {
     const content = this.shadowRoot?.getElementById("area-setup-content");
     const chev = this.shadowRoot?.getElementById("area-setup-chev");
@@ -4853,7 +5292,6 @@ connectedCallback() {
     if (chev) chev.style.transform = this._areaSelectorOpen ? "rotate(90deg)" : "";
     if (this._areaSelectorOpen) this._ensureAreaOptions();
   }
-
   _iconForEntity(entityId) {
     if (!this._hass || !entityId) return "mdi:help-circle-outline";
     const st = this._hass.states[entityId];
@@ -4861,7 +5299,6 @@ connectedCallback() {
     const domain = entityId.split(".")[0];
     return this._defaultIconForDomain(domain);
   }
-
   async _resolveEntityFromDevice(deviceId) {
     if (!this._hass || !deviceId) return;
     try {
@@ -4880,18 +5317,15 @@ connectedCallback() {
       return null;
     }
   }
-
   async _ensureNavOptions() {
     if (!this._hass || this._navOptionsLoaded) return;
     this._navOptionsLoaded = true;
     try {
-      const optionsMap = new Map();
-
+      const optionsMap = /* @__PURE__ */ new Map();
       const addOption = (value, label) => {
         if (!value || optionsMap.has(value)) return;
         optionsMap.set(value, { value, label: label || value });
       };
-
       const addPanelViews = (panel, config) => {
         const panelPath = panel?.url_path || "lovelace";
         const panelLabel = panel?.title || panelPath;
@@ -4904,14 +5338,12 @@ connectedCallback() {
           addOption(fullPath, `${panelLabel} / ${viewLabel}`);
         });
       };
-
       try {
         const cfg = await this._hass.connection.sendMessagePromise({ type: "lovelace/config" });
         addPanelViews({ url_path: "lovelace", title: "Lovelace" }, cfg);
       } catch (err) {
         addOption("/lovelace", "Lovelace (/lovelace)");
       }
-
       let dashboards = [];
       try {
         const dashResp = await this._hass.connection.sendMessagePromise({ type: "lovelace/dashboards" });
@@ -4920,46 +5352,57 @@ connectedCallback() {
       } catch (err) {
         dashboards = [];
       }
-
       if (dashboards.length === 0) {
-        const lovelacePanels = Object.values(this._hass.panels || {}).filter(p => p.component_name === "lovelace");
-        dashboards = lovelacePanels.map(p => ({ url_path: p.url_path, title: p.title || p.url_path, default: p?.url_path === "lovelace" }));
+        const lovelacePanels = Object.values(this._hass.panels || {}).filter((p) => p.component_name === "lovelace");
+        dashboards = lovelacePanels.map((p) => ({ url_path: p.url_path, title: p.title || p.url_path, default: p?.url_path === "lovelace" }));
       }
-
       if (dashboards.length > 0) {
         for (const dash of dashboards) {
-          const isDefault = dash?.default || dash?.url_path === undefined || dash?.url_path === null || dash?.url_path === "";
+          const isDefault = dash?.default || dash?.url_path === void 0 || dash?.url_path === null || dash?.url_path === "";
           const urlPath = isDefault ? "lovelace" : dash.url_path;
           const title = dash.title || urlPath;
           try {
-            const cfg = isDefault
-              ? await this._hass.connection.sendMessagePromise({ type: "lovelace/config" })
-              : await this._hass.connection.sendMessagePromise({ type: "lovelace/config", url_path: urlPath });
+            const cfg = isDefault ? await this._hass.connection.sendMessagePromise({ type: "lovelace/config" }) : await this._hass.connection.sendMessagePromise({ type: "lovelace/config", url_path: urlPath });
             addPanelViews({ url_path: urlPath, title }, cfg);
           } catch (err) {
             addOption(`/${urlPath}`, `${title} (${`/${urlPath}`})`);
           }
         }
       }
-
       this._navOptions = Array.from(optionsMap.values());
       this._applyNavSelectorOptions();
     } catch (err) {
       this._navOptionsLoaded = false;
     }
   }
-
   render() {
     this._ensureEditorState();
     if (!this._config) return;
     const alreadyRendered = !!this.shadowRoot.innerHTML;
     const domRevision = this.shadowRoot.querySelector("[data-rc-dom-revision]")?.dataset?.rcDomRevision;
-    if (alreadyRendered && domRevision === EDITOR_DOM_REVISION) { this.updVal(); if (JSON.stringify(this._config?.controls || []) !== this._lastRenderedControlsSig) this.renBtn(); this._applyNavSelectorOptions(); this._ensureNavOptions(); this._ensureAreaOptions(); this._updateAreaSetupUI(); this._updateSensorsSectionUI(); this._updateSparklineRefreshUI(); this._updateImageSectionUI(); this._updateAdaptiveImagesUI(); this._updateBadgesUI(); this._updateTypographyUI(); this._updateCardBehaviorUI(); this._updateActionsSectionUI(); this._updateRoomModesUI(); this._updateStatusGroupsUI(); this._updateHeaderSectionUI(); this._updateTabUI(); return; }
-    
+    if (alreadyRendered && domRevision === EDITOR_DOM_REVISION) {
+      this.updVal();
+      if (JSON.stringify(this._config?.controls || []) !== this._lastRenderedControlsSig) this.renBtn();
+      this._applyNavSelectorOptions();
+      this._ensureNavOptions();
+      this._ensureAreaOptions();
+      this._updateAreaSetupUI();
+      this._updateSensorsSectionUI();
+      this._updateSparklineRefreshUI();
+      this._updateImageSectionUI();
+      this._updateAdaptiveImagesUI();
+      this._updateBadgesUI();
+      this._updateTypographyUI();
+      this._updateCardBehaviorUI();
+      this._updateActionsSectionUI();
+      this._updateRoomModesUI();
+      this._updateStatusGroupsUI();
+      this._updateHeaderSectionUI();
+      this._updateTabUI();
+      return;
+    }
     this.shadowRoot.replaceChildren();
     const h = this._hass;
-    // Static editor scaffold: interpolations are package translations and normalized
-    // editor state. Configuration/entity text is assigned later through DOM properties.
     this.shadowRoot.innerHTML = `
       <style>
         .sec { padding: 12px 0; border-bottom: 1px solid var(--divider-color); }
@@ -5590,7 +6033,6 @@ connectedCallback() {
         </mwc-button>
       </div>
       </div>`;
-
     const tabConfigBtn = this.shadowRoot.getElementById("tab-config-btn");
     const tabButtonsBtn = this.shadowRoot.getElementById("tab-buttons-btn");
     if (tabConfigBtn) {
@@ -5616,7 +6058,7 @@ connectedCallback() {
     if (adaptiveImagesAdd) {
       adaptiveImagesAdd.addEventListener("click", (event) => {
         event.stopPropagation();
-        const rules = [...(Array.isArray(this._config?.adaptive_images) ? this._config.adaptive_images : []), { conditions: [] }];
+        const rules = [...Array.isArray(this._config?.adaptive_images) ? this._config.adaptive_images : [], { conditions: [] }];
         this._fire({ ...this._config, adaptive_images: rules });
         this._updateAdaptiveImagesUI();
       });
@@ -5672,7 +6114,7 @@ connectedCallback() {
     const roomModesAdd = this.shadowRoot.getElementById("room-modes-add");
     if (roomModesAdd) {
       roomModesAdd.addEventListener("click", () => {
-        const roomModes = [...(Array.isArray(this._config?.room_modes) ? this._config.room_modes : []), { entity: "" }];
+        const roomModes = [...Array.isArray(this._config?.room_modes) ? this._config.room_modes : [], { entity: "" }];
         this._roomModesSectionOpen = true;
         this._fire({ ...this._config, room_modes: roomModes });
         this._updateRoomModesUI();
@@ -5686,7 +6128,7 @@ connectedCallback() {
       });
     }
     const addStatusGroup = (group) => {
-      const groups = [...(Array.isArray(this._config?.status_groups) ? this._config.status_groups : []), group];
+      const groups = [...Array.isArray(this._config?.status_groups) ? this._config.status_groups : [], group];
       this._statusGroupsSectionOpen = true;
       this._fire({ ...this._config, status_groups: groups });
       this._updateStatusGroupsUI();
@@ -5730,17 +6172,15 @@ connectedCallback() {
         this._updateTypographyUI();
       });
     }
-
-    const weightOptions = ["normal", "bold", "100", "200", "300", "400", "500", "600", "700", "800", "900"].map(v => ({ value: v, label: v }));
+    const weightOptions = ["normal", "bold", "100", "200", "300", "400", "500", "600", "700", "800", "900"].map((v) => ({ value: v, label: v }));
     const styleOptions = [{ value: "normal", label: "Normal" }, { value: "italic", label: "Italic" }];
-
-    ["name", "info"].forEach(type => {
+    ["name", "info"].forEach((type) => {
       const weightSel = this.shadowRoot.getElementById(`header-${type}-weight-sel`);
       if (weightSel) {
         weightSel.hass = h;
         weightSel.selector = { select: { mode: "dropdown", options: weightOptions } };
         weightSel.value = this._config[`header_${type}_weight`] || (type === "name" ? "bold" : "normal");
-        weightSel.addEventListener("value-changed", ev => {
+        weightSel.addEventListener("value-changed", (ev) => {
           ev.stopPropagation();
           this._fire({ ...this._config, [`header_${type}_weight`]: ev.detail.value });
         });
@@ -5750,7 +6190,7 @@ connectedCallback() {
         styleSel.hass = h;
         styleSel.selector = { select: { mode: "dropdown", options: styleOptions } };
         styleSel.value = this._config[`header_${type}_style`] || "normal";
-        styleSel.addEventListener("value-changed", ev => {
+        styleSel.addEventListener("value-changed", (ev) => {
           ev.stopPropagation();
           this._fire({ ...this._config, [`header_${type}_style`]: ev.detail.value });
         });
@@ -5759,7 +6199,7 @@ connectedCallback() {
       const colorPicker = this.shadowRoot.getElementById(`header-${type}-color-picker`);
       if (colorField) {
         colorField.value = this._config[`header_${type}_color`] || "";
-        colorField.addEventListener("change", ev => {
+        colorField.addEventListener("change", (ev) => {
           ev.stopPropagation();
           const val = trimStr(ev.target.value || "");
           const next = { ...this._config };
@@ -5771,7 +6211,7 @@ connectedCallback() {
       }
       if (colorPicker) {
         colorPicker.value = parseColorToPickerHex(this._config[`header_${type}_color`] || "#ffffff");
-        colorPicker.addEventListener("change", ev => {
+        colorPicker.addEventListener("change", (ev) => {
           ev.stopPropagation();
           const val = ev.target.value;
           const next = { ...this._config, [`header_${type}_color`]: val };
@@ -5780,7 +6220,6 @@ connectedCallback() {
         });
       }
     });
-
     const headerTextShadowToggle = this.shadowRoot.getElementById("header-text-shadow-toggle");
     if (headerTextShadowToggle) {
       headerTextShadowToggle.checked = this._config?.show_header_text_shadow !== false;
@@ -5792,7 +6231,6 @@ connectedCallback() {
         this._fire(next);
       });
     }
-
     const tempUnitSel = this.shadowRoot.getElementById("temp-unit-sel");
     if (tempUnitSel) {
       tempUnitSel.hass = h;
@@ -5811,16 +6249,15 @@ connectedCallback() {
         this._fire(next);
       });
     }
-
-    this.shadowRoot.querySelectorAll(".i").forEach(e => {
+    this.shadowRoot.querySelectorAll(".i").forEach((e) => {
       const k = e.getAttribute("cfg");
       if (k === "window_sensors") e.selector = { entity: { domain: ["binary_sensor", "sensor"], multiple: true } };
       else if (k === "battery_sensors") e.selector = { entity: { device_class: "battery", multiple: true } };
       if (this._hass) e.hass = this._hass;
-      const evType = (e.localName === "oneline-room-card-textfield" || e.localName === "input") ? "change" : "value-changed";
+      const evType = e.localName === "oneline-room-card-textfield" || e.localName === "input" ? "change" : "value-changed";
       e.addEventListener(evType, (ev) => {
         ev.stopPropagation();
-        const v = ev.detail?.value !== undefined ? ev.detail.value : ev.target.value;
+        const v = ev.detail?.value !== void 0 ? ev.detail.value : ev.target.value;
         const c = { ...this._config };
         if (k === "humidity_warning_threshold") {
           const raw = v ?? "";
@@ -5829,12 +6266,21 @@ connectedCallback() {
           if (e.value !== String(c[k])) e.value = String(c[k]);
         } else if (k === "header_height") {
           const raw = String(v ?? "").trim();
-          if (raw === "") { delete c[k]; }
-          else { const num = Number(raw); c[k] = Number.isFinite(num) && num >= 0 ? Math.round(num) : 120; }
+          if (raw === "") {
+            delete c[k];
+          } else {
+            const num = Number(raw);
+            c[k] = Number.isFinite(num) && num >= 0 ? Math.round(num) : 120;
+          }
         } else if (k === "header_name_size" || k === "header_info_size") {
           const raw = String(v ?? "").trim();
-          if (raw === "") { delete c[k]; }
-          else { const num = Number(raw); c[k] = Number.isFinite(num) && num > 0 ? Math.round(num) : undefined; if (c[k] === undefined) delete c[k]; }
+          if (raw === "") {
+            delete c[k];
+          } else {
+            const num = Number(raw);
+            c[k] = Number.isFinite(num) && num > 0 ? Math.round(num) : void 0;
+            if (c[k] === void 0) delete c[k];
+          }
         } else if (["presence_sensor_label", "temp_sensor_label", "target_temp_sensor_label", "humid_sensor_label"].includes(k)) {
           const raw = trimStr(v ?? "");
           if (raw) c[k] = raw;
@@ -5946,7 +6392,7 @@ connectedCallback() {
     const windowAlwaysShowToggle = this.shadowRoot.getElementById("window-always-show");
     const windowClosedColorRow = this.shadowRoot.getElementById("window-closed-color-row");
     const syncWindowClosedRow = () => {
-      if (windowClosedColorRow) windowClosedColorRow.style.display = (this._config?.window_always_show === true) ? "flex" : "none";
+      if (windowClosedColorRow) windowClosedColorRow.style.display = this._config?.window_always_show === true ? "flex" : "none";
     };
     if (windowAlwaysShowToggle) {
       windowAlwaysShowToggle.checked = this._config?.window_always_show === true;
@@ -5979,7 +6425,8 @@ connectedCallback() {
         ev.stopPropagation();
         const val = trimStr(ev.target.value || "");
         const next = { ...this._config };
-        if (val) next.window_open_color = val; else delete next.window_open_color;
+        if (val) next.window_open_color = val;
+        else delete next.window_open_color;
         this._fire(next);
         if (windowOpenColorPicker) windowOpenColorPicker.value = parseColorToPickerHex(val || "#FFA000");
       });
@@ -6001,7 +6448,8 @@ connectedCallback() {
         ev.stopPropagation();
         const val = trimStr(ev.target.value || "");
         const next = { ...this._config };
-        if (val) next.window_closed_color = val; else delete next.window_closed_color;
+        if (val) next.window_closed_color = val;
+        else delete next.window_closed_color;
         this._fire(next);
         if (windowClosedColorPicker) windowClosedColorPicker.value = parseColorToPickerHex(val || "#9E9E9E");
       });
@@ -6015,19 +6463,16 @@ connectedCallback() {
         if (windowClosedColorField) windowClosedColorField.value = val;
       });
     }
-    // window_open_states text field (comma-separated)
     const windowOpenStatesField = this.shadowRoot.getElementById("window-open-states");
     if (windowOpenStatesField) {
-      const currentStates = Array.isArray(this._config?.window_open_states)
-        ? this._config.window_open_states.join(", ")
-        : (this._config?.window_open_states || "");
+      const currentStates = Array.isArray(this._config?.window_open_states) ? this._config.window_open_states.join(", ") : this._config?.window_open_states || "";
       windowOpenStatesField.value = currentStates;
       windowOpenStatesField.addEventListener("change", (ev) => {
         ev.stopPropagation();
         const raw = ev.target.value.trim();
         const next = { ...this._config };
         if (raw) {
-          const arr = raw.split(",").map(s => s.trim()).filter(Boolean);
+          const arr = raw.split(",").map((s) => s.trim()).filter(Boolean);
           next.window_open_states = arr;
         } else {
           delete next.window_open_states;
@@ -6035,13 +6480,11 @@ connectedCallback() {
         this._fire(next);
       });
     }
-    // window_state_colors dynamic section
     const renderWindowStateColors = () => {
       const list = this.shadowRoot.getElementById("window-state-colors-list");
       if (!list) return;
       list.replaceChildren();
-      const colorMap = (this._config?.window_state_colors && typeof this._config.window_state_colors === "object")
-        ? this._config.window_state_colors : {};
+      const colorMap = this._config?.window_state_colors && typeof this._config.window_state_colors === "object" ? this._config.window_state_colors : {};
       Object.entries(colorMap).forEach(([state, color]) => {
         const row = document.createElement("div");
         row.className = "cl-row";
@@ -6053,12 +6496,13 @@ connectedCallback() {
         stateField.addEventListener("change", (ev) => {
           ev.stopPropagation();
           const newKey = ev.target.value.trim();
-          const newMap = { ...(this._config?.window_state_colors || {}) };
+          const newMap = { ...this._config?.window_state_colors || {} };
           const colorVal = newMap[state] ?? color;
           delete newMap[state];
           if (newKey) newMap[newKey] = colorVal;
           const next = { ...this._config };
-          if (Object.keys(newMap).length > 0) next.window_state_colors = newMap; else delete next.window_state_colors;
+          if (Object.keys(newMap).length > 0) next.window_state_colors = newMap;
+          else delete next.window_state_colors;
           this._fire(next);
           renderWindowStateColors();
         });
@@ -6068,7 +6512,7 @@ connectedCallback() {
         colorField.style.cssText = "flex:1;margin-bottom:0;margin-left:6px;";
         colorField.addEventListener("change", (ev) => {
           ev.stopPropagation();
-          const newMap = { ...(this._config?.window_state_colors || {}) };
+          const newMap = { ...this._config?.window_state_colors || {} };
           newMap[state] = ev.target.value;
           this._fire({ ...this._config, window_state_colors: newMap });
           if (cmPicker) cmPicker.value = parseColorToPickerHex(ev.target.value);
@@ -6081,7 +6525,7 @@ connectedCallback() {
         cmPicker.title = getTranslation(h, "color");
         cmPicker.addEventListener("change", (ev) => {
           ev.stopPropagation();
-          const newMap = { ...(this._config?.window_state_colors || {}) };
+          const newMap = { ...this._config?.window_state_colors || {} };
           newMap[state] = ev.target.value;
           this._fire({ ...this._config, window_state_colors: newMap });
           colorField.value = ev.target.value;
@@ -6092,14 +6536,18 @@ connectedCallback() {
         delBtn.innerHTML = `<ha-icon icon="mdi:delete-outline"></ha-icon>`;
         delBtn.addEventListener("click", (ev) => {
           ev.stopPropagation();
-          const newMap = { ...(this._config?.window_state_colors || {}) };
+          const newMap = { ...this._config?.window_state_colors || {} };
           delete newMap[state];
           const next = { ...this._config };
-          if (Object.keys(newMap).length > 0) next.window_state_colors = newMap; else delete next.window_state_colors;
+          if (Object.keys(newMap).length > 0) next.window_state_colors = newMap;
+          else delete next.window_state_colors;
           this._fire(next);
           renderWindowStateColors();
         });
-        row.appendChild(stateField); row.appendChild(colorField); row.appendChild(cmPicker); row.appendChild(delBtn);
+        row.appendChild(stateField);
+        row.appendChild(colorField);
+        row.appendChild(cmPicker);
+        row.appendChild(delBtn);
         list.appendChild(row);
       });
     };
@@ -6108,9 +6556,12 @@ connectedCallback() {
     if (windowStateColorsAddBtn) {
       windowStateColorsAddBtn.addEventListener("click", (ev) => {
         ev.stopPropagation();
-        const newMap = { ...(this._config?.window_state_colors || {}) };
-        let newKey = "state"; let idx = 1;
-        while (newKey in newMap) { newKey = `state${idx++}`; }
+        const newMap = { ...this._config?.window_state_colors || {} };
+        let newKey = "state";
+        let idx = 1;
+        while (newKey in newMap) {
+          newKey = `state${idx++}`;
+        }
         newMap[newKey] = "#ffffff";
         this._fire({ ...this._config, window_state_colors: newMap });
         renderWindowStateColors();
@@ -6120,18 +6571,16 @@ connectedCallback() {
       const list = this.shadowRoot.getElementById("alert-sensors-list");
       if (!list) return;
       list.replaceChildren();
-      const source = Array.isArray(sourceInput)
-        ? sourceInput
-        : (Array.isArray(this._config?.alert_sensors) ? this._config.alert_sensors : []);
+      const source = Array.isArray(sourceInput) ? sourceInput : Array.isArray(this._config?.alert_sensors) ? this._config.alert_sensors : [];
       const normalize = (cfg) => {
         if (!cfg) return null;
         if (typeof cfg === "string") return { entity: cfg };
         if (typeof cfg === "object") {
           const n = { ...cfg };
           if (n.state && typeof n.state === "string") {
-            n.state = n.state.split(",").map(s => String(s).toLowerCase().trim()).filter(Boolean);
+            n.state = n.state.split(",").map((s) => String(s).toLowerCase().trim()).filter(Boolean);
           } else if (Array.isArray(n.state)) {
-            n.state = n.state.map(s => String(s).toLowerCase().trim()).filter(Boolean);
+            n.state = n.state.map((s) => String(s).toLowerCase().trim()).filter(Boolean);
           }
           return n;
         }
@@ -6139,7 +6588,8 @@ connectedCallback() {
       };
       const fireUpdate = (arr) => {
         const next = { ...this._config };
-        if (arr.length > 0) next.alert_sensors = arr; else delete next.alert_sensors;
+        if (arr.length > 0) next.alert_sensors = arr;
+        else delete next.alert_sensors;
         this._fire(next);
       };
       source.forEach((item, idx) => {
@@ -6150,16 +6600,14 @@ connectedCallback() {
         headerRow.className = "badge-head-row";
         const entityLabel = document.createElement("span");
         entityLabel.className = "badge-entity-label";
-        entityLabel.textContent = cfg.entity
-          ? (h.states[cfg.entity]?.attributes?.friendly_name || cfg.entity)
-          : getTranslation(h, "alert_sensor_entity");
+        entityLabel.textContent = cfg.entity ? h.states[cfg.entity]?.attributes?.friendly_name || cfg.entity : getTranslation(h, "alert_sensor_entity");
         const deleteBtn = document.createElement("button");
         deleteBtn.type = "button";
         deleteBtn.className = "badge-del-btn";
         deleteBtn.innerHTML = `<ha-icon icon="mdi:delete-outline"></ha-icon>`;
         deleteBtn.addEventListener("click", (ev) => {
           ev.stopPropagation();
-          const arr = [...(this._config?.alert_sensors || [])];
+          const arr = [...this._config?.alert_sensors || []];
           arr.splice(idx, 1);
           fireUpdate(arr);
           renderAlertSensors();
@@ -6167,7 +6615,6 @@ connectedCallback() {
         headerRow.appendChild(entityLabel);
         headerRow.appendChild(deleteBtn);
         row.appendChild(headerRow);
-
         const entityPicker = document.createElement("ha-entity-picker");
         entityPicker.label = getTranslation(h, "alert_sensor_entity");
         entityPicker.allowCustomEntity = true;
@@ -6177,24 +6624,24 @@ connectedCallback() {
         entityPicker.style.cssText = "flex:1 1 220px;min-width:200px;";
         entityPicker.addEventListener("value-changed", (ev) => {
           ev.stopPropagation();
-          const arr = [...(this._config?.alert_sensors || [])];
+          const arr = [...this._config?.alert_sensors || []];
           arr[idx] = { ...cfg, entity: ev.detail?.value || "" };
           fireUpdate(arr);
           renderAlertSensors();
         });
-
         const mkNumField = (key, labelKey) => {
           const f = document.createElement("oneline-room-card-textfield");
           f.label = getTranslation(h, labelKey);
           f.type = "number";
-          f.value = cfg[key] !== undefined ? String(cfg[key]) : "";
+          f.value = cfg[key] !== void 0 ? String(cfg[key]) : "";
           f.style.cssText = "flex:1 1 120px;min-width:100px;";
           f.addEventListener("change", (ev) => {
             ev.stopPropagation();
             const val = trimStr(ev.target.value || "");
-            const arr = [...(this._config?.alert_sensors || [])];
+            const arr = [...this._config?.alert_sensors || []];
             const next = { ...cfg };
-            if (val === "") delete next[key]; else next[key] = Number(val);
+            if (val === "") delete next[key];
+            else next[key] = Number(val);
             arr[idx] = next;
             fireUpdate(arr);
           });
@@ -6202,22 +6649,20 @@ connectedCallback() {
         };
         const aboveField = mkNumField("above", "alert_sensor_above");
         const belowField = mkNumField("below", "alert_sensor_below");
-
         const stateField = document.createElement("oneline-room-card-textfield");
         stateField.label = getTranslation(h, "alert_sensor_state");
-        stateField.value = Array.isArray(cfg.state) ? cfg.state.join(", ") : (cfg.state || "");
+        stateField.value = Array.isArray(cfg.state) ? cfg.state.join(", ") : cfg.state || "";
         stateField.style.cssText = "flex:1 1 120px;min-width:100px;";
         stateField.addEventListener("change", (ev) => {
           ev.stopPropagation();
           const raw = trimStr(ev.target.value || "");
-          const arr = [...(this._config?.alert_sensors || [])];
+          const arr = [...this._config?.alert_sensors || []];
           const next = { ...cfg };
           if (raw === "") delete next.state;
-          else next.state = raw.split(",").map(s => s.trim()).filter(Boolean);
+          else next.state = raw.split(",").map((s) => s.trim()).filter(Boolean);
           arr[idx] = next;
           fireUpdate(arr);
         });
-
         const controlsRow = document.createElement("div");
         controlsRow.style.cssText = "display:flex;flex-wrap:wrap;gap:8px;width:100%;";
         controlsRow.appendChild(aboveField);
@@ -6234,7 +6679,7 @@ connectedCallback() {
       alertSensorsAddBtn.addEventListener("click", (ev) => {
         ev.preventDefault();
         ev.stopPropagation();
-        const arr = [...(this._config?.alert_sensors || [])];
+        const arr = [...this._config?.alert_sensors || []];
         arr.push({ entity: "" });
         this._fire({ ...this._config, alert_sensors: arr });
         renderAlertSensors(arr);
@@ -6250,7 +6695,6 @@ connectedCallback() {
         this._fire(next);
       });
     }
-
     const badgesHead = this.shadowRoot.getElementById("badges-head");
     if (badgesHead) {
       badgesHead.addEventListener("click", () => {
@@ -6258,14 +6702,13 @@ connectedCallback() {
         this._updateBadgesUI();
       });
     }
-    
     const infoLinePosSel = this.shadowRoot.getElementById("info-line-pos-sel");
     if (infoLinePosSel) {
       infoLinePosSel.hass = h;
       infoLinePosSel.selector = { select: { mode: "dropdown", options: [
         { value: "header", label: getTranslation(h, "info_position_header") },
         { value: "below_header", label: getTranslation(h, "info_position_below") }
-      ]}};
+      ] } };
       infoLinePosSel.value = this._config?.info_line_position || "header";
       infoLinePosSel.addEventListener("value-changed", (e) => {
         e.stopPropagation();
@@ -6275,7 +6718,6 @@ connectedCallback() {
         this._fire(next);
       });
     }
-
     const layoutHead = this.shadowRoot.getElementById("layout-head");
     if (layoutHead) {
       layoutHead.addEventListener("click", () => {
@@ -6293,18 +6735,23 @@ connectedCallback() {
         ev.stopPropagation();
         let val = parseInt(ev.target.value, 10);
         for (const p of INFO_SNAP) {
-          if (Math.abs(val - p) <= INFO_SNAP_THRESHOLD) { val = p; break; }
+          if (Math.abs(val - p) <= INFO_SNAP_THRESHOLD) {
+            val = p;
+            break;
+          }
         }
         ev.target.value = String(val);
         if (nameOffsetValue) nameOffsetValue.textContent = `${val}%`;
         const next = { ...this._config };
-        if (val > 0) next.header_name_offset = val; else delete next.header_name_offset;
+        if (val > 0) next.header_name_offset = val;
+        else delete next.header_name_offset;
         if (this._config?.header_sync_offsets) {
           const infS = this.shadowRoot.getElementById("info-offset-slider");
           const infV = this.shadowRoot.getElementById("info-offset-value");
           if (infS) infS.value = String(val);
           if (infV) infV.textContent = `${val}%`;
-          if (val > 0) next.header_info_offset = val; else delete next.header_info_offset;
+          if (val > 0) next.header_info_offset = val;
+          else delete next.header_info_offset;
         }
         this._fire(next);
       });
@@ -6319,18 +6766,23 @@ connectedCallback() {
         ev.stopPropagation();
         let val = parseInt(ev.target.value, 10);
         for (const p of INFO_SNAP) {
-          if (Math.abs(val - p) <= INFO_SNAP_THRESHOLD) { val = p; break; }
+          if (Math.abs(val - p) <= INFO_SNAP_THRESHOLD) {
+            val = p;
+            break;
+          }
         }
         ev.target.value = String(val);
         if (infoOffsetValue) infoOffsetValue.textContent = `${val}%`;
         const next = { ...this._config };
-        if (val > 0) next.header_info_offset = val; else delete next.header_info_offset;
+        if (val > 0) next.header_info_offset = val;
+        else delete next.header_info_offset;
         if (this._config?.header_sync_offsets) {
           const namS = this.shadowRoot.getElementById("name-offset-slider");
           const namV = this.shadowRoot.getElementById("name-offset-value");
           if (namS) namS.value = String(val);
           if (namV) namV.textContent = `${val}%`;
-          if (val > 0) next.header_name_offset = val; else delete next.header_name_offset;
+          if (val > 0) next.header_name_offset = val;
+          else delete next.header_name_offset;
         }
         this._fire(next);
       });
@@ -6344,7 +6796,8 @@ connectedCallback() {
         if (ev.target.checked) {
           next.header_sync_offsets = true;
           const val = this._config?.header_name_offset ?? 0;
-          if (val > 0) next.header_info_offset = val; else delete next.header_info_offset;
+          if (val > 0) next.header_info_offset = val;
+          else delete next.header_info_offset;
         } else {
           delete next.header_sync_offsets;
         }
@@ -6372,38 +6825,32 @@ connectedCallback() {
     const dblServiceDataInput = this.shadowRoot.getElementById("dbl-service-data");
     const dblTargetPicker = this.shadowRoot.getElementById("dbl-target");
     const dblNavPath = this.shadowRoot.getElementById("dbl-nav-path");
-
     if (tapTargetPicker) tapTargetPicker.hass = h;
     if (holdTargetPicker) holdTargetPicker.hass = h;
     if (dblTargetPicker) dblTargetPicker.hass = h;
     if (tapNavPath) tapNavPath.hass = h;
     if (holdNavPath) holdNavPath.hass = h;
     if (dblNavPath) dblNavPath.hass = h;
-
-const updateActionFields = (action, serviceField, serviceDataField, targetField, navField, actionConfig) => {
-      // Definiere hier, bei welchen Aktionen das Entitäts-Feld angezeigt werden soll
+    const updateActionFields = (action, serviceField, serviceDataField, targetField, navField, actionConfig) => {
       const needsTarget = ["call-service", "more-info", "toggle"].includes(action);
-      
       if (serviceField) serviceField.style.display = action === "call-service" ? "" : "none";
       if (serviceDataField) serviceDataField.style.display = action === "call-service" ? "" : "none";
       if (targetField) targetField.style.display = needsTarget ? "" : "none";
       if (navField) navField.style.display = action === "navigate" ? "" : "none";
-      
       if (serviceField) serviceField.value = actionConfig?.service || "";
       if (serviceDataField) {
         const rawData = actionConfig?.service_data;
-        serviceDataField.value = rawData === undefined ? "" : (typeof rawData === "string" ? rawData : JSON.stringify(rawData, null, 2));
+        serviceDataField.value = rawData === void 0 ? "" : typeof rawData === "string" ? rawData : JSON.stringify(rawData, null, 2);
       }
       if (targetField) {
         const entityId = actionConfig?.target?.entity_id;
-        targetField.value = Array.isArray(entityId) ? (entityId[0] || "") : (entityId || "");
+        targetField.value = Array.isArray(entityId) ? entityId[0] || "" : entityId || "";
       }
       if (navField) {
         navField.value = actionConfig?.navigation_path || "";
         if (this._hass && navField.hass !== this._hass) navField.hass = this._hass;
       }
     };
-
     if (tapActionSelect) {
       tapActionSelect.hass = h;
       tapActionSelect.selector = { select: { mode: "dropdown", options: actOpts.concat({ value: "call-service", label: getTranslation(h, "act_call_service") || "Action (service)" }) } };
@@ -6412,10 +6859,8 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         ev.stopPropagation();
         const action = ev.detail?.value || "more-info";
         const c = { ...this._config };
-        c.tap_action = { ...(c.tap_action || {}), action };
- if (action !== "navigate") delete c.tap_action.navigation_path;
-        
-        // Target nur löschen, wenn es nicht eine der drei unterstützten Aktionen ist
+        c.tap_action = { ...c.tap_action || {}, action };
+        if (action !== "navigate") delete c.tap_action.navigation_path;
         if (!["call-service", "more-info", "toggle"].includes(action)) {
           delete c.tap_action.target;
         }
@@ -6437,7 +6882,7 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         ev.stopPropagation();
         const action = ev.detail?.value || "none";
         const c = { ...this._config };
-        c.hold_action = { ...(c.hold_action || {}), action };
+        c.hold_action = { ...c.hold_action || {}, action };
         if (action !== "navigate") delete c.hold_action.navigation_path;
         if (action !== "call-service") {
           delete c.hold_action.service;
@@ -6458,7 +6903,7 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         ev.stopPropagation();
         const action = ev.detail?.value || "none";
         const c = { ...this._config };
-        c.double_tap_action = { ...(c.double_tap_action || {}), action };
+        c.double_tap_action = { ...c.double_tap_action || {}, action };
         if (action !== "navigate") delete c.double_tap_action.navigation_path;
         if (action !== "call-service") {
           delete c.double_tap_action.service;
@@ -6476,7 +6921,7 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         ev.stopPropagation();
         const value = trimStr(ev.target.value || "");
         const c = { ...this._config };
-        c.tap_action = { ...(c.tap_action || {}), action: "call-service" };
+        c.tap_action = { ...c.tap_action || {}, action: "call-service" };
         if (value) c.tap_action.service = value;
         else delete c.tap_action.service;
         this._fire(c);
@@ -6487,10 +6932,13 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         ev.stopPropagation();
         const raw = trimStr(ev.target.value || "");
         const c = { ...this._config };
-        c.tap_action = { ...(c.tap_action || {}), action: "call-service" };
+        c.tap_action = { ...c.tap_action || {}, action: "call-service" };
         if (raw) {
-          try { c.tap_action.service_data = JSON.parse(raw); }
-          catch { c.tap_action.service_data = raw; }
+          try {
+            c.tap_action.service_data = JSON.parse(raw);
+          } catch {
+            c.tap_action.service_data = raw;
+          }
         } else {
           delete c.tap_action.service_data;
         }
@@ -6504,7 +6952,7 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         const value = trimStr(ev.detail?.value || "");
         const action = tapActionSelect?.value || this._config?.tap_action?.action || "more-info";
         const c = { ...this._config };
-        c.tap_action = { ...(c.tap_action || {}), action };
+        c.tap_action = { ...c.tap_action || {}, action };
         const needsTarget = ["call-service", "more-info", "toggle"].includes(action);
         if (needsTarget && value) c.tap_action.target = { entity_id: value };
         else delete c.tap_action.target;
@@ -6520,7 +6968,7 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         ev.stopPropagation();
         const value = trimStr(ev.target.value || "");
         const c = { ...this._config };
-        c.hold_action = { ...(c.hold_action || {}), action: "call-service" };
+        c.hold_action = { ...c.hold_action || {}, action: "call-service" };
         if (value) c.hold_action.service = value;
         else delete c.hold_action.service;
         this._fire(c);
@@ -6531,10 +6979,13 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         ev.stopPropagation();
         const raw = trimStr(ev.target.value || "");
         const c = { ...this._config };
-        c.hold_action = { ...(c.hold_action || {}), action: "call-service" };
+        c.hold_action = { ...c.hold_action || {}, action: "call-service" };
         if (raw) {
-          try { c.hold_action.service_data = JSON.parse(raw); }
-          catch { c.hold_action.service_data = raw; }
+          try {
+            c.hold_action.service_data = JSON.parse(raw);
+          } catch {
+            c.hold_action.service_data = raw;
+          }
         } else {
           delete c.hold_action.service_data;
         }
@@ -6548,7 +6999,7 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         const value = trimStr(ev.detail?.value || "");
         const action = holdActionSelect?.value || this._config?.hold_action?.action || "none";
         const c = { ...this._config };
-        c.hold_action = { ...(c.hold_action || {}), action };
+        c.hold_action = { ...c.hold_action || {}, action };
         const needsTarget = ["call-service", "more-info", "toggle"].includes(action);
         if (needsTarget && value) c.hold_action.target = { entity_id: value };
         else delete c.hold_action.target;
@@ -6564,7 +7015,7 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         ev.stopPropagation();
         const value = trimStr(ev.target.value || "");
         const c = { ...this._config };
-        c.double_tap_action = { ...(c.double_tap_action || {}), action: "call-service" };
+        c.double_tap_action = { ...c.double_tap_action || {}, action: "call-service" };
         if (value) c.double_tap_action.service = value;
         else delete c.double_tap_action.service;
         this._fire(c);
@@ -6575,10 +7026,13 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         ev.stopPropagation();
         const raw = trimStr(ev.target.value || "");
         const c = { ...this._config };
-        c.double_tap_action = { ...(c.double_tap_action || {}), action: "call-service" };
+        c.double_tap_action = { ...c.double_tap_action || {}, action: "call-service" };
         if (raw) {
-          try { c.double_tap_action.service_data = JSON.parse(raw); }
-          catch { c.double_tap_action.service_data = raw; }
+          try {
+            c.double_tap_action.service_data = JSON.parse(raw);
+          } catch {
+            c.double_tap_action.service_data = raw;
+          }
         } else {
           delete c.double_tap_action.service_data;
         }
@@ -6592,7 +7046,7 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         const value = trimStr(ev.detail?.value || "");
         const action = dblActionSelect?.value || this._config?.double_tap_action?.action || "none";
         const c = { ...this._config };
-        c.double_tap_action = { ...(c.double_tap_action || {}), action };
+        c.double_tap_action = { ...c.double_tap_action || {}, action };
         const needsTarget = ["call-service", "more-info", "toggle"].includes(action);
         if (needsTarget && value) c.double_tap_action.target = { entity_id: value };
         else delete c.double_tap_action.target;
@@ -6608,7 +7062,7 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         ev.stopPropagation();
         const value = trimStr(ev.detail?.value || "");
         const c = { ...this._config };
-        c.tap_action = { ...(c.tap_action || {}), action: "navigate" };
+        c.tap_action = { ...c.tap_action || {}, action: "navigate" };
         if (value) c.tap_action.navigation_path = value;
         else delete c.tap_action.navigation_path;
         this._fire(c);
@@ -6620,7 +7074,7 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         ev.stopPropagation();
         const value = trimStr(ev.detail?.value || "");
         const c = { ...this._config };
-        c.hold_action = { ...(c.hold_action || {}), action: "navigate" };
+        c.hold_action = { ...c.hold_action || {}, action: "navigate" };
         if (value) c.hold_action.navigation_path = value;
         else delete c.hold_action.navigation_path;
         this._fire(c);
@@ -6632,7 +7086,7 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         ev.stopPropagation();
         const value = trimStr(ev.detail?.value || "");
         const c = { ...this._config };
-        c.double_tap_action = { ...(c.double_tap_action || {}), action: "navigate" };
+        c.double_tap_action = { ...c.double_tap_action || {}, action: "navigate" };
         if (value) c.double_tap_action.navigation_path = value;
         else delete c.double_tap_action.navigation_path;
         this._fire(c);
@@ -6669,20 +7123,19 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         this._fire(next);
       });
     }
-    
     const behaviorSel = this.shadowRoot.getElementById("behavior-sel");
     if (behaviorSel) {
       behaviorSel.hass = h;
       behaviorSel.selector = { select: { mode: "dropdown", options: [
-        {value: "fixed", label: getTranslation(h, "behavior_fixed")},
-        {value: "collapsed", label: getTranslation(h, "behavior_collapsed")},
-        {value: "expanded", label: getTranslation(h, "behavior_expanded")},
-        {value: "remember", label: getTranslation(h, "behavior_remember")}
-      ]}};
+        { value: "fixed", label: getTranslation(h, "behavior_fixed") },
+        { value: "collapsed", label: getTranslation(h, "behavior_collapsed") },
+        { value: "expanded", label: getTranslation(h, "behavior_expanded") },
+        { value: "remember", label: getTranslation(h, "behavior_remember") }
+      ] } };
       const isColl = this._config?.collapsible === true;
       const noRem = this._config?.remember_state === false;
       const isColld = this._config?.default_state === "collapsed";
-      behaviorSel.value = !isColl ? "fixed" : (!noRem ? "remember" : (isColld ? "collapsed" : "expanded"));
+      behaviorSel.value = !isColl ? "fixed" : !noRem ? "remember" : isColld ? "collapsed" : "expanded";
       behaviorSel.addEventListener("value-changed", (ev) => {
         ev.stopPropagation();
         const v = ev.detail.value;
@@ -6707,7 +7160,6 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         this._fire(next);
       });
     }
-    
     const standardBadgeBg = this.shadowRoot.getElementById("standard-badge-bg");
     const standardBadgeBgPicker = this.shadowRoot.getElementById("standard-badge-bg-picker");
     if (standardBadgeBg) {
@@ -6735,20 +7187,22 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
     }
     this._applyNavSelectorOptions();
     this._ensureNavOptions();
-
     const tmplSelect = this.shadowRoot.getElementById("tmpl-select");
     const tmplEntity = this.shadowRoot.getElementById("tmpl-entity");
     const globalLabelPos = this.shadowRoot.getElementById("global-label-pos");
     const quickAdd = this.shadowRoot.getElementById("quick-add");
     if (quickAdd) {
       quickAdd.open = this._quickAddOpen === true;
-      quickAdd.addEventListener("toggle", () => { this._quickAddOpen = quickAdd.open; });
+      quickAdd.addEventListener("toggle", () => {
+        this._quickAddOpen = quickAdd.open;
+      });
     }
-if (globalLabelPos) {
+    if (globalLabelPos) {
       globalLabelPos.hass = h;
       globalLabelPos.selector = {
         select: {
-          mode: "dropdown", options: [
+          mode: "dropdown",
+          options: [
             { value: "right", label: getTranslation(h, "pos_right") || "Rechts" },
             { value: "bottom", label: getTranslation(h, "pos_bottom") || "Unten" },
             { value: "top", label: getTranslation(h, "pos_top") || "Oben" },
@@ -6760,23 +7214,16 @@ if (globalLabelPos) {
       globalLabelPos.addEventListener("value-changed", (ev) => {
         ev.stopPropagation();
         const v = ev.detail?.value;
-        
-        // FIX 1: Wert sofort hart in die UI schreiben
-        ev.target.value = v; 
-        
+        ev.target.value = v;
         const next = { ...this._config };
-        
-        // FIX 2: YAML sauber halten & veraltete Keys löschen
         if (v === "right" || !v) {
           delete next.global_label_position;
-          delete next.buttons_label_position; 
+          delete next.buttons_label_position;
         } else {
           next.global_label_position = v;
           delete next.buttons_label_position;
         }
-        
         this._fire(next);
-        // FIX 3: KEIN this.renBtn() aufrufen! Das würde die UI zerstören.
       });
     }
     const globalIconSize = this.shadowRoot.getElementById("global-icon-size");
@@ -6787,7 +7234,8 @@ if (globalLabelPos) {
         ev.stopPropagation();
         const v = ev.target.value.trim();
         const next = { ...this._config };
-        if (v) next.global_icon_size = v; else delete next.global_icon_size;
+        if (v) next.global_icon_size = v;
+        else delete next.global_icon_size;
         this._fire(next);
         this.renBtn();
       });
@@ -6802,7 +7250,10 @@ if (globalLabelPos) {
         const error = this.shadowRoot.getElementById("sparkline-refresh-error");
         if (!raw) {
           delete next.sparkline_refresh;
-          if (error) { error.textContent = ""; error.style.display = "none"; }
+          if (error) {
+            error.textContent = "";
+            error.style.display = "none";
+          }
           this._fire(next);
           return;
         }
@@ -6812,9 +7263,7 @@ if (globalLabelPos) {
         ev.target.value = String(normalized);
         const adjusted = !Number.isFinite(numeric) || numeric !== normalized;
         if (error) {
-          error.textContent = adjusted
-            ? getTranslation(this._hass, "sparkline_refresh_adjusted").replace("{value}", String(normalized))
-            : "";
+          error.textContent = adjusted ? getTranslation(this._hass, "sparkline_refresh_adjusted").replace("{value}", String(normalized)) : "";
           error.style.display = adjusted ? "block" : "none";
         }
         this._fire(next);
@@ -6828,7 +7277,8 @@ if (globalLabelPos) {
         ev.stopPropagation();
         const v = ev.target.value.trim();
         const next = { ...this._config };
-        if (v) next.global_button_background = v; else delete next.global_button_background;
+        if (v) next.global_button_background = v;
+        else delete next.global_button_background;
         this._fire(next);
         this.renBtn();
       });
@@ -6844,7 +7294,7 @@ if (globalLabelPos) {
         });
       }
       const globalBtnBgPresets = this.shadowRoot.querySelectorAll("#global-btn-bg-presets .bg-preset");
-      globalBtnBgPresets.forEach(btn => {
+      globalBtnBgPresets.forEach((btn) => {
         btn.addEventListener("click", () => {
           const val = btn.getAttribute("data-val");
           globalBtnBg.value = val;
@@ -6867,32 +7317,24 @@ if (globalLabelPos) {
       const emptyHint = this.shadowRoot.getElementById("qa-empty-hint");
       if (emptyHint) emptyHint.classList.toggle("hidden", hasMatch);
     };
-if (tmplSelect) {
+    if (tmplSelect) {
       tmplSelect.hass = h;
       tmplSelect.selector = { select: { mode: "dropdown", options: this._getControlTemplates().map((t) => ({ value: t.id, label: t.label })) } };
-      
-      // Einen Frame warten, damit der deutsche Text sauber lädt (Timing-Fix)
       requestAnimationFrame(() => {
         tmplSelect.value = this._quickAddType;
       });
-
       tmplSelect.addEventListener("value-changed", (ev) => {
         ev.stopPropagation();
         const tid = ev.detail.value;
         if (!tid) return;
-        
-        // FIX 1: Das Dropdown sofort zwingen, den Text visuell zu behalten!
         ev.target.value = tid;
-        
         this._quickAddType = tid;
         const template = this._getTemplateById(tid);
         const domains = template?.domains || [];
         this._quickAddEntity = "";
-        
-        if (tmplEntity) { 
-          // FIX 2: Das rechte Feld (Entität) sofort optisch leeren, da der Typ gewechselt wurde
+        if (tmplEntity) {
           tmplEntity.value = "";
-          tmplEntity.selector = domains.length > 0 ? { entity: { domain: domains } } : { entity: {} }; 
+          tmplEntity.selector = domains.length > 0 ? { entity: { domain: domains } } : { entity: {} };
         }
         updateQuickAddHints();
       });
@@ -6917,24 +7359,23 @@ if (tmplSelect) {
         if (!ent) return;
         const template = this._getTemplateById(tid);
         const next = this._buildControlFromTemplate(template, ent);
-        const c = [...(this._config.controls || []), next];
+        const c = [...this._config.controls || [], next];
         this._fire({ ...this._config, controls: c });
         this.renBtn();
         this._updateBulkToggleButton();
       });
     }
-
-    this.shadowRoot.querySelectorAll(".i-cp").forEach(e => {
+    this.shadowRoot.querySelectorAll(".i-cp").forEach((e) => {
       e.addEventListener("change", (ev) => {
         ev.stopPropagation();
         this._fire({ ...this._config, color: ev.target.value });
         this.updVal();
       });
     });
-
     this.shadowRoot.getElementById("add").addEventListener("click", () => {
-      const c = [...(this._config.controls || [])];
-      let w = 15; if (c.length > 0) w = c[c.length - 1].width || 15;
+      const c = [...this._config.controls || []];
+      let w = 15;
+      if (c.length > 0) w = c[c.length - 1].width || 15;
       let ent = "", n = "";
       if (c.length === 0 && this._config.entity) {
         ent = this._config.entity;
@@ -6960,7 +7401,10 @@ if (tmplSelect) {
       });
     }
     this._updateBulkToggleButton();
-    this.updVal(); this.updCp(); this.renBtn(); this.updPreview();
+    this.updVal();
+    this.updCp();
+    this.renBtn();
+    this.updPreview();
     this._updateSensorsSectionUI();
     this._updateSparklineRefreshUI();
     this._updateImageSectionUI();
@@ -6972,7 +7416,6 @@ if (tmplSelect) {
     this._updateAdaptiveImagesUI();
     this._updateHeaderSectionUI();
   }
-
   _updateTabUI() {
     const configPanel = this.shadowRoot?.getElementById("tab-config-panel");
     const buttonsPanel = this.shadowRoot?.getElementById("tab-buttons-panel");
@@ -6984,14 +7427,12 @@ if (tmplSelect) {
     if (configBtn) configBtn.classList.toggle("active", isConfig);
     if (buttonsBtn) buttonsBtn.classList.toggle("active", !isConfig);
   }
-
   _updateCardBehaviorUI() {
     const content = this.shadowRoot?.getElementById("card-beh-content");
     const chev = this.shadowRoot?.getElementById("card-beh-chev");
     if (content) content.hidden = !this._cardBehaviorOpen;
     if (chev) chev.style.transform = this._cardBehaviorOpen ? "rotate(90deg)" : "";
   }
-
   _updateActionsSectionUI() {
     const section = this.shadowRoot?.getElementById("actions-sec");
     const content = this.shadowRoot?.getElementById("actions-sec-content");
@@ -7000,7 +7441,6 @@ if (tmplSelect) {
     if (section) section.classList.toggle("open", this._actionsSectionOpen);
     if (chev) chev.style.transform = this._actionsSectionOpen ? "rotate(90deg)" : "";
   }
-
   _updateRoomModesUI() {
     const content = this.shadowRoot?.getElementById("room-modes-content");
     const chev = this.shadowRoot?.getElementById("room-modes-chev");
@@ -7011,7 +7451,7 @@ if (tmplSelect) {
     const modes = Array.isArray(this._config?.room_modes) ? this._config.room_modes : [];
     const updateMode = (index, key, value) => {
       const nextModes = (Array.isArray(this._config?.room_modes) ? this._config.room_modes : []).map((mode) => ({ ...mode }));
-      if (value === undefined || value === null || value === "" || (Array.isArray(value) && value.length === 0)) delete nextModes[index][key];
+      if (value === void 0 || value === null || value === "" || Array.isArray(value) && value.length === 0) delete nextModes[index][key];
       else nextModes[index][key] = value;
       this._fire({ ...this._config, room_modes: nextModes });
     };
@@ -7043,7 +7483,10 @@ if (tmplSelect) {
         const icon = document.createElement("ha-icon");
         icon.setAttribute("icon", iconName);
         button.appendChild(icon);
-        button.addEventListener("click", (event) => { event.stopPropagation(); action(); });
+        button.addEventListener("click", (event) => {
+          event.stopPropagation();
+          action();
+        });
         return button;
       };
       actions.append(
@@ -7059,7 +7502,6 @@ if (tmplSelect) {
         })
       );
       header.append(label, actions);
-
       const picker = document.createElement("ha-entity-picker");
       picker.hass = this._hass;
       picker.label = getTranslation(this._hass, "room_mode_entity");
@@ -7070,23 +7512,27 @@ if (tmplSelect) {
       picker.addEventListener("value-changed", (event) => {
         event.stopPropagation();
         const value = trimStr(event.detail?.value);
-        updateMode(index, "entity", ["scene", "script"].includes(getEntityDomain(value)) ? value : undefined);
+        updateMode(index, "entity", ["scene", "script"].includes(getEntityDomain(value)) ? value : void 0);
         this._updateRoomModesUI();
       });
-
       const fields = document.createElement("div");
       fields.className = "row";
       const nameField = document.createElement("oneline-room-card-textfield");
       nameField.label = getTranslation(this._hass, "name");
       nameField.value = mode.name || "";
-      nameField.addEventListener("change", (event) => { event.stopPropagation(); updateMode(index, "name", trimStr(event.target.value)); });
+      nameField.addEventListener("change", (event) => {
+        event.stopPropagation();
+        updateMode(index, "name", trimStr(event.target.value));
+      });
       const iconPicker = document.createElement("ha-icon-picker");
       iconPicker.hass = this._hass;
       iconPicker.label = getTranslation(this._hass, "icon");
       iconPicker.value = mode.icon || "";
-      iconPicker.addEventListener("value-changed", (event) => { event.stopPropagation(); updateMode(index, "icon", trimStr(event.detail?.value)); });
+      iconPicker.addEventListener("value-changed", (event) => {
+        event.stopPropagation();
+        updateMode(index, "icon", trimStr(event.detail?.value));
+      });
       fields.append(nameField, iconPicker);
-
       const colorRow = document.createElement("div");
       colorRow.className = "cl-row";
       const colorField = document.createElement("oneline-room-card-textfield");
@@ -7108,7 +7554,6 @@ if (tmplSelect) {
         updateMode(index, "color", event.target.value);
       });
       colorRow.append(colorField, colorPicker);
-
       const conditionLabel = document.createElement("div");
       conditionLabel.className = "image-title";
       conditionLabel.style.cssText = "margin:10px 0 6px;font-weight:600";
@@ -7126,7 +7571,6 @@ if (tmplSelect) {
       list.appendChild(box);
     });
   }
-
   _updateStatusGroupsUI() {
     const content = this.shadowRoot?.getElementById("status-groups-content");
     const chev = this.shadowRoot?.getElementById("status-groups-chev");
@@ -7164,10 +7608,12 @@ if (tmplSelect) {
       const icon = document.createElement("ha-icon");
       icon.setAttribute("icon", iconName);
       button.appendChild(icon);
-      button.addEventListener("click", (event) => { event.stopPropagation(); action(); });
+      button.addEventListener("click", (event) => {
+        event.stopPropagation();
+        action();
+      });
       return button;
     };
-
     list.replaceChildren();
     groups.forEach((group, index) => {
       const box = document.createElement("div");
@@ -7190,7 +7636,6 @@ if (tmplSelect) {
         makeAction("mdi:delete", getTranslation(this._hass, "status_group_remove"), false, () => commitGroups(groups.filter((_, groupIndex) => groupIndex !== index).map((item) => ({ ...item }))))
       );
       header.append(title, actions);
-
       const textRow = document.createElement("div");
       textRow.className = "row";
       const name = document.createElement("oneline-room-card-textfield");
@@ -7217,7 +7662,6 @@ if (tmplSelect) {
         });
       });
       textRow.append(name, icon);
-
       const entities = document.createElement("ha-selector");
       entities.hass = this._hass;
       entities.label = getTranslation(this._hass, "status_group_entities");
@@ -7226,9 +7670,10 @@ if (tmplSelect) {
       entities.addEventListener("value-changed", (event) => {
         event.stopPropagation();
         const value = Array.isArray(event.detail?.value) ? event.detail.value.filter(Boolean) : [];
-        updateGroup(index, (nextGroup) => { nextGroup.entities = value; });
+        updateGroup(index, (nextGroup) => {
+          nextGroup.entities = value;
+        });
       });
-
       const displayLabel = document.createElement("label");
       displayLabel.className = "image-preset-help";
       displayLabel.textContent = getTranslation(this._hass, "status_group_display");
@@ -7250,7 +7695,6 @@ if (tmplSelect) {
           else delete nextGroup.aggregate;
         }, true);
       });
-
       const activeStates = document.createElement("oneline-room-card-textfield");
       activeStates.label = getTranslation(this._hass, "status_group_active_states");
       activeStates.value = Array.isArray(group.active_states) ? group.active_states.join(", ") : "";
@@ -7263,7 +7707,6 @@ if (tmplSelect) {
           else delete nextGroup.active_states;
         });
       });
-
       const numericRow = document.createElement("div");
       numericRow.className = "row";
       numericRow.style.display = display.value === "value" ? "" : "none";
@@ -7286,10 +7729,11 @@ if (tmplSelect) {
       precision.value = String(group.precision ?? 1);
       precision.addEventListener("change", (event) => {
         event.stopPropagation();
-        updateGroup(index, (nextGroup) => { nextGroup.precision = Math.max(0, Math.min(4, Number(event.target.value) || 0)); });
+        updateGroup(index, (nextGroup) => {
+          nextGroup.precision = Math.max(0, Math.min(4, Number(event.target.value) || 0));
+        });
       });
       numericRow.append(unit, precision);
-
       const color = document.createElement("oneline-room-card-textfield");
       color.label = getTranslation(this._hass, "color");
       color.value = group.color || "";
@@ -7301,7 +7745,6 @@ if (tmplSelect) {
           else delete nextGroup.color;
         });
       });
-
       const toggles = document.createElement("div");
       toggles.className = "editor-stack";
       const makeToggle = (labelKey, key) => {
@@ -7311,13 +7754,14 @@ if (tmplSelect) {
         toggle.checked = group[key] === true;
         toggle.addEventListener("change", (event) => {
           event.stopPropagation();
-          updateGroup(index, (nextGroup) => { nextGroup[key] = event.target.checked === true; });
+          updateGroup(index, (nextGroup) => {
+            nextGroup[key] = event.target.checked === true;
+          });
         });
         formfield.appendChild(toggle);
         return formfield;
       };
       toggles.append(makeToggle("status_group_hide_zero", "hide_when_zero"), makeToggle("status_group_details", "details"));
-
       const conditionTitle = document.createElement("div");
       conditionTitle.className = "image-preset-heading";
       conditionTitle.textContent = getTranslation(this._hass, "status_group_conditions");
@@ -7333,24 +7777,20 @@ if (tmplSelect) {
           else delete nextGroup.conditions;
         });
       });
-
       box.append(header, textRow, entities, displayLabel, display, activeStates, numericRow, color, toggles, conditionTitle, conditions);
       list.appendChild(box);
     });
   }
-
   _updateHeaderSectionUI() {
     const content = this.shadowRoot?.getElementById("header-sec-content");
     const chev = this.shadowRoot?.getElementById("header-sec-chev");
     if (content) content.hidden = !this._headerSectionOpen;
     if (chev) chev.style.transform = this._headerSectionOpen ? "rotate(90deg)" : "";
-
     const layoutC = this.shadowRoot?.getElementById("layout-content");
     const layoutCh = this.shadowRoot?.getElementById("layout-chev");
     if (layoutC) layoutC.hidden = !this._layoutSectionOpen;
     if (layoutCh) layoutCh.style.transform = this._layoutSectionOpen ? "rotate(90deg)" : "";
   }
-
   _updateAdaptiveImagesUI() {
     const list = this.shadowRoot?.getElementById("adaptive-images-list");
     if (!list || !this._config) return;
@@ -7387,10 +7827,12 @@ if (tmplSelect) {
       const icon = document.createElement("ha-icon");
       icon.setAttribute("icon", iconName);
       button.appendChild(icon);
-      button.addEventListener("click", (event) => { event.stopPropagation(); action(); });
+      button.addEventListener("click", (event) => {
+        event.stopPropagation();
+        action();
+      });
       return button;
     };
-
     list.replaceChildren();
     rules.forEach((rule, index) => {
       const box = document.createElement("div");
@@ -7413,7 +7855,6 @@ if (tmplSelect) {
         makeAction("mdi:delete", getTranslation(this._hass, "adaptive_image_remove"), false, () => updateRules(rules.filter((_, ruleIndex) => ruleIndex !== index).map((item) => ({ ...item }))))
       );
       header.append(title, actions);
-
       const nameField = document.createElement("oneline-room-card-textfield");
       nameField.label = getTranslation(this._hass, "adaptive_image_name");
       nameField.value = rule.name || "";
@@ -7425,7 +7866,6 @@ if (tmplSelect) {
           else delete nextRule.name;
         }, true);
       });
-
       const presetLabel = document.createElement("label");
       presetLabel.className = "image-preset-help";
       presetLabel.textContent = getTranslation(this._hass, "adaptive_image_preset");
@@ -7454,7 +7894,6 @@ if (tmplSelect) {
           }
         }, true);
       });
-
       const urlField = document.createElement("oneline-room-card-textfield");
       urlField.label = getTranslation(this._hass, "img_url");
       urlField.value = rule.image || "";
@@ -7468,7 +7907,6 @@ if (tmplSelect) {
           } else delete nextRule.image;
         }, true);
       });
-
       const uploadRow = document.createElement("div");
       uploadRow.className = "upload-row";
       const fileInput = document.createElement("input");
@@ -7486,7 +7924,10 @@ if (tmplSelect) {
       uploadStatus.className = "upload-status";
       uploadStatus.setAttribute("role", "status");
       uploadStatus.setAttribute("aria-live", "polite");
-      uploadButton.addEventListener("click", (event) => { event.stopPropagation(); fileInput.click(); });
+      uploadButton.addEventListener("click", (event) => {
+        event.stopPropagation();
+        fileInput.click();
+      });
       fileInput.addEventListener("change", async (event) => {
         event.stopPropagation();
         const file = event.target.files?.[0];
@@ -7514,7 +7955,6 @@ if (tmplSelect) {
         }
       });
       uploadRow.append(fileInput, uploadButton);
-
       const position = parseImagePosition(rule.image_position || this._config.image_position);
       const focalTitle = document.createElement("div");
       focalTitle.className = "image-preset-help";
@@ -7537,14 +7977,15 @@ if (tmplSelect) {
           output.textContent = `${event.target.value}%`;
           const x = axis === "x" ? Number(event.target.value) : Number(focalControls.querySelector("input[data-axis='x']")?.value ?? position.x);
           const y = axis === "y" ? Number(event.target.value) : Number(focalControls.querySelector("input[data-axis='y']")?.value ?? position.y);
-          updateRule(index, (nextRule) => { nextRule.image_position = parseImagePosition(`${x}% ${y}%`).value; });
+          updateRule(index, (nextRule) => {
+            nextRule.image_position = parseImagePosition(`${x}% ${y}%`).value;
+          });
         });
         input.dataset.axis = axis;
         focalControls.append(label, input, output);
       };
       buildRange("x", position.x, "image_horizontal");
       buildRange("y", position.y, "image_vertical");
-
       const conditionTitle = document.createElement("div");
       conditionTitle.className = "image-preset-heading";
       conditionTitle.textContent = getTranslation(this._hass, "adaptive_image_conditions");
@@ -7555,14 +7996,14 @@ if (tmplSelect) {
         event.stopPropagation();
         const value = Array.isArray(event.detail?.value) ? event.detail.value : [];
         conditions.conditions = value;
-        updateRule(index, (nextRule) => { nextRule.conditions = value; });
+        updateRule(index, (nextRule) => {
+          nextRule.conditions = value;
+        });
       });
-
       box.append(header, nameField, presetLabel, preset, urlField, uploadRow, uploadStatus, focalTitle, focalControls, conditionTitle, conditions);
       list.appendChild(box);
     });
   }
-
   _updateImageSectionUI() {
     const sec = this.shadowRoot?.getElementById("image-sec");
     const content = this.shadowRoot?.getElementById("image-content");
@@ -7577,7 +8018,6 @@ if (tmplSelect) {
       this._updateAdaptiveImagesUI();
     }
   }
-
   _setImagePosition(x, y) {
     const position = parseImagePosition(`${x}% ${y}%`);
     const next = { ...this._config };
@@ -7587,7 +8027,6 @@ if (tmplSelect) {
     this._updateFocalPointUI();
     this.updPreview();
   }
-
   _updateFocalPointUI() {
     const position = parseImagePosition(this._config?.image_position);
     const marker = this.shadowRoot?.getElementById("focal-marker");
@@ -7595,13 +8034,15 @@ if (tmplSelect) {
     const yInput = this.shadowRoot?.getElementById("focal-y");
     const xValue = this.shadowRoot?.getElementById("focal-x-value");
     const yValue = this.shadowRoot?.getElementById("focal-y-value");
-    if (marker) { marker.style.left = `${position.x}%`; marker.style.top = `${position.y}%`; }
+    if (marker) {
+      marker.style.left = `${position.x}%`;
+      marker.style.top = `${position.y}%`;
+    }
     if (xInput) xInput.value = String(position.x);
     if (yInput) yInput.value = String(position.y);
     if (xValue) xValue.textContent = `${Math.round(position.x)}%`;
     if (yValue) yValue.textContent = `${Math.round(position.y)}%`;
   }
-
   _setupFocalPointControl() {
     const preview = this.shadowRoot?.getElementById("focal-preview");
     const xInput = this.shadowRoot?.getElementById("focal-x");
@@ -7612,8 +8053,8 @@ if (tmplSelect) {
     const updateFromPointer = (event) => {
       const rect = preview.getBoundingClientRect();
       if (!rect.width || !rect.height) return;
-      const x = Math.round(Math.max(0, Math.min(100, ((event.clientX - rect.left) / rect.width) * 100)));
-      const y = Math.round(Math.max(0, Math.min(100, ((event.clientY - rect.top) / rect.height) * 100)));
+      const x = Math.round(Math.max(0, Math.min(100, (event.clientX - rect.left) / rect.width * 100)));
+      const y = Math.round(Math.max(0, Math.min(100, (event.clientY - rect.top) / rect.height * 100)));
       this._setImagePosition(x, y);
     };
     preview.addEventListener("pointerdown", (event) => {
@@ -7621,7 +8062,9 @@ if (tmplSelect) {
       preview.setPointerCapture?.(event.pointerId);
       updateFromPointer(event);
     });
-    preview.addEventListener("pointermove", (event) => { if (dragging) updateFromPointer(event); });
+    preview.addEventListener("pointermove", (event) => {
+      if (dragging) updateFromPointer(event);
+    });
     const stopDragging = (event) => {
       dragging = false;
       preview.releasePointerCapture?.(event.pointerId);
@@ -7634,16 +8077,12 @@ if (tmplSelect) {
     center.addEventListener("click", () => this._setImagePosition(50, 50));
     this._updateFocalPointUI();
   }
-
   _renderImagePresetPicker() {
     const container = this.shadowRoot?.getElementById("image-presets");
     if (!container || !this._config) return;
     const hasCustomImage = typeof this._config.image === "string" && this._config.image.trim() !== "";
-    const selectedPreset = !hasCustomImage && ROOM_IMAGE_PRESET_MAP.has(this._config.image_preset)
-      ? this._config.image_preset
-      : "";
+    const selectedPreset = !hasCustomImage && ROOM_IMAGE_PRESET_MAP.has(this._config.image_preset) ? this._config.image_preset : "";
     const buttons = [];
-
     const customButton = document.createElement("button");
     customButton.type = "button";
     customButton.className = `image-preset custom${selectedPreset ? "" : " selected"}`;
@@ -7659,7 +8098,6 @@ if (tmplSelect) {
       this.updPreview();
     });
     buttons.push(customButton);
-
     ROOM_IMAGE_PRESETS.forEach((preset) => {
       const button = document.createElement("button");
       const isSelected = selectedPreset === preset.id;
@@ -7667,13 +8105,11 @@ if (tmplSelect) {
       button.className = `image-preset${isSelected ? " selected" : ""}`;
       button.setAttribute("aria-pressed", isSelected ? "true" : "false");
       button.title = getTranslation(this._hass, preset.labelKey);
-
       const image = document.createElement("img");
       image.src = getRoomImagePresetUrl(preset.id);
       image.alt = "";
       image.loading = "lazy";
       image.decoding = "async";
-
       const label = document.createElement("span");
       label.className = "image-preset-label";
       label.textContent = getTranslation(this._hass, preset.labelKey);
@@ -7690,10 +8126,8 @@ if (tmplSelect) {
       });
       buttons.push(button);
     });
-
     container.replaceChildren(...buttons);
   }
-
   _updateSensorsSectionUI() {
     const sec = this.shadowRoot?.getElementById("sensors-sec");
     const content = this.shadowRoot?.getElementById("sensors-content");
@@ -7704,8 +8138,8 @@ if (tmplSelect) {
       c.temp_sensor,
       c.target_temp_sensor,
       c.humid_sensor,
-      ...(Array.isArray(c.window_sensors) ? c.window_sensors : []),
-      ...(Array.isArray(c.battery_sensors) ? c.battery_sensors : [])
+      ...Array.isArray(c.window_sensors) ? c.window_sensors : [],
+      ...Array.isArray(c.battery_sensors) ? c.battery_sensors : []
     ].filter((v) => v && String(v).trim() !== "").length;
     const label = getTranslation(this._hass, "sensors");
     title.textContent = count > 0 ? `${label} (${count})` : label;
@@ -7734,12 +8168,10 @@ if (tmplSelect) {
     this._syncManualSensorLabelInputs();
     this._updateWindowLabelsUI();
   }
-
   _updateSparklineRefreshUI() {
     const field = this.shadowRoot?.getElementById("sparkline-refresh");
     if (field) field.value = this._config?.sparkline_refresh ?? "";
   }
-
   _syncManualSensorLabelInputs() {
     this.shadowRoot?.querySelectorAll(".sensor-label-input").forEach((input) => {
       const key = input.dataset?.cfg;
@@ -7748,18 +8180,12 @@ if (tmplSelect) {
       if (input.value !== value) input.value = value;
     });
   }
-
   _updateWindowLabelsUI() {
     const list = this.shadowRoot?.getElementById("window-labels-list");
     if (!list) return;
-
     const h = this._hass;
-    const labels = (this._config?.window_labels && typeof this._config.window_labels === "object")
-      ? this._config.window_labels
-      : {};
-    const sensors = Array.isArray(this._config?.window_sensors)
-      ? this._config.window_sensors.map((entity) => trimStr(entity)).filter(Boolean)
-      : [];
+    const labels = this._config?.window_labels && typeof this._config.window_labels === "object" ? this._config.window_labels : {};
+    const sensors = Array.isArray(this._config?.window_sensors) ? this._config.window_sensors.map((entity) => trimStr(entity)).filter(Boolean) : [];
     const entries = [...new Set(sensors)].map((entity) => [entity, labels[entity] || ""]);
     const fireLabels = (nextLabels) => {
       const clean = {};
@@ -7774,14 +8200,11 @@ if (tmplSelect) {
       this._fire(next);
       this._updateWindowLabelsUI();
     };
-
     list.replaceChildren();
     if (entries.length === 0) return;
-
     entries.forEach(([entity, label], idx) => {
       const box = document.createElement("div");
       box.className = "badge-box";
-
       const headRow = document.createElement("div");
       headRow.className = "badge-head-row";
       const entityLabel = document.createElement("span");
@@ -7789,12 +8212,10 @@ if (tmplSelect) {
       entityLabel.textContent = entity || `${getTranslation(h, "window")} ${idx + 1}`;
       headRow.appendChild(entityLabel);
       box.appendChild(headRow);
-
       const labelCaption = document.createElement("label");
       labelCaption.className = "window-label-field-label";
       labelCaption.textContent = getTranslation(h, "window_custom_label");
       box.appendChild(labelCaption);
-
       const labelField = document.createElement("input");
       labelField.type = "text";
       labelField.className = "window-label-input";
@@ -7807,29 +8228,23 @@ if (tmplSelect) {
       });
       labelField.addEventListener("keydown", (ev) => ev.stopPropagation());
       box.appendChild(labelField);
-
       list.appendChild(box);
     });
   }
-
   _updateBadgesUI() {
     const sec = this.shadowRoot?.getElementById("badges-sec");
     const content = this.shadowRoot?.getElementById("badges-content");
     const title = this.shadowRoot?.getElementById("badges-title");
     if (!sec || !content || !title) return;
-
     const h = this._hass;
     const badges = Array.isArray(this._config?.header_badges) ? this._config.header_badges : [];
     const sectionLabel = getTranslation(h, "header_badges");
     title.textContent = badges.length > 0 ? `${sectionLabel} (${badges.length})` : sectionLabel;
     sec.classList.toggle("open", this._badgesSectionOpen);
     content.hidden = !this._badgesSectionOpen;
-
     const addBtn = content.querySelector("#add-badge");
     if (addBtn) addBtn.label = getTranslation(h, "badge_add");
-
     if (!this._badgesSectionOpen) return;
-
     const climatePicker = content.querySelector('ha-entity-picker[cfg="entity"]');
     if (climatePicker) {
       climatePicker.hess = h;
@@ -7840,7 +8255,6 @@ if (tmplSelect) {
         this._fire({ ...this._config, entity: e.detail?.value || "" });
       };
     }
-
     const autoToggle = content.querySelector("#auto-climate-btn-toggle");
     if (autoToggle) {
       autoToggle.checked = !!this._config?.auto_climate_button;
@@ -7850,13 +8264,11 @@ if (tmplSelect) {
         this._fire({ ...this._config, auto_climate_button: e.target.checked });
       };
     }
-
     const bgField = content.querySelector("#standard-badge-bg");
     const bgPop = content.querySelector("#standard-badge-bg-popover");
     const bgPicker = content.querySelector("#standard-badge-bg-picker");
     const bgPrv = bgPicker?.closest(".cp-preview")?.querySelector("div");
     const bgVal = this._config?.header_info_background || "";
-
     if (bgField) {
       bgField.value = bgVal;
       bgField.onclick = (e) => e.stopPropagation();
@@ -7885,7 +8297,6 @@ if (tmplSelect) {
         this._fire({ ...this._config, header_info_background: rgba });
       };
     }
-
     const hlaShow = content.querySelector("#hla-show");
     if (hlaShow) {
       hlaShow.checked = this._config?.show_card_last_activity === true;
@@ -7899,28 +8310,25 @@ if (tmplSelect) {
     }
     const list = content.querySelector("#badges-list");
     if (!list) return;
-
     const updBadge = (idx, key, val) => {
-      const arr = [...(this._config?.header_badges || [])];
+      const arr = [...this._config?.header_badges || []];
       arr[idx] = { ...arr[idx], [key]: val };
       this._fire({ ...this._config, header_badges: arr });
       this._updateBadgesUI();
     };
     const delBadge = (idx) => {
-      const arr = [...(this._config?.header_badges || [])];
+      const arr = [...this._config?.header_badges || []];
       arr.splice(idx, 1);
       const next = { ...this._config };
-      if (arr.length > 0) next.header_badges = arr; else delete next.header_badges;
+      if (arr.length > 0) next.header_badges = arr;
+      else delete next.header_badges;
       this._fire(next);
       this._updateBadgesUI();
     };
-
     list.replaceChildren();
-
     badges.forEach((badge, idx) => {
       const box = document.createElement("div");
       box.className = "badge-box";
-
       const headRow = document.createElement("div");
       headRow.className = "badge-head-row";
       const entityLabel = document.createElement("span");
@@ -7934,7 +8342,6 @@ if (tmplSelect) {
       headRow.appendChild(entityLabel);
       headRow.appendChild(delBtn);
       box.appendChild(headRow);
-
       const ep = document.createElement("ha-entity-picker");
       ep.label = getTranslation(h, "entity");
       ep.value = badge.entity || "";
@@ -7945,10 +8352,8 @@ if (tmplSelect) {
         updBadge(idx, "entity", ev.detail?.value ?? "");
       });
       box.appendChild(ep);
-
       const labelRow = document.createElement("div");
       labelRow.style.cssText = "display: flex; flex-direction: column; gap: 8px; margin-bottom: 8px;";
-
       const lf = document.createElement("oneline-room-card-textfield");
       lf.label = getTranslation(h, "badge_label");
       lf.placeholder = h?.states[badge.entity]?.attributes?.friendly_name || "";
@@ -7959,10 +8364,8 @@ if (tmplSelect) {
         updBadge(idx, "label", ev.target.value || "");
       });
       labelRow.appendChild(lf);
-
       const toggleRow = document.createElement("div");
       toggleRow.style.cssText = "display: flex; gap: 16px; align-items: center; padding-left: 4px;";
-
       const nameFormfield = document.createElement("ha-formfield");
       nameFormfield.label = getTranslation(h, "show_name");
       const nameSwitch = document.createElement("ha-switch");
@@ -7973,7 +8376,6 @@ if (tmplSelect) {
       });
       nameFormfield.appendChild(nameSwitch);
       toggleRow.appendChild(nameFormfield);
-
       const lcFormfield = document.createElement("ha-formfield");
       lcFormfield.label = getTranslation(h, "show_last_changed");
       const lcSwitch = document.createElement("ha-switch");
@@ -7984,27 +8386,22 @@ if (tmplSelect) {
       });
       lcFormfield.appendChild(lcSwitch);
       toggleRow.appendChild(lcFormfield);
-
       labelRow.appendChild(toggleRow);
       box.appendChild(labelRow);
-
       const bgRow = document.createElement("div");
       bgRow.style.cssText = "position: relative; display: flex; align-items: flex-end; margin-bottom: 8px;";
-
-      const bgField = document.createElement("oneline-room-card-textfield");
-      bgField.label = getTranslation(h, "badge_background");
-      bgField.style.width = "100%";
-      bgField.value = badge.background || "";
-      bgField.addEventListener("change", (ev) => {
+      const bgField2 = document.createElement("oneline-room-card-textfield");
+      bgField2.label = getTranslation(h, "badge_background");
+      bgField2.style.width = "100%";
+      bgField2.value = badge.background || "";
+      bgField2.addEventListener("change", (ev) => {
         ev.stopPropagation();
         updBadge(idx, "background", trimStr(ev.target.value || ""));
       });
-      bgRow.appendChild(bgField);
-
+      bgRow.appendChild(bgField2);
       const colorContainer = document.createElement("div");
       colorContainer.className = "color-container";
       colorContainer.style.cssText = "position: absolute; right: 8px; bottom: 8px; z-index: 1;";
-
       const popover = document.createElement("div");
       popover.className = "color-popover";
       const popoverField = document.createElement("oneline-room-card-textfield");
@@ -8019,37 +8416,33 @@ if (tmplSelect) {
       });
       popover.appendChild(popoverField);
       colorContainer.appendChild(popover);
-
       const cpPreview = document.createElement("div");
       cpPreview.className = "cp-preview";
       const cpInner = document.createElement("div");
       cpInner.style.backgroundColor = badge.background || "transparent";
       cpPreview.appendChild(cpInner);
-
-      const bgPicker = document.createElement("input");
-      bgPicker.type = "color";
-      bgPicker.style.cssText = "position: absolute; inset: 0; opacity: 0; cursor: pointer; border: none; padding: 0; width: 100%; height: 100%;";
-      bgPicker.value = parseColorToPickerHex(badge.background);
-      bgPicker.addEventListener("change", (ev) => {
+      const bgPicker2 = document.createElement("input");
+      bgPicker2.type = "color";
+      bgPicker2.style.cssText = "position: absolute; inset: 0; opacity: 0; cursor: pointer; border: none; padding: 0; width: 100%; height: 100%;";
+      bgPicker2.value = parseColorToPickerHex(badge.background);
+      bgPicker2.addEventListener("change", (ev) => {
         ev.stopPropagation();
         const hex = ev.target.value;
         const rgba = hexToRgba(hex, 0.25);
         updBadge(idx, "background", rgba);
         cpInner.style.backgroundColor = rgba;
         popoverField.value = rgba;
-        bgField.value = rgba;
+        bgField2.value = rgba;
       });
-      cpPreview.appendChild(bgPicker);
+      cpPreview.appendChild(bgPicker2);
       colorContainer.appendChild(cpPreview);
       bgRow.appendChild(colorContainer);
-
       box.appendChild(bgRow);
       list.appendChild(box);
     });
-
     if (addBtn) {
       addBtn.onclick = () => {
-        const arr = [...(this._config?.header_badges || [])];
+        const arr = [...this._config?.header_badges || []];
         arr.push({ entity: "", show_name: true });
         this._badgesSectionOpen = true;
         this._fire({ ...this._config, header_badges: arr });
@@ -8057,7 +8450,6 @@ if (tmplSelect) {
       };
     }
   }
-
   _updateTypographyUI() {
     const sec = this.shadowRoot?.getElementById("typo-sec");
     const content = this.shadowRoot?.getElementById("typo-content");
@@ -8066,8 +8458,7 @@ if (tmplSelect) {
     content.hidden = this._typoSectionOpen !== true;
     const headerTextShadowToggle = this.shadowRoot?.getElementById("header-text-shadow-toggle");
     if (headerTextShadowToggle) headerTextShadowToggle.checked = this._config?.show_header_text_shadow !== false;
-    
-    ["name", "info"].forEach(type => {
+    ["name", "info"].forEach((type) => {
       const w = this.shadowRoot.getElementById(`header-${type}-weight-sel`);
       if (w) {
         const val = this._config?.[`header_${type}_weight`] || (type === "name" ? "bold" : "normal");
@@ -8090,7 +8481,6 @@ if (tmplSelect) {
       }
     });
   }
-
   updPreview() {
     if (!this._config) return;
     const img = this.shadowRoot.getElementById("prev-img");
@@ -8108,15 +8498,14 @@ if (tmplSelect) {
     }
     this._updateFocalPointUI();
   }
-
   _saveAllScrollPositions() {
     const saved = [];
-    const seen = new WeakSet();
+    const seen = /* @__PURE__ */ new WeakSet();
     const scan = (root) => {
       try {
         const iter = document.createNodeIterator(root, NodeFilter.SHOW_ELEMENT);
         let node;
-        while ((node = iter.nextNode())) {
+        while (node = iter.nextNode()) {
           if (seen.has(node)) continue;
           seen.add(node);
           if (node.scrollTop > 0 || node.scrollLeft > 0) {
@@ -8124,15 +8513,16 @@ if (tmplSelect) {
           }
           if (node.shadowRoot) scan(node.shadowRoot);
         }
-      } catch (_e) { }
+      } catch (_e) {
+      }
     };
     scan(document.body);
     return saved;
   }
-
   renBtn() {
     if (!this._config?.controls) return;
-    const div = this.shadowRoot.getElementById("b"); if (!div) return;
+    const div = this.shadowRoot.getElementById("b");
+    if (!div) return;
     const h = this._hass;
     if (!h) return;
     this._syncControlIds();
@@ -8144,7 +8534,8 @@ if (tmplSelect) {
     ];
     const boxes = [];
     this._config.controls.forEach((ctrl, i) => {
-      const box = document.createElement("details"); box.className = "box";
+      const box = document.createElement("details");
+      box.className = "box";
       const isTemplate = ctrl.type === "template";
       const hideEntity = isTemplate ? "hidden" : "";
       const showTemplate = isTemplate ? "" : "hidden";
@@ -8153,20 +8544,26 @@ if (tmplSelect) {
       const key = this._controlIds[i] || this._makeControlId();
       this._controlIds[i] = key;
       box.dataset.controlId = key;
-      box.addEventListener("pointerdown", () => { this._lastInteractedControlId = key; });
-      box.addEventListener("focusin", () => { this._lastInteractedControlId = key; });
+      box.addEventListener("pointerdown", () => {
+        this._lastInteractedControlId = key;
+      });
+      box.addEventListener("focusin", () => {
+        this._lastInteractedControlId = key;
+      });
       this._collapsedState = this._collapsedState || {};
-      if (this._collapsedState[key] === undefined) this._collapsedState[key] = true;
+      if (this._collapsedState[key] === void 0) this._collapsedState[key] = true;
       const r_dom = (ctrl.entity || "").split(".")[0];
       const r_st = h.states[ctrl.entity];
       const r_supp = r_st?.attributes?.supported_color_modes || [];
-      const r_hasColorTemp = r_supp.includes("color_temp") || r_st?.attributes?.color_temp !== undefined;
+      const r_hasColorTemp = r_supp.includes("color_temp") || r_st?.attributes?.color_temp !== void 0;
       const showStyle = ctrl.control_mode === "slider" ? "block" : "none";
-      const showMode = (ctrl.control_mode === "slider" && r_dom === "light" && r_hasColorTemp) ? "block" : "none";
+      const showMode = ctrl.control_mode === "slider" && r_dom === "light" && r_hasColorTemp ? "block" : "none";
       box.open = this._collapsedState[key] !== true;
-      box.addEventListener("toggle", () => { this._collapsedState[key] = !box.open; this._updateBulkToggleButton(); });
-      const summaryText = ctrl.name || ctrl.entity || (isTemplate ? (ctrl.content || "Template") : "Button");
-      // Static per-control editor scaffold. summaryText is assigned with textContent below.
+      box.addEventListener("toggle", () => {
+        this._collapsedState[key] = !box.open;
+        this._updateBulkToggleButton();
+      });
+      const summaryText = ctrl.name || ctrl.entity || (isTemplate ? ctrl.content || "Template" : "Button");
       box.innerHTML = `
         <summary class="head">
           <span class="head-left"><ha-icon class="chev" icon="mdi:chevron-right"></ha-icon><span class="summary-text"></span></span>
@@ -8283,7 +8680,6 @@ if (tmplSelect) {
         </div>
         </div>`;
       box.querySelector(".summary-text").textContent = `#${i + 1} — ${summaryText}`;
-
       const head = box.querySelector(".head");
       if (head) {
         head.setAttribute("draggable", "true");
@@ -8326,12 +8722,29 @@ if (tmplSelect) {
         this._fire({ ...this._config, controls: c });
         this.renBtn();
       });
-
-      const keepOpen = () => { this._collapsedState[key] = false; };
-      const upd = (k, v, skipRender = false) => { keepOpen(); const c = [...this._config.controls]; c[i] = { ...c[i], [k]: v }; if (skipRender) { this._lastRenderedControlsSig = JSON.stringify(c); } this._fire({ ...this._config, controls: c }); };
-      const updAct = (type, val) => { keepOpen(); const c = [...this._config.controls]; const old = c[i][type] || {}; c[i] = { ...c[i], [type]: { ...old, action: val } }; this._fire({ ...this._config, controls: c }); this.renBtn(); };
+      const keepOpen = () => {
+        this._collapsedState[key] = false;
+      };
+      const upd = (k, v, skipRender = false) => {
+        keepOpen();
+        const c = [...this._config.controls];
+        c[i] = { ...c[i], [k]: v };
+        if (skipRender) {
+          this._lastRenderedControlsSig = JSON.stringify(c);
+        }
+        this._fire({ ...this._config, controls: c });
+      };
+      const updAct = (type, val) => {
+        keepOpen();
+        const c = [...this._config.controls];
+        const old = c[i][type] || {};
+        c[i] = { ...c[i], [type]: { ...old, action: val } };
+        this._fire({ ...this._config, controls: c });
+        this.renBtn();
+      };
       box.querySelector(".u").onclick = (e) => {
-        e.preventDefault(); e.stopPropagation();
+        e.preventDefault();
+        e.stopPropagation();
         if (i > 0) {
           const c = [...this._config.controls];
           [c[i], c[i - 1]] = [c[i - 1], c[i]];
@@ -8343,7 +8756,8 @@ if (tmplSelect) {
         }
       };
       box.querySelector(".d").onclick = (e) => {
-        e.preventDefault(); e.stopPropagation();
+        e.preventDefault();
+        e.stopPropagation();
         if (i < this._config.controls.length - 1) {
           const c = [...this._config.controls];
           [c[i], c[i + 1]] = [c[i + 1], c[i]];
@@ -8355,7 +8769,8 @@ if (tmplSelect) {
         }
       };
       box.querySelector(".del").onclick = (e) => {
-        e.preventDefault(); e.stopPropagation();
+        e.preventDefault();
+        e.stopPropagation();
         const c = [...this._config.controls];
         c.splice(i, 1);
         this._controlIds.splice(i, 1);
@@ -8368,14 +8783,15 @@ if (tmplSelect) {
         rt.hass = h;
         rt.selector = {
           select: {
-            mode: "dropdown", options: [
+            mode: "dropdown",
+            options: [
               { value: "entity", label: getTranslation(h, "type_entity") },
               { value: "template", label: getTranslation(h, "type_template") }
             ]
           }
         };
         rt.value = isTemplate ? "template" : "entity";
-        rt.addEventListener("value-changed", e => {
+        rt.addEventListener("value-changed", (e) => {
           e.stopPropagation();
           const val = e.detail?.value;
           const c = [...this._config.controls];
@@ -8388,12 +8804,19 @@ if (tmplSelect) {
           } else {
             delete next.type;
           }
-          c[i] = next; this._fire({ ...this._config, controls: c }); this.renBtn();
+          c[i] = next;
+          this._fire({ ...this._config, controls: c });
+          this.renBtn();
         });
       }
-      const ep = box.querySelector(".ep"); if (ep) {
-        ep.hass = h; ep.value = ctrl.entity; ep.addEventListener("value-changed", e => {
-          const val = e.detail.value; const st = h.states[val]; const c = [...this._config.controls];
+      const ep = box.querySelector(".ep");
+      if (ep) {
+        ep.hass = h;
+        ep.value = ctrl.entity;
+        ep.addEventListener("value-changed", (e) => {
+          const val = e.detail.value;
+          const st = h.states[val];
+          const c = [...this._config.controls];
           const epDomain = val?.split(".")[0] || "";
           let next = { ...c[i], entity: val };
           if (st?.attributes?.friendly_name) next.name = st.attributes.friendly_name;
@@ -8402,7 +8825,10 @@ if (tmplSelect) {
           } else {
             next.icon = st?.attributes?.icon || this._iconForEntity(val);
           }
-          keepOpen(); c[i] = next; this._fire({ ...this._config, controls: c }); this.renBtn();
+          keepOpen();
+          c[i] = next;
+          this._fire({ ...this._config, controls: c });
+          this.renBtn();
         });
       }
       const dvWrap = box.querySelector(".dv-wrap");
@@ -8413,11 +8839,11 @@ if (tmplSelect) {
         dv.hass = h;
         dv.selector = { device: {} };
         dv.value = ctrl.device || "";
-        dv.addEventListener("value-changed", async e => {
+        dv.addEventListener("value-changed", async (e) => {
           e.stopPropagation();
           const deviceId = e.detail?.value ?? "";
           const c = [...this._config.controls];
-          const next = { ...c[i], device: deviceId || undefined };
+          const next = { ...c[i], device: deviceId || void 0 };
           if (deviceId) {
             const ent = await this._resolveEntityFromDevice(deviceId);
             if (ent) {
@@ -8427,18 +8853,24 @@ if (tmplSelect) {
               if (st?.attributes?.friendly_name) next.name = st.attributes.friendly_name;
             }
           }
-          keepOpen(); c[i] = next; this._fire({ ...this._config, controls: c }); this.renBtn();
+          keepOpen();
+          c[i] = next;
+          this._fire({ ...this._config, controls: c });
+          this.renBtn();
         });
         dvWrap.appendChild(dv);
       }
-      const nm = box.querySelector(".nm"); if (nm) { nm.value = ctrl.name || ""; nm.addEventListener("change", e => upd("name", e.target.value)); }
-
+      const nm = box.querySelector(".nm");
+      if (nm) {
+        nm.value = ctrl.name || "";
+        nm.addEventListener("change", (e) => upd("name", e.target.value));
+      }
       const clPop = box.querySelector(".cl-pop");
       const clp = box.querySelector(".cl-p");
       const clPrv = clp?.closest(".cp-preview")?.querySelector("div");
       if (clPop) {
         clPop.value = ctrl.color || "";
-        clPop.addEventListener("change", e => {
+        clPop.addEventListener("change", (e) => {
           const val = e.target.value;
           upd("color", val);
           if (clp) clp.value = parseColorToPickerHex(val);
@@ -8448,21 +8880,20 @@ if (tmplSelect) {
       if (clp) {
         clp.value = parseColorToPickerHex(ctrl.color || "#000000");
         if (clPrv) clPrv.style.backgroundColor = ctrl.color || "#000000";
-        clp.addEventListener("input", e => {
+        clp.addEventListener("input", (e) => {
           const val = e.target.value;
           upd("color", val);
           if (clPop) clPop.value = val;
           if (clPrv) clPrv.style.backgroundColor = val;
         });
       }
-
       const bgTxt = box.querySelector(".bg-txt");
       const bgPop = box.querySelector(".bg-txt-pop");
       const bgCp = box.querySelector(".bg-cp");
       const bgPrv = bgCp?.closest(".cp-preview")?.querySelector("div");
       if (bgTxt) {
         bgTxt.value = ctrl.button_background || "";
-        bgTxt.addEventListener("change", e => {
+        bgTxt.addEventListener("change", (e) => {
           const val = trimStr(e.target.value || "");
           upd("button_background", val);
           if (bgPop) bgPop.value = val;
@@ -8472,7 +8903,7 @@ if (tmplSelect) {
       }
       if (bgPop) {
         bgPop.value = ctrl.button_background || "";
-        bgPop.addEventListener("change", e => {
+        bgPop.addEventListener("change", (e) => {
           const val = trimStr(e.target.value || "");
           upd("button_background", val);
           if (bgTxt) bgTxt.value = val;
@@ -8483,7 +8914,7 @@ if (tmplSelect) {
       if (bgCp) {
         bgCp.value = parseColorToPickerHex(ctrl.button_background || "#ffffff");
         if (bgPrv) bgPrv.style.backgroundColor = ctrl.button_background || "#ffffff";
-        bgCp.addEventListener("input", e => {
+        bgCp.addEventListener("input", (e) => {
           const val = e.target.value;
           upd("button_background", val);
           if (bgTxt) bgTxt.value = val;
@@ -8491,7 +8922,7 @@ if (tmplSelect) {
           if (bgPrv) bgPrv.style.backgroundColor = val;
         });
       }
-      box.querySelectorAll(".local-bg-presets .bg-preset").forEach(btn => {
+      box.querySelectorAll(".local-bg-presets .bg-preset").forEach((btn) => {
         btn.addEventListener("click", () => {
           const val = btn.getAttribute("data-val");
           if (bgTxt) bgTxt.value = val;
@@ -8501,12 +8932,16 @@ if (tmplSelect) {
           upd("button_background", val);
         });
       });
-      const isz = box.querySelector(".isz"); if (isz) {
+      const isz = box.querySelector(".isz");
+      if (isz) {
         const rawIsz = trimStr(ctrl.icon_size) || "";
         isz.value = /^\d+(\.\d+)?(px)?$/.test(rawIsz) ? rawIsz.replace("px", "") : rawIsz;
-        isz.addEventListener("change", e => { e.stopPropagation(); const v = e.target.value.trim(); upd("icon_size", v || undefined); });
+        isz.addEventListener("change", (e) => {
+          e.stopPropagation();
+          const v = e.target.value.trim();
+          upd("icon_size", v || void 0);
+        });
       }
-      
       const coverOnly = box.querySelector(".cover-only");
       const ctrlDomain = ctrl.entity?.split(".")?.[0] || "";
       if (coverOnly) {
@@ -8515,29 +8950,33 @@ if (tmplSelect) {
         const cpv = coverOnly.querySelector(".cpv");
         if (scp) {
           scp.checked = ctrl.show_cover_presets === true;
-          scp.addEventListener("change", e => {
+          scp.addEventListener("change", (e) => {
             e.stopPropagation();
             const c = [...this._config.controls];
             const next = { ...c[i], show_cover_presets: e.target.checked === true };
             if (!e.target.checked) delete next.show_cover_presets;
-            c[i] = next; keepOpen(); this._fire({ ...this._config, controls: c });
+            c[i] = next;
+            keepOpen();
+            this._fire({ ...this._config, controls: c });
           });
         }
         if (cpv) {
-          const presets = Array.isArray(ctrl.cover_presets) ? ctrl.cover_presets.join(", ") : (ctrl.cover_presets || "");
+          const presets = Array.isArray(ctrl.cover_presets) ? ctrl.cover_presets.join(", ") : ctrl.cover_presets || "";
           cpv.value = presets;
-          cpv.addEventListener("change", e => {
+          cpv.addEventListener("change", (e) => {
             e.stopPropagation();
             const raw = e.target.value.trim();
-            const parsed = raw ? raw.split(",").map(v => parseFloat(v.trim())).filter(v => !isNaN(v)) : undefined;
+            const parsed = raw ? raw.split(",").map((v) => parseFloat(v.trim())).filter((v) => !isNaN(v)) : void 0;
             const c = [...this._config.controls];
             const next = { ...c[i] };
-            if (parsed?.length) next.cover_presets = parsed; else delete next.cover_presets;
-            c[i] = next; keepOpen(); this._fire({ ...this._config, controls: c });
+            if (parsed?.length) next.cover_presets = parsed;
+            else delete next.cover_presets;
+            c[i] = next;
+            keepOpen();
+            this._fire({ ...this._config, controls: c });
           });
         }
       }
-      
       const climateOnly = box.querySelector(".climate-only");
       if (climateOnly) {
         climateOnly.hidden = ctrlDomain !== "climate";
@@ -8545,56 +8984,67 @@ if (tmplSelect) {
         const ctpv = climateOnly.querySelector(".ctpv");
         if (sctp) {
           sctp.checked = ctrl.show_climate_presets === true;
-          sctp.addEventListener("change", e => {
+          sctp.addEventListener("change", (e) => {
             e.stopPropagation();
             const c = [...this._config.controls];
             const next = { ...c[i] };
-            if (e.target.checked) next.show_climate_presets = true; else delete next.show_climate_presets;
-            c[i] = next; keepOpen(); this._fire({ ...this._config, controls: c });
+            if (e.target.checked) next.show_climate_presets = true;
+            else delete next.show_climate_presets;
+            c[i] = next;
+            keepOpen();
+            this._fire({ ...this._config, controls: c });
           });
         }
         if (ctpv) {
-          const presets = Array.isArray(ctrl.climate_presets) ? ctrl.climate_presets.join(", ") : (ctrl.climate_presets || "");
+          const presets = Array.isArray(ctrl.climate_presets) ? ctrl.climate_presets.join(", ") : ctrl.climate_presets || "";
           ctpv.value = presets;
-          ctpv.addEventListener("change", e => {
+          ctpv.addEventListener("change", (e) => {
             e.stopPropagation();
             const raw = e.target.value.trim();
-            const parsed = raw ? raw.split(",").map(v => {
+            const parsed = raw ? raw.split(",").map((v) => {
               const t = v.trim().toLowerCase();
               if (t === "auto" || t === "max") return t;
               const n = parseFloat(t);
               return isNaN(n) ? null : n;
-            }).filter(v => v !== null) : undefined;
+            }).filter((v) => v !== null) : void 0;
             const c = [...this._config.controls];
             const next = { ...c[i] };
-            if (parsed?.length) next.climate_presets = parsed; else delete next.climate_presets;
-            c[i] = next; keepOpen(); this._fire({ ...this._config, controls: c });
+            if (parsed?.length) next.climate_presets = parsed;
+            else delete next.climate_presets;
+            c[i] = next;
+            keepOpen();
+            this._fire({ ...this._config, controls: c });
           });
         }
         const shvac = climateOnly.querySelector(".shvac");
         if (shvac) {
           shvac.checked = ctrl.show_hvac_modes === true;
-          shvac.addEventListener("change", e => {
+          shvac.addEventListener("change", (e) => {
             e.stopPropagation();
             const c = [...this._config.controls];
             const next = { ...c[i] };
-            if (e.target.checked) next.show_hvac_modes = true; else delete next.show_hvac_modes;
-            c[i] = next; keepOpen(); this._fire({ ...this._config, controls: c });
+            if (e.target.checked) next.show_hvac_modes = true;
+            else delete next.show_hvac_modes;
+            c[i] = next;
+            keepOpen();
+            this._fire({ ...this._config, controls: c });
           });
         }
         const sfan = climateOnly.querySelector(".sfan");
         if (sfan) {
           sfan.checked = ctrl.show_fan_modes === true;
-          sfan.addEventListener("change", e => {
+          sfan.addEventListener("change", (e) => {
             e.stopPropagation();
             const c = [...this._config.controls];
             const next = { ...c[i] };
-            if (e.target.checked) next.show_fan_modes = true; else delete next.show_fan_modes;
-            c[i] = next; keepOpen(); this._fire({ ...this._config, controls: c });
+            if (e.target.checked) next.show_fan_modes = true;
+            else delete next.show_fan_modes;
+            c[i] = next;
+            keepOpen();
+            this._fire({ ...this._config, controls: c });
           });
         }
       }
-
       const lightOnly = box.querySelector(".light-only");
       if (lightOnly) {
         lightOnly.hidden = ctrlDomain !== "light";
@@ -8605,18 +9055,20 @@ if (tmplSelect) {
         const cfvContainer = lightOnly.querySelector(".cfv-swatches");
         if (sbv) {
           sbv.checked = ctrl.show_brightness_value !== false;
-          sbv.addEventListener("change", e => {
+          sbv.addEventListener("change", (e) => {
             e.stopPropagation();
             const c = [...this._config.controls];
             const next = { ...c[i] };
             next.show_brightness_value = e.target.checked;
             this._lastInteractedControlId = key;
-            c[i] = next; keepOpen(); this._fire({ ...this._config, controls: c });
+            c[i] = next;
+            keepOpen();
+            this._fire({ ...this._config, controls: c });
           });
         }
         if (sbp) {
           sbp.checked = ctrl.show_brightness_presets === true;
-          sbp.addEventListener("change", e => {
+          sbp.addEventListener("change", (e) => {
             e.stopPropagation();
             const c = [...this._config.controls];
             const next = { ...c[i] };
@@ -8627,57 +9079,58 @@ if (tmplSelect) {
               delete next.show_brightness_presets;
             }
             this._lastInteractedControlId = key;
-            c[i] = next; keepOpen(); this._fire({ ...this._config, controls: c });
+            c[i] = next;
+            keepOpen();
+            this._fire({ ...this._config, controls: c });
           });
         }
         if (bpv) {
-          bpv.value = Array.isArray(ctrl.brightness_presets)
-            ? ctrl.brightness_presets.join(", ")
-            : (ctrl.brightness_presets || "");
-          bpv.addEventListener("change", e => {
+          bpv.value = Array.isArray(ctrl.brightness_presets) ? ctrl.brightness_presets.join(", ") : ctrl.brightness_presets || "";
+          bpv.addEventListener("change", (e) => {
             e.stopPropagation();
             const raw = e.target.value.trim();
-            const parsed = raw
-              ? raw.split(",")
-                .map(v => parseFloat(v.trim()))
-                .filter(v => !isNaN(v))
-                .map(v => Math.max(1, Math.min(100, Math.round(v))))
-              : [];
+            const parsed = raw ? raw.split(",").map((v) => parseFloat(v.trim())).filter((v) => !isNaN(v)).map((v) => Math.max(1, Math.min(100, Math.round(v)))) : [];
             const c = [...this._config.controls];
             const next = { ...c[i] };
             const unique = [...new Set(parsed)];
             if (unique.length) next.brightness_presets = unique;
             else delete next.brightness_presets;
             this._lastInteractedControlId = key;
-            c[i] = next; keepOpen(); this._fire({ ...this._config, controls: c });
+            c[i] = next;
+            keepOpen();
+            this._fire({ ...this._config, controls: c });
           });
         }
         if (scf) {
           scf.checked = ctrl.show_color_favorites === true;
-          scf.addEventListener("change", e => {
+          scf.addEventListener("change", (e) => {
             e.stopPropagation();
             const c = [...this._config.controls];
             const next = { ...c[i] };
             if (e.target.checked) {
               next.show_color_favorites = true;
               if (!next.color_favorites) next.color_favorites = "#ff9800; #2196f3; #4caf50";
-            } else { delete next.show_color_favorites; }
+            } else {
+              delete next.show_color_favorites;
+            }
             this._lastInteractedControlId = key;
-            c[i] = next; keepOpen(); this._fire({ ...this._config, controls: c });
+            c[i] = next;
+            keepOpen();
+            this._fire({ ...this._config, controls: c });
           });
         }
         if (cfvContainer) {
           const parseFavToHex = (raw) => {
             const t = String(raw).trim();
             if (/^#[0-9a-f]{6}$/i.test(t)) return t.toLowerCase();
-            const parts = t.split(",").map(v => parseInt(v.trim(), 10));
-            if (parts.length === 3 && parts.every(p => !isNaN(p) && p >= 0 && p <= 255))
-              return "#" + parts.map(p => p.toString(16).padStart(2, "0")).join("");
+            const parts = t.split(",").map((v) => parseInt(v.trim(), 10));
+            if (parts.length === 3 && parts.every((p) => !isNaN(p) && p >= 0 && p <= 255))
+              return "#" + parts.map((p) => p.toString(16).padStart(2, "0")).join("");
             return null;
           };
           const getFavsArray = (raw) => {
-            if (Array.isArray(raw)) return raw.map(v => parseFavToHex(Array.isArray(v) ? v.join(",") : v)).filter(Boolean);
-            if (typeof raw === "string") return raw.split(";").map(s => parseFavToHex(s)).filter(Boolean);
+            if (Array.isArray(raw)) return raw.map((v) => parseFavToHex(Array.isArray(v) ? v.join(",") : v)).filter(Boolean);
+            if (typeof raw === "string") return raw.split(";").map((s) => parseFavToHex(s)).filter(Boolean);
             return [];
           };
           const rebuildSwatches = () => {
@@ -8692,29 +9145,33 @@ if (tmplSelect) {
               picker.type = "color";
               picker.value = hex;
               picker.style.cssText = "position:absolute;inset:0;opacity:0;width:100%;height:100%;cursor:pointer;border:none;padding:0;";
-              picker.addEventListener("pointerdown", e => e.stopPropagation());
-              picker.addEventListener("change", e => {
+              picker.addEventListener("pointerdown", (e) => e.stopPropagation());
+              picker.addEventListener("change", (e) => {
                 e.stopPropagation();
                 const newFavs = getFavsArray(this._config.controls[i]?.color_favorites);
                 newFavs[idx] = e.target.value;
                 const c = [...this._config.controls];
                 c[i] = { ...c[i], color_favorites: newFavs.join("; ") };
-                keepOpen(); this._fire({ ...this._config, controls: c });
+                keepOpen();
+                this._fire({ ...this._config, controls: c });
                 rebuildSwatches();
               });
               const delBtn = document.createElement("button");
               delBtn.type = "button";
               delBtn.style.cssText = "position:absolute;top:-5px;right:-5px;width:14px;height:14px;border-radius:50%;background:#d32f2f;border:none;cursor:pointer;display:flex;align-items:center;justify-content:center;padding:0;font-size:10px;color:white;line-height:1;z-index:1;";
               delBtn.textContent = "×";
-              delBtn.addEventListener("pointerdown", e => e.stopPropagation());
-              delBtn.addEventListener("click", e => {
+              delBtn.addEventListener("pointerdown", (e) => e.stopPropagation());
+              delBtn.addEventListener("click", (e) => {
                 e.stopPropagation();
                 const newFavs = getFavsArray(this._config.controls[i]?.color_favorites);
                 newFavs.splice(idx, 1);
                 const c = [...this._config.controls];
                 const next = { ...c[i] };
-                if (newFavs.length) next.color_favorites = newFavs.join("; "); else delete next.color_favorites;
-                c[i] = next; keepOpen(); this._fire({ ...this._config, controls: c });
+                if (newFavs.length) next.color_favorites = newFavs.join("; ");
+                else delete next.color_favorites;
+                c[i] = next;
+                keepOpen();
+                this._fire({ ...this._config, controls: c });
                 rebuildSwatches();
               });
               wrap.appendChild(swatch);
@@ -8732,18 +9189,22 @@ if (tmplSelect) {
             addBtn.type = "button";
             addBtn.style.cssText = "width:24px;height:24px;border-radius:50%;background:rgba(128,128,128,0.12);border:1.5px dashed var(--divider-color,rgba(0,0,0,0.25));cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:16px;color:var(--secondary-text-color);padding:0;line-height:1;";
             addBtn.textContent = "+";
-            addPicker.addEventListener("pointerdown", e => e.stopPropagation());
-            addPicker.addEventListener("change", e => {
+            addPicker.addEventListener("pointerdown", (e) => e.stopPropagation());
+            addPicker.addEventListener("change", (e) => {
               e.stopPropagation();
               const newFavs = getFavsArray(this._config.controls[i]?.color_favorites);
               newFavs.push(e.target.value);
               const c = [...this._config.controls];
               c[i] = { ...c[i], color_favorites: newFavs.join("; ") };
-              keepOpen(); this._fire({ ...this._config, controls: c });
+              keepOpen();
+              this._fire({ ...this._config, controls: c });
               rebuildSwatches();
             });
-            addBtn.addEventListener("pointerdown", e => e.stopPropagation());
-            addBtn.addEventListener("click", e => { e.stopPropagation(); addPicker.click(); });
+            addBtn.addEventListener("pointerdown", (e) => e.stopPropagation());
+            addBtn.addEventListener("click", (e) => {
+              e.stopPropagation();
+              addPicker.click();
+            });
             addWrap.appendChild(addPicker);
             addWrap.appendChild(addBtn);
             cfvContainer.appendChild(addWrap);
@@ -8751,12 +9212,10 @@ if (tmplSelect) {
           rebuildSwatches();
         }
       }
-
       const mediaOnly = box.querySelector(".media-only");
       if (mediaOnly) {
         mediaOnly.hidden = true;
       }
-      
       if (!isTemplate) {
         const entityOnly = box.querySelector(".entity-only");
         if (entityOnly) {
@@ -8769,9 +9228,7 @@ if (tmplSelect) {
           cmSec.appendChild(cmTitle);
           const cmList = document.createElement("div");
           cmSec.appendChild(cmList);
-          const normMap = ctrl.color_map
-            ? Object.fromEntries(Object.entries(ctrl.color_map).map(([k, v]) => [k === true ? "on" : k === false ? "off" : String(k), v]))
-            : {};
+          const normMap = ctrl.color_map ? Object.fromEntries(Object.entries(ctrl.color_map).map(([k, v]) => [k === true ? "on" : k === false ? "off" : String(k), v])) : {};
           Object.entries(normMap).forEach(([state, color]) => {
             const row = document.createElement("div");
             row.className = "cl-row";
@@ -8780,7 +9237,7 @@ if (tmplSelect) {
             stateField.label = getTranslation(h, "color_map_state");
             stateField.value = state;
             stateField.style.cssText = "flex:1;margin-bottom:0;";
-            stateField.addEventListener("change", ev => {
+            stateField.addEventListener("change", (ev) => {
               ev.stopPropagation();
               const newKey = ev.target.value.trim();
               const c = [...this._config.controls];
@@ -8789,118 +9246,168 @@ if (tmplSelect) {
               delete oldMap[state];
               if (newKey) oldMap[newKey] = colorVal;
               const next = { ...c[i] };
-              if (Object.keys(oldMap).length > 0) next.color_map = oldMap; else delete next.color_map;
-              c[i] = next; keepOpen(); this._fire({ ...this._config, controls: c }); this.renBtn();
+              if (Object.keys(oldMap).length > 0) next.color_map = oldMap;
+              else delete next.color_map;
+              c[i] = next;
+              keepOpen();
+              this._fire({ ...this._config, controls: c });
+              this.renBtn();
             });
             const colorField = document.createElement("oneline-room-card-textfield");
             colorField.label = getTranslation(h, "color");
             colorField.value = typeof color === "string" ? color : "";
             colorField.style.cssText = "flex:1;margin-bottom:0;";
-            colorField.addEventListener("change", ev => {
+            colorField.addEventListener("change", (ev) => {
               ev.stopPropagation();
               const c = [...this._config.controls];
               const newMap = Object.fromEntries(Object.entries(c[i]?.color_map || {}).map(([k, v]) => [k === true ? "on" : k === false ? "off" : String(k), v]));
               newMap[state] = ev.target.value;
-              c[i] = { ...c[i], color_map: newMap }; keepOpen(); this._fire({ ...this._config, controls: c });
+              c[i] = { ...c[i], color_map: newMap };
+              keepOpen();
+              this._fire({ ...this._config, controls: c });
               if (cmPicker) cmPicker.value = parseColorToPickerHex(ev.target.value);
             });
             const cmPicker = document.createElement("input");
             cmPicker.type = "color";
             cmPicker.className = "cp";
             cmPicker.value = parseColorToPickerHex(typeof color === "string" ? color : "#000000");
-            cmPicker.addEventListener("change", ev => {
+            cmPicker.addEventListener("change", (ev) => {
               ev.stopPropagation();
               const c = [...this._config.controls];
               const newMap = Object.fromEntries(Object.entries(c[i]?.color_map || {}).map(([k, v]) => [k === true ? "on" : k === false ? "off" : String(k), v]));
               newMap[state] = ev.target.value;
-              c[i] = { ...c[i], color_map: newMap }; keepOpen(); this._fire({ ...this._config, controls: c });
+              c[i] = { ...c[i], color_map: newMap };
+              keepOpen();
+              this._fire({ ...this._config, controls: c });
               colorField.value = ev.target.value;
             });
             const delCmBtn = document.createElement("button");
             delCmBtn.type = "button";
             delCmBtn.className = "badge-del-btn";
             delCmBtn.innerHTML = `<ha-icon icon="mdi:delete-outline"></ha-icon>`;
-            delCmBtn.addEventListener("click", ev => {
+            delCmBtn.addEventListener("click", (ev) => {
               ev.stopPropagation();
               const c = [...this._config.controls];
               const newMap = Object.fromEntries(Object.entries(c[i]?.color_map || {}).map(([k, v]) => [k === true ? "on" : k === false ? "off" : String(k), v]));
               delete newMap[state];
               const next = { ...c[i] };
-              if (Object.keys(newMap).length > 0) next.color_map = newMap; else delete next.color_map;
-              c[i] = next; keepOpen(); this._fire({ ...this._config, controls: c }); this.renBtn();
+              if (Object.keys(newMap).length > 0) next.color_map = newMap;
+              else delete next.color_map;
+              c[i] = next;
+              keepOpen();
+              this._fire({ ...this._config, controls: c });
+              this.renBtn();
             });
-            row.appendChild(stateField); row.appendChild(colorField); row.appendChild(cmPicker); row.appendChild(delCmBtn);
+            row.appendChild(stateField);
+            row.appendChild(colorField);
+            row.appendChild(cmPicker);
+            row.appendChild(delCmBtn);
             cmList.appendChild(row);
           });
           const addCmBtn = document.createElement("mwc-button");
           addCmBtn.setAttribute("raised", "");
           addCmBtn.setAttribute("label", getTranslation(h, "color_map_add"));
           addCmBtn.innerHTML = `<ha-icon icon="mdi:plus" slot="icon"></ha-icon>`;
-          addCmBtn.addEventListener("click", ev => {
+          addCmBtn.addEventListener("click", (ev) => {
             ev.stopPropagation();
             const c = [...this._config.controls];
             const newMap = Object.fromEntries(Object.entries(c[i]?.color_map || {}).map(([k, v]) => [k === true ? "on" : k === false ? "off" : String(k), v]));
-            let newKey = "state"; let idx = 1;
-            while (newKey in newMap) { newKey = `state${idx++}`; }
+            let newKey = "state";
+            let idx = 1;
+            while (newKey in newMap) {
+              newKey = `state${idx++}`;
+            }
             newMap[newKey] = "#ffffff";
-            c[i] = { ...c[i], color_map: newMap }; keepOpen(); this._fire({ ...this._config, controls: c }); this.renBtn();
+            c[i] = { ...c[i], color_map: newMap };
+            keepOpen();
+            this._fire({ ...this._config, controls: c });
+            this.renBtn();
           });
           cmSec.appendChild(addCmBtn);
           entityOnly.appendChild(cmSec);
         }
       }
-      const ic = box.querySelector(".ic"); if (ic) { ic.value = ctrl.icon || ""; ic.addEventListener("value-changed", e => { e.stopPropagation(); upd("icon", e.detail.value); }); }
-      const tc = box.querySelector(".tc"); if (tc) { tc.value = ctrl.content || ""; tc.addEventListener("change", e => { upd("content", e.target.value); this.renBtn(); }); }
-      const ti = box.querySelector(".ti"); if (ti) { ti.value = ctrl.icon || ""; ti.addEventListener("change", e => { upd("icon", e.target.value); this.renBtn(); }); }
-      const tcl = box.querySelector(".tcl"); if (tcl) { tcl.value = ctrl.color || ""; tcl.addEventListener("change", e => { upd("color", e.target.value); this.renBtn(); }); }
-      const ts = box.querySelector(".ts"); if (ts) { ts.value = ctrl.state || ""; ts.addEventListener("change", e => { upd("state", e.target.value); this.renBtn(); }); }
-      
-      const ht = box.querySelector(".ht"); 
+      const ic = box.querySelector(".ic");
+      if (ic) {
+        ic.value = ctrl.icon || "";
+        ic.addEventListener("value-changed", (e) => {
+          e.stopPropagation();
+          upd("icon", e.detail.value);
+        });
+      }
+      const tc = box.querySelector(".tc");
+      if (tc) {
+        tc.value = ctrl.content || "";
+        tc.addEventListener("change", (e) => {
+          upd("content", e.target.value);
+          this.renBtn();
+        });
+      }
+      const ti = box.querySelector(".ti");
+      if (ti) {
+        ti.value = ctrl.icon || "";
+        ti.addEventListener("change", (e) => {
+          upd("icon", e.target.value);
+          this.renBtn();
+        });
+      }
+      const tcl = box.querySelector(".tcl");
+      if (tcl) {
+        tcl.value = ctrl.color || "";
+        tcl.addEventListener("change", (e) => {
+          upd("color", e.target.value);
+          this.renBtn();
+        });
+      }
+      const ts = box.querySelector(".ts");
+      if (ts) {
+        ts.value = ctrl.state || "";
+        ts.addEventListener("change", (e) => {
+          upd("state", e.target.value);
+          this.renBtn();
+        });
+      }
+      const ht = box.querySelector(".ht");
       if (ht) {
-        ht.hass = h; 
+        ht.hass = h;
         ht.selector = { number: { min: 40, max: 250, mode: "box", unit_of_measurement: "px" } };
-        ht.value = ctrl.height || 60; 
-        ht.addEventListener("value-changed", e => { 
-          e.stopPropagation(); 
-          e.target.value = e.detail.value; // UI sofort zwingen
-          upd("height", Number(e.detail.value), true); // skipRender = true
+        ht.value = ctrl.height || 60;
+        ht.addEventListener("value-changed", (e) => {
+          e.stopPropagation();
+          e.target.value = e.detail.value;
+          upd("height", Number(e.detail.value), true);
         });
       }
-      
- const wd = box.querySelector(".wd"); 
+      const wd = box.querySelector(".wd");
       if (wd) {
-        wd.hass = h; 
+        wd.hass = h;
         wd.selector = { select: { mode: "dropdown", options: [{ value: "60", label: "1/1" }, { value: "40", label: "2/3" }, { value: "30", label: "1/2" }, { value: "20", label: "1/3" }, { value: "15", label: "1/4" }, { value: "12", label: "1/5" }, { value: "10", label: "1/6" }] } };
-        wd.value = String(ctrl.width || 15); 
-        wd.addEventListener("value-changed", e => { 
-          e.stopPropagation(); 
+        wd.value = String(ctrl.width || 15);
+        wd.addEventListener("value-changed", (e) => {
+          e.stopPropagation();
           if (!e.detail.value) return;
-
-          // 1. UI sofort auf den neuen Text-Wert zwingen (wie bei lp)
-          e.target.value = e.detail.value; 
-
-          // 2. Als Zahl speichern, aber mit 'true' (skipRender) den UI-Abbruch verhindern!
-          upd("width", parseInt(e.detail.value, 10), true); 
+          e.target.value = e.detail.value;
+          upd("width", parseInt(e.detail.value, 10), true);
         });
       }
-      
-      const al = box.querySelector(".al"); 
+      const al = box.querySelector(".al");
       if (al) {
-        al.hass = h; 
+        al.hass = h;
         al.selector = { select: { mode: "dropdown", options: [{ value: "left", label: getTranslation(h, "left") }, { value: "center", label: getTranslation(h, "center") }, { value: "right", label: getTranslation(h, "right") }] } };
-        al.value = ctrl.align || "center"; 
-        al.addEventListener("value-changed", e => { 
-          e.stopPropagation(); 
-          e.target.value = e.detail.value; // UI sofort zwingen
-          upd("align", e.detail.value, true); // skipRender = true
+        al.value = ctrl.align || "center";
+        al.addEventListener("value-changed", (e) => {
+          e.stopPropagation();
+          e.target.value = e.detail.value;
+          upd("align", e.detail.value, true);
         });
       }
-
-      const lp = box.querySelector(".lp"); if (lp) {
+      const lp = box.querySelector(".lp");
+      if (lp) {
         lp.hass = h;
         lp.selector = {
           select: {
-            mode: "dropdown", options: [
+            mode: "dropdown",
+            options: [
               { value: "global", label: getTranslation(h, "use_global") || "Global" },
               { value: "right", label: getTranslation(h, "pos_right") || "Rechts" },
               { value: "bottom", label: getTranslation(h, "pos_bottom") || "Unten" },
@@ -8910,129 +9417,137 @@ if (tmplSelect) {
           }
         };
         lp.value = ctrl.label_position || "global";
-        lp.addEventListener("value-changed", e => { 
-          e.stopPropagation(); 
+        lp.addEventListener("value-changed", (e) => {
+          e.stopPropagation();
           const val = e.detail.value;
-          
-          // FIX 1: UI sofort zwingen, den Text zu behalten
           e.target.value = val;
-          
           if (val === "global" || !val) {
             keepOpen();
             const c = [...this._config.controls];
             delete c[i].label_position;
-            // FIX 2: Signatur aktualisieren, um unnötigen Re-Render zu blockieren
-            this._lastRenderedControlsSig = JSON.stringify(c); 
+            this._lastRenderedControlsSig = JSON.stringify(c);
             this._fire({ ...this._config, controls: c });
           } else {
-            // FIX 3: Das 'true' am Ende ist extrem wichtig! Es bedeutet "skipRender = true".
-            // Dadurch wird `this.renBtn()` NICHT ausgeführt und das Dropdown stürzt nicht ab.
-            upd("label_position", val, true); 
+            upd("label_position", val, true);
           }
         });
       }
-const tl = box.querySelector(".tl"); 
+      const tl = box.querySelector(".tl");
       if (tl) {
         tl.hass = h;
         tl.selector = {
           select: {
-            mode: "dropdown", options: [
+            mode: "dropdown",
+            options: [
               { value: "state", label: getTranslation(h, "primary_state") || "Wert zuerst" },
               { value: "name", label: getTranslation(h, "primary_name") || "Name zuerst" }
             ]
           }
         };
         tl.value = ctrl.state_first === true ? "state" : "name";
-        tl.addEventListener("value-changed", e => { 
-          e.stopPropagation(); 
+        tl.addEventListener("value-changed", (e) => {
+          e.stopPropagation();
           if (!e.detail.value) return;
-          
           const isStateFirst = e.detail.value === "state";
           const currentStateFirst = this._config.controls[i]?.state_first === true;
-          
-          // Endlos-Schleife & unnötiges Speichern verhindern
           if (isStateFirst === currentStateFirst) return;
-          
-          // 1. UI sofort zwingen, den Text visuell zu behalten
-          e.target.value = e.detail.value; 
-          
-          // 2. Als Boolean speichern, aber mit 'true' (skipRender) den UI-Abbruch verhindern!
-          upd("state_first", isStateFirst, true); 
+          e.target.value = e.detail.value;
+          upd("state_first", isStateFirst, true);
         });
       }
-      const ss = box.querySelector(".ss"); ss.checked = ctrl.show_state !== false; ss.addEventListener("change", e => { e.stopPropagation(); upd("show_state", e.target.checked); });
-      const sl = box.querySelector(".sl"); sl.checked = ctrl.show_label !== false; sl.addEventListener("change", e => { e.stopPropagation(); upd("show_label", e.target.checked); });
-      const si = box.querySelector(".si"); si.checked = ctrl.show_icon !== false; si.addEventListener("change", e => { e.stopPropagation(); upd("show_icon", e.target.checked); });
-      const slc = box.querySelector(".slc"); if (slc) { slc.checked = ctrl.show_last_changed === true; slc.addEventListener("change", e => { e.stopPropagation(); upd("show_last_changed", e.target.checked); }); }
+      const ss = box.querySelector(".ss");
+      ss.checked = ctrl.show_state !== false;
+      ss.addEventListener("change", (e) => {
+        e.stopPropagation();
+        upd("show_state", e.target.checked);
+      });
+      const sl = box.querySelector(".sl");
+      sl.checked = ctrl.show_label !== false;
+      sl.addEventListener("change", (e) => {
+        e.stopPropagation();
+        upd("show_label", e.target.checked);
+      });
+      const si = box.querySelector(".si");
+      si.checked = ctrl.show_icon !== false;
+      si.addEventListener("change", (e) => {
+        e.stopPropagation();
+        upd("show_icon", e.target.checked);
+      });
+      const slc = box.querySelector(".slc");
+      if (slc) {
+        slc.checked = ctrl.show_last_changed === true;
+        slc.addEventListener("change", (e) => {
+          e.stopPropagation();
+          upd("show_last_changed", e.target.checked);
+        });
+      }
       const sps = box.querySelector(".sps");
       if (sps) {
         sps.checked = ctrl.show_sparkline === true;
-        sps.addEventListener("change", e => {
+        sps.addEventListener("change", (e) => {
           e.stopPropagation();
           const detailWrap = box.querySelector(".spd-wrap");
           if (detailWrap) detailWrap.style.display = r_dom === "sensor" && e.target.checked === true ? "inline-flex" : "none";
-          upd("show_sparkline", e.target.checked === true ? true : undefined);
+          upd("show_sparkline", e.target.checked === true ? true : void 0);
         });
       }
       const spd = box.querySelector(".spd");
       if (spd) {
         spd.checked = ctrl.sparkline_detail === true;
-        spd.addEventListener("change", e => { e.stopPropagation(); upd("sparkline_detail", e.target.checked === true ? true : undefined); });
+        spd.addEventListener("change", (e) => {
+          e.stopPropagation();
+          upd("sparkline_detail", e.target.checked === true ? true : void 0);
+        });
       }
       const sh = box.querySelector(".sh");
       if (sh) {
         sh.value = ctrl.sparkline_hours || "";
-        sh.addEventListener("change", e => {
+        sh.addEventListener("change", (e) => {
           e.stopPropagation();
           const num = parseFloat(e.target.value);
-          upd("sparkline_hours", (Number.isFinite(num) && num > 0) ? Math.round(num) : undefined);
+          upd("sparkline_hours", Number.isFinite(num) && num > 0 ? Math.round(num) : void 0);
         });
       }
-      const hd = box.querySelector(".hd"); hd.checked = !ctrl.hide; hd.addEventListener("change", e => { e.stopPropagation(); upd("hide", !e.target.checked); });
+      const hd = box.querySelector(".hd");
+      hd.checked = !ctrl.hide;
+      hd.addEventListener("change", (e) => {
+        e.stopPropagation();
+        upd("hide", !e.target.checked);
+      });
       const tap = box.querySelector(".tap");
       const tapNav = box.querySelector(".tap-nav");
-      
-      // CSS-Trick: Navigations-Pfad-Feld blitzschnell ein/ausblenden
       const toggleTapNav = (action) => {
         if (!tapNav) return;
         tapNav.classList.toggle("hidden", action !== "navigate");
       };
-
-      // FIX: Eigene schnelle Speicherfunktion OHNE this.renBtn()
       const saveActionFast = (type, val) => {
         keepOpen();
         const c = [...this._config.controls];
         const old = c[i][type] || {};
         c[i] = { ...c[i], [type]: { ...old, action: val } };
-        this._lastRenderedControlsSig = JSON.stringify(c); // UI-Neuaufbau hart blockieren
+        this._lastRenderedControlsSig = JSON.stringify(c);
         this._fire({ ...this._config, controls: c });
       };
-
       if (tap) {
-        tap.hass = h; 
+        tap.hass = h;
         tap.selector = { select: { mode: "dropdown", options: actOpts } };
         const initialTapAction = ctrl.tap_action?.action || "more-info";
         tap.value = initialTapAction;
         toggleTapNav(initialTapAction);
-        
-        tap.addEventListener("value-changed", e => {
+        tap.addEventListener("value-changed", (e) => {
           e.stopPropagation();
           if (!e.detail) return;
           const action = e.detail.value || "more-info";
-          
-          // Verhindert sinnloses Ausführen
           if (action === (this._config.controls[i]?.tap_action?.action || "more-info")) return;
-          
-          e.target.value = action; // 1. Dropdown zwingen, den Text zu behalten
-          toggleTapNav(action);    // 2. Feld drunter sofort ein-/ausblenden
-          saveActionFast("tap_action", action); // 3. Leise speichern
+          e.target.value = action;
+          toggleTapNav(action);
+          saveActionFast("tap_action", action);
         });
       }
-      
       if (tapNav) {
         tapNav.value = ctrl.tap_action?.navigation_path || "";
         tapNav.classList.toggle("hidden", ctrl.tap_action?.action !== "navigate");
-        tapNav.addEventListener("change", e => {
+        tapNav.addEventListener("change", (e) => {
           e.stopPropagation();
           const c = [...this._config.controls];
           const action = e.target.value ? { action: "navigate", navigation_path: e.target.value } : { action: "navigate" };
@@ -9041,196 +9556,159 @@ const tl = box.querySelector(".tl");
           this._fire({ ...this._config, controls: c });
         });
       }
-      
-      const hold = box.querySelector(".hold"); 
+      const hold = box.querySelector(".hold");
       if (hold) {
-        hold.hass = h; 
+        hold.hass = h;
         hold.selector = { select: { mode: "dropdown", options: actOpts } };
-        hold.value = ctrl.hold_action?.action || "toggle"; 
-        hold.addEventListener("value-changed", e => { 
-          e.stopPropagation(); 
+        hold.value = ctrl.hold_action?.action || "toggle";
+        hold.addEventListener("value-changed", (e) => {
+          e.stopPropagation();
           if (!e.detail) return;
           const action = e.detail.value || "toggle";
-          
           if (action === (this._config.controls[i]?.hold_action?.action || "toggle")) return;
-          
           e.target.value = action;
           saveActionFast("hold_action", action);
         });
       }
-      
-      const dbl = box.querySelector(".dbl"); 
+      const dbl = box.querySelector(".dbl");
       if (dbl) {
-        dbl.hass = h; 
+        dbl.hass = h;
         dbl.selector = { select: { mode: "dropdown", options: actOpts } };
-        dbl.value = ctrl.double_tap_action?.action || "none"; 
-        dbl.addEventListener("value-changed", e => { 
-          e.stopPropagation(); 
+        dbl.value = ctrl.double_tap_action?.action || "none";
+        dbl.addEventListener("value-changed", (e) => {
+          e.stopPropagation();
           if (!e.detail) return;
           const action = e.detail.value || "none";
-          
           if (action === (this._config.controls[i]?.double_tap_action?.action || "none")) return;
-          
           e.target.value = action;
           saveActionFast("double_tap_action", action);
         });
       }
-const cm = box.querySelector(".cm"); 
+      const cm = box.querySelector(".cm");
       if (cm) {
-        cm.hass = h; 
+        cm.hass = h;
         const isSelectDom = r_dom === "select" || r_dom === "input_select";
         const cmOptions = [
-          { value: "none", label: getTranslation(h, "ctrl_default") || "Standard" },
+          { value: "none", label: getTranslation(h, "ctrl_default") || "Standard" }
         ];
         if (!isSelectDom) {
           cmOptions.push({ value: "slider", label: getTranslation(h, "ctrl_slider") || "Inline Slider" });
         }
         cmOptions.push({ value: "buttons", label: getTranslation(h, "ctrl_buttons") || "Inline Buttons" });
         if (r_dom !== "media_player") {
-          cmOptions.push({ value: "full", label: isSelectDom ? (getTranslation(h, "ctrl_all_options") || "Alle Optionen") : (getTranslation(h, "ctrl_full") || "Full Controls") });
+          cmOptions.push({ value: "full", label: isSelectDom ? getTranslation(h, "ctrl_all_options") || "Alle Optionen" : getTranslation(h, "ctrl_full") || "Full Controls" });
         }
         cm.selector = {
           select: {
-            mode: "dropdown", options: cmOptions
+            mode: "dropdown",
+            options: cmOptions
           }
         };
         cm.value = ctrl.control_mode || "none";
-        cm.addEventListener("value-changed", e => {
+        cm.addEventListener("value-changed", (e) => {
           e.stopPropagation();
           const v = e.detail.value || "none";
           const currentMode = this._config.controls[i]?.control_mode || "none";
           if (v === currentMode) return;
-
-          // 1. Dropdown visuell sofort einrasten lassen
           e.target.value = v;
-
           keepOpen();
           const c = [...this._config.controls];
-          
-          // 2. SAUBERES LÖSCHEN statt undefined
           if (v === "none") {
             delete c[i].control_mode;
           } else {
             c[i] = { ...c[i], control_mode: v };
           }
-          
-          // 3. Speichern und UI-Neuaufbau blockieren
           this._lastRenderedControlsSig = JSON.stringify(c);
           this._fire({ ...this._config, controls: c });
-
-          // 4. CSS-Trick: Untermenüs verzögerungsfrei ein/ausblenden
           const sstWrap = box.querySelector(".sst-wrap");
           const smWrap = box.querySelector(".sm-wrap");
           if (sstWrap) sstWrap.style.display = v === "slider" ? "block" : "none";
-          if (smWrap) smWrap.style.display = (v === "slider" && r_dom === "light" && r_hasColorTemp) ? "block" : "none";
+          if (smWrap) smWrap.style.display = v === "slider" && r_dom === "light" && r_hasColorTemp ? "block" : "none";
         });
       }
-
       const sst = box.querySelector(".sst");
       if (sst) {
         sst.hass = h;
         sst.selector = { select: { mode: "dropdown", options: [
-          {value: "inline", label: getTranslation(h, "style_inline") || "Inline"},
-          {value: "background", label: getTranslation(h, "style_bg") || "Hintergrund"}
-        ]}};
+          { value: "inline", label: getTranslation(h, "style_inline") || "Inline" },
+          { value: "background", label: getTranslation(h, "style_bg") || "Hintergrund" }
+        ] } };
         sst.value = ctrl.slider_style || "inline";
-        sst.addEventListener("value-changed", e => {
+        sst.addEventListener("value-changed", (e) => {
           e.stopPropagation();
           const v = e.detail.value || "inline";
           const currentStyle = this._config.controls[i]?.slider_style || "inline";
           if (v === currentStyle) return;
-
           e.target.value = v;
-
           keepOpen();
           const c = [...this._config.controls];
-          
-          // SAUBERES LÖSCHEN
           if (v === "inline") {
             delete c[i].slider_style;
           } else {
             c[i] = { ...c[i], slider_style: v };
           }
-          
           this._lastRenderedControlsSig = JSON.stringify(c);
           this._fire({ ...this._config, controls: c });
         });
       }
-
       const sm = box.querySelector(".sm");
       if (sm) {
         sm.hass = h;
         sm.selector = { select: { mode: "dropdown", options: [
-          {value: "brightness", label: getTranslation(h, "slider_mode_brightness") || "Helligkeit"},
-          {value: "color_temp", label: getTranslation(h, "slider_mode_color_temp") || "Farbtemperatur"}
-        ]}};
+          { value: "brightness", label: getTranslation(h, "slider_mode_brightness") || "Helligkeit" },
+          { value: "color_temp", label: getTranslation(h, "slider_mode_color_temp") || "Farbtemperatur" }
+        ] } };
         sm.value = ctrl.slider_mode || "brightness";
-        sm.addEventListener("value-changed", e => {
+        sm.addEventListener("value-changed", (e) => {
           e.stopPropagation();
           const v = e.detail.value || "brightness";
           const currentMode = this._config.controls[i]?.slider_mode || "brightness";
           if (v === currentMode) return;
-
           e.target.value = v;
-
           keepOpen();
           const c = [...this._config.controls];
-          
-          // SAUBERES LÖSCHEN
           if (v === "brightness") {
             delete c[i].slider_mode;
           } else {
             c[i] = { ...c[i], slider_mode: v };
           }
-          
           this._lastRenderedControlsSig = JSON.stringify(c);
           this._fire({ ...this._config, controls: c });
         });
       }
-
-
       const visCondEditor = box.querySelector(".vis-cond-editor");
       if (visCondEditor) {
         visCondEditor.hass = h;
         visCondEditor.conditions = ctrl.visibility || [];
-        visCondEditor.addEventListener("value-changed", e => {
+        visCondEditor.addEventListener("value-changed", (e) => {
           e.stopPropagation();
           visCondEditor.conditions = e.detail.value;
           upd("visibility", e.detail.value, true);
         });
       }
-
       const chipsPosSel = box.querySelector(".chips-pos-sel");
       const chipsList = box.querySelector(".chips-list");
       const addChipBtn = box.querySelector(".add-chip");
       if (chipsPosSel) {
-        chipsPosSel.hass = h; 
-        chipsPosSel.selector = { 
-          select: { 
-            mode: "dropdown", 
-            options: [ 
-              { value: "bottom", label: getTranslation(h, "chips_bottom") || "Unter dem Titel" }, 
-              { value: "top", label: getTranslation(h, "chips_top") || "Über dem Titel" } 
+        chipsPosSel.hass = h;
+        chipsPosSel.selector = {
+          select: {
+            mode: "dropdown",
+            options: [
+              { value: "bottom", label: getTranslation(h, "chips_bottom") || "Unter dem Titel" },
+              { value: "top", label: getTranslation(h, "chips_top") || "Über dem Titel" }
             ]
           }
         };
         chipsPosSel.value = ctrl.chips_position || "bottom";
-        chipsPosSel.addEventListener("value-changed", e => { 
-          e.stopPropagation(); 
+        chipsPosSel.addEventListener("value-changed", (e) => {
+          e.stopPropagation();
           if (!e.detail.value) return;
           const v = e.detail.value;
           const currentPos = this._config.controls[i]?.chips_position || "bottom";
-
-          // Verhindert doppeltes Feuern
           if (v === currentPos) return;
-
-          // 1. UI-Zwang für das Dropdown
           e.target.value = v;
-
-          // 2. Leise speichern ohne UI-Neuaufbau (skipRender = true)
-          upd("chips_position", v, true); 
-
-          // 3. Sofortige optische Verschiebung per DOM-Manipulation
+          upd("chips_position", v, true);
           const btnTxt = box.querySelector(".btn-txt");
           const previewChips = box.querySelector(".btn-chips");
           if (previewChips) {
@@ -9244,12 +9722,11 @@ const cm = box.querySelector(".cm");
           }
         });
       }
-
       if (chipsList) {
         this._updateSubChipsUI(chipsList, ctrl, i, h);
       }
       if (addChipBtn && chipsList) {
-        addChipBtn.addEventListener("click", e => {
+        addChipBtn.addEventListener("click", (e) => {
           e.preventDefault();
           e.stopPropagation();
           const c = [...this._config.controls];
@@ -9261,7 +9738,6 @@ const cm = box.querySelector(".cm");
           this._updateSubChipsUI(chipsList, c[i], i, h);
         });
       }
-
       const tpIcon = box.querySelector(".tp-ic");
       const tpText = box.querySelector(".tp-tx");
       if (tpIcon && tpText && isTemplate) {
@@ -9286,22 +9762,19 @@ const cm = box.querySelector(".cm");
       });
     });
   }
-
   updVal() {
     if (!this._config) return;
-    this.shadowRoot.querySelectorAll(".i").forEach(e => {
+    this.shadowRoot.querySelectorAll(".i").forEach((e) => {
       const k = e.getAttribute("cfg");
       let v = k === "nav_path" ? this._config.tap_action?.navigation_path || "" : this._config[k] ?? "";
       if (k === "humidity_warning_threshold") v = this._config[k] ?? 60;
       if (e.value !== v) e.value = v;
     });
-
     const infoLinePosSel = this.shadowRoot.getElementById("info-line-pos-sel");
     if (infoLinePosSel) {
       const posVal = this._config.info_line_position || "header";
       if (infoLinePosSel.value !== posVal) infoLinePosSel.value = posVal;
-    }                           
-
+    }
     const tapActionSel = this.shadowRoot.getElementById("tap-action");
     const holdActionSel = this.shadowRoot.getElementById("hold-action");
     const dblActionSel = this.shadowRoot.getElementById("dbl-action");
@@ -9332,13 +9805,12 @@ const cm = box.querySelector(".cm");
       const v = this._config?.show_name !== false;
       if (showNameToggle.checked !== v) showNameToggle.checked = v;
     }
-
     const behaviorSel = this.shadowRoot.getElementById("behavior-sel");
     if (behaviorSel) {
       const isColl = this._config?.collapsible === true;
       const noRem = this._config?.remember_state === false;
       const isColld = this._config?.default_state === "collapsed";
-      const v = !isColl ? "fixed" : (!noRem ? "remember" : (isColld ? "collapsed" : "expanded"));
+      const v = !isColl ? "fixed" : !noRem ? "remember" : isColld ? "collapsed" : "expanded";
       if (behaviorSel.value !== v) behaviorSel.value = v;
     }
     const hlaShow = this.shadowRoot.getElementById("hla-show");
@@ -9346,13 +9818,12 @@ const cm = box.querySelector(".cm");
       const v = this._config?.show_card_last_activity === true;
       if (hlaShow.checked !== v) hlaShow.checked = v;
     }
-    ["name", "info"].forEach(type => {
+    ["name", "info"].forEach((type) => {
       const weightSel = this.shadowRoot.getElementById(`header-${type}-weight-sel`);
       if (weightSel) weightSel.value = this._config[`header_${type}_weight`] || (type === "name" ? "bold" : "normal");
       const styleSel = this.shadowRoot.getElementById(`header-${type}-style-sel`);
       if (styleSel) styleSel.value = this._config[`header_${type}_style`] || "normal";
     });
-
     const infoOffsetSlider = this.shadowRoot.getElementById("info-offset-slider");
     if (infoOffsetSlider) {
       const infoOffsetValue = this.shadowRoot.getElementById("info-offset-value");
@@ -9367,24 +9838,20 @@ const cm = box.querySelector(".cm");
       if (nameOffsetSlider.value !== v) nameOffsetSlider.value = v;
       if (nameOffsetValue) nameOffsetValue.textContent = `${v}%`;
     }
-
     const syncOffsetsToggle = this.shadowRoot.getElementById("sync-offsets-toggle");
     if (syncOffsetsToggle) {
       syncOffsetsToggle.checked = !!this._config?.header_sync_offsets;
     }
-
     this.updCp();
   }
-
   updCp() {
     if (!this._config) return;
-    this.shadowRoot.querySelectorAll(".cl-p").forEach(e => {
+    this.shadowRoot.querySelectorAll(".cl-p").forEach((e) => {
       const k = e.getAttribute("cfg");
       if (!k) return;
       const v = this._config[k] || "";
       const hex = parseColorToPickerHex(v);
       if (e.value !== hex) e.value = hex;
-
       const container = e.closest(".color-container");
       if (container) {
         const prev = container.querySelector(".cp-preview div");
@@ -9405,25 +9872,22 @@ const cm = box.querySelector(".cm");
       }
     });
   }
-
   _updateSubChipsUI(container, ctrl, ctrlIdx, h) {
     container.replaceChildren();
     const chips = ctrl.sub_chips || [];
     const updChip = (chipIdx, k, v) => {
       const c = [...this._config.controls];
-      const chs = [...(c[ctrlIdx].sub_chips || [])];
+      const chs = [...c[ctrlIdx].sub_chips || []];
       chs[chipIdx] = { ...chs[chipIdx], [k]: v };
       if (!v && k !== "entity") delete chs[chipIdx][k];
       c[ctrlIdx] = { ...c[ctrlIdx], sub_chips: chs };
       this._lastRenderedControlsSig = JSON.stringify(c);
       this._fire({ ...this._config, controls: c });
     };
-
     chips.forEach((chip, chipIdx) => {
       const box = document.createElement("div");
       box.className = "box";
       box.style.cssText = "border:1px solid var(--divider-color); padding:10px; border-radius:8px; position:relative; margin-top:8px";
-
       const del = document.createElement("button");
       del.type = "button";
       del.setAttribute("aria-label", "Delete");
@@ -9434,7 +9898,7 @@ const cm = box.querySelector(".cm");
         e.preventDefault();
         e.stopPropagation();
         const c = [...this._config.controls];
-        const chs = [...(c[ctrlIdx].sub_chips || [])];
+        const chs = [...c[ctrlIdx].sub_chips || []];
         chs.splice(chipIdx, 1);
         c[ctrlIdx] = { ...c[ctrlIdx], sub_chips: chs };
         this._lastRenderedControlsSig = JSON.stringify(c);
@@ -9442,59 +9906,64 @@ const cm = box.querySelector(".cm");
         this._updateSubChipsUI(container, c[ctrlIdx], ctrlIdx, h);
       };
       box.appendChild(del);
-
       const ep = document.createElement("ha-entity-picker");
       ep.label = getTranslation(h, "chip_entity");
       ep.hass = h;
       ep.value = chip.entity || "";
       ep.style.width = "calc(100% - 38px)";
-      ep.addEventListener("value-changed", e => { e.stopPropagation(); ep.value = e.detail.value; updChip(chipIdx, "entity", e.detail.value); });
+      ep.addEventListener("value-changed", (e) => {
+        e.stopPropagation();
+        ep.value = e.detail.value;
+        updChip(chipIdx, "entity", e.detail.value);
+      });
       box.appendChild(ep);
-
       const row1 = document.createElement("div");
       row1.className = "row";
       row1.style.marginTop = "8px";
-
       const ap = document.createElement("ha-selector");
       ap.label = getTranslation(h, "chip_attribute");
       ap.hass = h;
       ap.selector = { attribute: { entity_id: chip.entity } };
       ap.value = chip.attribute || "";
       ap.style.flex = "1";
-      ap.addEventListener("value-changed", e => { e.stopPropagation(); ap.value = e.detail.value; updChip(chipIdx, "attribute", e.detail.value); });
+      ap.addEventListener("value-changed", (e) => {
+        e.stopPropagation();
+        ap.value = e.detail.value;
+        updChip(chipIdx, "attribute", e.detail.value);
+      });
       row1.appendChild(ap);
-
       const ip = document.createElement("ha-icon-picker");
       ip.label = getTranslation(h, "chip_icon");
       ip.hass = h;
       ip.value = chip.icon || "";
       ip.style.flex = "1";
-      ip.addEventListener("value-changed", e => { e.stopPropagation(); ip.value = e.detail.value; updChip(chipIdx, "icon", e.detail.value); });
+      ip.addEventListener("value-changed", (e) => {
+        e.stopPropagation();
+        ip.value = e.detail.value;
+        updChip(chipIdx, "icon", e.detail.value);
+      });
       row1.appendChild(ip);
       box.appendChild(row1);
-
       const lb = document.createElement("oneline-room-card-textfield");
       lb.label = getTranslation(h, "chip_label");
       lb.value = chip.label || "";
       lb.style.width = "100%";
       lb.style.marginTop = "8px";
-      lb.addEventListener("change", e => { e.stopPropagation(); lb.value = e.target.value; updChip(chipIdx, "label", e.target.value); });
+      lb.addEventListener("change", (e) => {
+        e.stopPropagation();
+        lb.value = e.target.value;
+        updChip(chipIdx, "label", e.target.value);
+      });
       box.appendChild(lb);
-
       container.appendChild(box);
     });
   }
-}
-
-// =============================================================================
-// REGISTRATION (SAFE & ROBUST)
-// =============================================================================
-
-const findElementsAcrossShadowRoots = (root, selector) => {
+};
+var findElementsAcrossShadowRoots = (root, selector) => {
   if (!root?.querySelectorAll) return [];
   const matches = [];
   const pendingRoots = [root];
-  const visitedRoots = new Set();
+  const visitedRoots = /* @__PURE__ */ new Set();
   while (pendingRoots.length > 0) {
     const currentRoot = pendingRoots.pop();
     if (!currentRoot || visitedRoots.has(currentRoot)) continue;
@@ -9506,8 +9975,7 @@ const findElementsAcrossShadowRoots = (root, selector) => {
   }
   return matches;
 };
-
-const patchExistingEditor = (ExistingEditor, NewEditor) => {
+var patchExistingEditor = (ExistingEditor, NewEditor) => {
   Object.getOwnPropertyNames(NewEditor.prototype).forEach((name) => {
     if (name === "constructor") return;
     const descriptor = Object.getOwnPropertyDescriptor(NewEditor.prototype, name);
@@ -9519,8 +9987,7 @@ const patchExistingEditor = (ExistingEditor, NewEditor) => {
     editor.render();
   });
 };
-
-const patchExistingCard = (ExistingCard, NewCard) => {
+var patchExistingCard = (ExistingCard, NewCard) => {
   Object.getOwnPropertyNames(NewCard.prototype).forEach((name) => {
     if (name === "constructor") return;
     const desc = Object.getOwnPropertyDescriptor(NewCard.prototype, name);
@@ -9531,21 +9998,18 @@ const patchExistingCard = (ExistingCard, NewCard) => {
     if (desc) Object.defineProperty(ExistingCard, name, desc);
   });
 };
-
-const existingEditor = customElements.get("oneline-room-card-editor");
+var existingEditor = customElements.get("oneline-room-card-editor");
 if (!existingEditor) {
   customElements.define("oneline-room-card-editor", OneLineRoomCardEditor);
 } else if (existingEditor !== OneLineRoomCardEditor) {
   patchExistingEditor(existingEditor, OneLineRoomCardEditor);
 }
-
-const existingCard = customElements.get("oneline-room-card");
+var existingCard = customElements.get("oneline-room-card");
 if (!existingCard) {
   customElements.define("oneline-room-card", OneLineRoomCard);
 } else if (existingCard !== OneLineRoomCard) {
   patchExistingCard(existingCard, OneLineRoomCard);
 }
-
 window.customCards = window.customCards || [];
 if (!window.customCards.some((card) => card?.type === "oneline-room-card")) {
   window.customCards.push({
@@ -9555,3 +10019,35 @@ if (!window.customCards.some((card) => card?.type === "oneline-room-card")) {
     description: "Minimalist Room Card for Home Assistant"
   });
 }
+export {
+  EDITOR_DOM_REVISION,
+  OneLineRoomCardEditor,
+  ROOM_IMAGE_PRESETS,
+  SHARED_SPARKLINE_CACHE,
+  SHARED_SPARKLINE_PENDING,
+  TRANSLATIONS,
+  clampNum,
+  convertTemperatureValue,
+  evalTemplateString,
+  evaluateAdaptiveImageConditions,
+  evaluateRoomModeActiveWhen,
+  formatConvertedTemperature,
+  formatEntityStateForDisplay,
+  getConditionEntityDependencies,
+  getRoomImagePresetUrl,
+  getSparklineStats,
+  getStatusGroupResult,
+  getTemplateEntityDependencies,
+  getTranslation,
+  hexToRgba,
+  normalizeSparklineSamples,
+  normalizeTemperatureUnit,
+  parseImagePosition,
+  patchExistingEditor,
+  pruneSharedSparklineCache,
+  readableTextForHex,
+  replaceTemplateExpressions,
+  resolveAdaptiveRoomImage,
+  templateNeedsEveryHassUpdate,
+  validateImageUpload
+};

--- a/docs/modularization-plan.md
+++ b/docs/modularization-plan.md
@@ -1,13 +1,14 @@
 # Test-gated modularization plan
 
-This note is the Phase 0 / first-deliverable decision for issue #100. It does
-not authorize a source split. The current single-file source and copy build
-remain the known-good rollback point until a separate Gate 1 pull request is
-reviewed and manually smoke-tested in Home Assistant.
+This note tracks the test-gated implementation of issue #100 for v1.5.0.
+The approved baseline is published v1.4.0 (`88b2314`), with 68 passing automated
+tests and the completed manual Home Assistant test. That single-file source and
+copy build remain the rollback point for the separate Gate 1 bundler PR.
+No helper extraction starts until Gate 1 passes CI and its manual HA smoke test.
 
 ## Build approach decision
 
-Use **esbuild**, pinned exactly to `0.28.2`, for the future Gate 1 experiment.
+Use **esbuild**, pinned exactly to `0.28.2`, for Gate 1.
 That version was reviewed on 2026-08-20 from the [official npm package](https://www.npmjs.com/package/esbuild).
 It is selected because it can bundle ESM into one readable, unminified ESM
 artifact without adding a browser/runtime dependency. Rollup remains the
@@ -25,16 +26,22 @@ The Gate 1 experiment must use these constraints:
 }
 ```
 
-The esbuild dependency is deliberately not installed by this planning change.
-Adding it, replacing the current copy build, or moving code requires its own
-reversible PR. That PR must compare the generated artifact against the current
-baseline and pass the manual matrix in `docs/manual-smoke-test.md`.
+The Gate 1 PR installs the dependency and replaces only the build pipeline.
+Runtime/editor bodies, translations, image resolution and registration order
+remain unchanged. The sole source addition is an explicit named-export block
+for internal tests; tests no longer append exports to the generated bundle.
+Tree shaking is disabled during this first step to avoid silently pruning
+existing code. The browser target is ES2022, retaining native `import.meta.url`.
+This reversible PR must pass the manual matrix in `docs/manual-smoke-test.md`
+before source extraction begins.
 
 ## Current baseline and artifact contract
 
 - `src/room-card.js` is the canonical, single-file source.
 - `dist/room-card.js` is the readable generated HACS artifact.
-- `scripts/build.mjs` currently performs a deterministic byte-for-byte copy.
+- `scripts/build.mjs` bundles using shared options in `scripts/build-config.mjs`.
+- `scripts/check-build.mjs` builds into a unique temporary directory, compares
+  bytes with the committed artifact, and cleans up without rewriting `dist/`.
 - `scripts/check-release.mjs` rejects stale output and version drift.
 - CI builds from a clean checkout, rejects a changed artifact, runs syntax and
   regression checks, then runs the HACS validator.
@@ -43,6 +50,19 @@ baseline and pass the manual matrix in `docs/manual-smoke-test.md`.
   Card/editor/`window.customCards` registration shares the final registration
   block; the compatibility input remains guarded directly after its class until
   a later gated move can preserve its cold-load order.
+- Tests assert the order input wrapper → editor → card and a single custom-card
+  registration after loading the artifact twice.
+- Build metadata rejects additional output files and runtime imports. Tests
+  resolve all 16 presets against the real bundle URL and check that every JPEG
+  exists under the adjacent `dist/rooms/` HACS directory.
+- A separate module probe evaluates the unchanged artifact with HACS, pinned
+  CDN and `/local/` URLs. It verifies that images resolve beside the module,
+  never relative to the dashboard page; it does not replace the real HA test.
+
+The initial generated bundle is 498,265 bytes versus the v1.4.0 artifact's
+499,441 bytes (about 0.24% smaller). This is a formatting/build comparison, not
+a claimed browser load-time improvement. Manual cold-load timing and behavior
+remain part of the HA gate.
 
 This establishes a known-good build/test baseline without changing runtime
 behavior. Automated coverage includes cold-load editor behavior, actions,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,453 @@
       "name": "oneline-room-card",
       "version": "1.4.0",
       "devDependencies": {
+        "esbuild": "0.28.2",
         "happy-dom": "20.11.6"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@types/node": {
@@ -65,6 +508,48 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
       }
     },
     "node_modules/happy-dom": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "node": ">=20"
   },
   "devDependencies": {
+    "esbuild": "0.28.2",
     "happy-dom": "20.11.6"
   }
 }

--- a/scripts/build-config.mjs
+++ b/scripts/build-config.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+// One options owner for the committed artifact and isolated reproducibility checks.
+export const buildRoomCard = async (outfile) => {
+  const result = await build({
+    absWorkingDir: repositoryRoot,
+    entryPoints: ["src/room-card.js"],
+    outfile,
+    bundle: true,
+    format: "esm",
+    platform: "browser",
+    target: "es2022",
+    minify: false,
+    treeShaking: false,
+    splitting: false,
+    sourcemap: false,
+    charset: "utf8",
+    legalComments: "inline",
+    metafile: true,
+    logLevel: "silent"
+  });
+  const outputs = Object.values(result.metafile.outputs);
+  assert.equal(outputs.length, 1, "HACS requires a single JavaScript artifact.");
+  assert.deepEqual(outputs[0].imports, [], "The artifact must not contain runtime imports.");
+  return result;
+};

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,12 +1,5 @@
-import { copyFile, mkdir } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { buildRoomCard, repositoryRoot } from "./build-config.mjs";
+import { resolve } from "node:path";
 
-const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const sourceFile = resolve(repositoryRoot, "src/room-card.js");
-const distributionFile = resolve(repositoryRoot, "dist/room-card.js");
-
-await mkdir(dirname(distributionFile), { recursive: true });
-await copyFile(sourceFile, distributionFile);
-
-console.log("Built dist/room-card.js from src/room-card.js.");
+await buildRoomCard(resolve(repositoryRoot, "dist/room-card.js"));
+console.log("Bundled dist/room-card.js from src/room-card.js.");

--- a/scripts/check-build.mjs
+++ b/scripts/check-build.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { buildRoomCard, repositoryRoot } from "./build-config.mjs";
+
+export const assertFreshDistribution = async (distributionFile = resolve(repositoryRoot, "dist/room-card.js")) => {
+  const directory = await mkdtemp(join(tmpdir(), "roomcard-build-"));
+  try {
+    const output = join(directory, "room-card.js");
+    await buildRoomCard(output);
+    const [fresh, committed] = await Promise.all([
+      readFile(output, "utf8"),
+      readFile(distributionFile, "utf8")
+    ]);
+    assert.ok(committed === fresh, "dist/room-card.js is stale. Run `npm run build`.");
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+};

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { assertFreshDistribution } from "./check-build.mjs";
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -21,12 +22,12 @@ const matchVersion = (content, pattern, label) => {
 };
 
 const sourceVersion = matchVersion(source, /const VERSION = "(\d+\.\d+\.\d+)";/, "source");
-const distributionVersion = matchVersion(distribution, /const VERSION = "(\d+\.\d+\.\d+)";/, "distribution");
+const distributionVersion = matchVersion(distribution, /(?:const|var|let) VERSION = "(\d+\.\d+\.\d+)";/, "distribution");
 const readmeVersion = matchVersion(readme, /What's new in (\d+\.\d+\.\d+)/, "README");
 const changelogVersion = matchVersion(changelog, /^## \[(\d+\.\d+\.\d+)\]$/m, "changelog");
 const manifestVersion = JSON.parse(packageJson).version;
 
-assert.equal(distribution, source, "dist/room-card.js is stale. Run `npm run build`.");
+await assertFreshDistribution();
 
 for (const [label, version] of [
   ["distribution", distributionVersion],

--- a/src/room-card.js
+++ b/src/room-card.js
@@ -9555,3 +9555,38 @@ if (!window.customCards.some((card) => card?.type === "oneline-room-card")) {
     description: "Minimalist Room Card for Home Assistant"
   });
 }
+
+// Internal test seams: named ESM exports survive bundling without instrumenting
+// the shipped artifact. These are not a supported consumer configuration API.
+export {
+  EDITOR_DOM_REVISION,
+  OneLineRoomCardEditor,
+  ROOM_IMAGE_PRESETS,
+  SHARED_SPARKLINE_CACHE,
+  SHARED_SPARKLINE_PENDING,
+  TRANSLATIONS,
+  clampNum,
+  convertTemperatureValue,
+  evalTemplateString,
+  evaluateAdaptiveImageConditions,
+  evaluateRoomModeActiveWhen,
+  formatConvertedTemperature,
+  formatEntityStateForDisplay,
+  getConditionEntityDependencies,
+  getRoomImagePresetUrl,
+  getSparklineStats,
+  getStatusGroupResult,
+  getTemplateEntityDependencies,
+  getTranslation,
+  hexToRgba,
+  normalizeSparklineSamples,
+  normalizeTemperatureUnit,
+  parseImagePosition,
+  patchExistingEditor,
+  pruneSharedSparklineCache,
+  readableTextForHex,
+  replaceTemplateExpressions,
+  resolveAdaptiveRoomImage,
+  templateNeedsEveryHassUpdate,
+  validateImageUpload
+};

--- a/tests/adaptive-images.test.mjs
+++ b/tests/adaptive-images.test.mjs
@@ -8,11 +8,7 @@ const {
   evaluateAdaptiveImageConditions,
   getConditionEntityDependencies,
   resolveAdaptiveRoomImage
-} = await importRoomCard([
-  "evaluateAdaptiveImageConditions",
-  "getConditionEntityDependencies",
-  "resolveAdaptiveRoomImage"
-]);
+} = await importRoomCard();
 
 test("adaptive image rules are strict, ordered, and fall back safely", () => {
   const hass = createHass({

--- a/tests/build-release-contract.test.mjs
+++ b/tests/build-release-contract.test.mjs
@@ -1,31 +1,80 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { readFile, readdir, mkdtemp, writeFile, rm } from "node:fs/promises";
 import test from "node:test";
-import { dirname, resolve } from "node:path";
+import { dirname, resolve, join } from "node:path";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
-import { installDomEnvironment } from "./support/dom-env.mjs";
+import { installDomEnvironment, importRoomCard } from "./support/dom-env.mjs";
+import { assertFreshDistribution } from "../scripts/check-build.mjs";
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
+test("a stale artifact is rejected without overwriting it", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "roomcard-stale-test-"));
+  try {
+    const fixture = join(directory, "room-card.js");
+    const stale = "// deliberately stale distribution\n";
+    await writeFile(fixture, stale);
+    await assert.rejects(assertFreshDistribution(fixture), /dist\/room-card\.js is stale/);
+    assert.equal(await readFile(fixture, "utf8"), stale);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("the committed HACS artifact is deterministic, self-contained, and registers once", async () => {
   installDomEnvironment();
-  const [source, distribution] = await Promise.all([
-    readFile(resolve(repositoryRoot, "src/room-card.js"), "utf8"),
-    readFile(resolve(repositoryRoot, "dist/room-card.js"), "utf8")
-  ]);
-  assert.equal(distribution, source);
+  await assertFreshDistribution();
+  const distribution = await readFile(resolve(repositoryRoot, "dist/room-card.js"), "utf8");
   assert.equal(/^\s*import\s/m.test(distribution), false);
+  // The build's parsed esbuild metafile also checks static/dynamic imports;
+  // a text regex would incorrectly flag the French label "l'import (...)".
+  assert.equal(distribution.includes("sourceMappingURL="), false);
+
+  const registrations = [];
+  const define = customElements.define.bind(customElements);
+  customElements.define = (name, constructor, options) => {
+    registrations.push(name);
+    return define(name, constructor, options);
+  };
 
   const load = (suffix) => import(`data:text/javascript;base64,${Buffer.from(`${distribution}\n// ${suffix}`).toString("base64")}`);
   await load("first registration pass");
   await load("second registration pass");
 
+  assert.deepEqual(registrations, [
+    "oneline-room-card-textfield",
+    "oneline-room-card-editor",
+    "oneline-room-card"
+  ]);
+
   assert.ok(customElements.get("oneline-room-card-textfield"));
   assert.ok(customElements.get("oneline-room-card"));
   assert.ok(customElements.get("oneline-room-card-editor"));
   assert.equal(window.customCards.filter((card) => card.type === "oneline-room-card").length, 1);
+});
+
+test("all preset images resolve beside the real module URL and exist in the HACS distribution", async () => {
+  const { ROOM_IMAGE_PRESETS, getRoomImagePresetUrl } = await importRoomCard();
+  const artifactUrl = new URL("../dist/room-card.js", import.meta.url);
+  const hacs = JSON.parse(await readFile(resolve(repositoryRoot, "hacs.json"), "utf8"));
+  assert.equal(hacs.filename, "room-card.js");
+  assert.deepEqual((await readdir(resolve(repositoryRoot, "dist"))).sort(), ["room-card.js", "rooms"]);
+  const version = JSON.parse(await readFile(resolve(repositoryRoot, "package.json"), "utf8")).version;
+  const expectedFiles = [];
+  for (const preset of ROOM_IMAGE_PRESETS) {
+    const expected = new URL(`./rooms/${preset.file}`, artifactUrl);
+    expected.searchParams.set("v", version);
+    assert.equal(getRoomImagePresetUrl(preset.id), expected.href);
+    const bytes = await readFile(expected);
+    assert.ok(bytes.length > 0, `${preset.file} must not be empty`);
+    assert.equal(bytes.subarray(0, 3).toString("hex"), "ffd8ff", `${preset.file} must be an actual JPEG`);
+    expectedFiles.push(preset.file);
+  }
+  assert.deepEqual((await readdir(resolve(repositoryRoot, "dist/rooms"))).sort(), expectedFiles.sort());
+  assert.equal(getRoomImagePresetUrl("not-a-preset"), "");
 });
 
 test("release metadata accepts the matching tag and rejects a mismatched tag clearly", async () => {
@@ -45,4 +94,12 @@ test("release metadata accepts the matching tag and rejects a mismatched tag cle
   const mismatch = runCheck("v9.9.9");
   assert.notEqual(mismatch.status, 0);
   assert.match(mismatch.stderr, new RegExp(`Tag v9\\.9\\.9 does not match source version ${version.replaceAll(".", "\\.")}`));
+});
+
+test("browser-style HACS, CDN, and local module URLs preserve relative preset resolution", () => {
+  const result = spawnSync(process.execPath, ["--experimental-vm-modules", "tests/support/bundle-url-probe.mjs"], {
+    cwd: repositoryRoot,
+    encoding: "utf8"
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
 });

--- a/tests/editor-behavior.test.mjs
+++ b/tests/editor-behavior.test.mjs
@@ -10,13 +10,7 @@ const {
   patchExistingEditor,
   OneLineRoomCardEditor,
   EDITOR_DOM_REVISION
-} = await importRoomCard([
-  "parseImagePosition",
-  "validateImageUpload",
-  "patchExistingEditor",
-  "OneLineRoomCardEditor",
-  "EDITOR_DOM_REVISION"
-]);
+} = await importRoomCard();
 
 const createEditor = () => {
   const editor = document.createElement("oneline-room-card-editor");

--- a/tests/media-accessibility.test.mjs
+++ b/tests/media-accessibility.test.mjs
@@ -4,7 +4,7 @@ import test from "node:test";
 import { createHass, importRoomCard, installDomEnvironment, wait } from "./support/dom-env.mjs";
 
 installDomEnvironment();
-await importRoomCard(["MEDIA_PLAYER_FEATURES"]);
+await importRoomCard();
 
 const createRenderedCard = (config, hass) => {
   const card = document.createElement("oneline-room-card");

--- a/tests/performance-behavior.test.mjs
+++ b/tests/performance-behavior.test.mjs
@@ -10,13 +10,7 @@ const {
   SHARED_SPARKLINE_CACHE,
   SHARED_SPARKLINE_PENDING,
   pruneSharedSparklineCache
-} = await importRoomCard([
-  "getTemplateEntityDependencies",
-  "templateNeedsEveryHassUpdate",
-  "SHARED_SPARKLINE_CACHE",
-  "SHARED_SPARKLINE_PENDING",
-  "pruneSharedSparklineCache"
-]);
+} = await importRoomCard();
 
 const createRenderedCard = (config, hass) => {
   const card = document.createElement("oneline-room-card");

--- a/tests/render-signatures.test.mjs
+++ b/tests/render-signatures.test.mjs
@@ -18,7 +18,7 @@ globalThis.customElements = {
 };
 
 // Tests exercise the exact artifact installed by HACS. The build and release
-// checks separately ensure this file is identical to the canonical source.
+// checks separately ensure this file is identical to a fresh isolated build.
 const sourceUrl = new URL("../dist/room-card.js", import.meta.url);
 const source = await readFile(sourceUrl, "utf8");
 const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;

--- a/tests/room-modes.test.mjs
+++ b/tests/room-modes.test.mjs
@@ -4,10 +4,7 @@ import test from "node:test";
 import { createHass, importRoomCard, installDomEnvironment } from "./support/dom-env.mjs";
 
 installDomEnvironment();
-const { evaluateRoomModeActiveWhen, getConditionEntityDependencies } = await importRoomCard([
-  "evaluateRoomModeActiveWhen",
-  "getConditionEntityDependencies"
-]);
+const { evaluateRoomModeActiveWhen, getConditionEntityDependencies } = await importRoomCard();
 
 const createRenderedCard = (config, hass) => {
   const card = document.createElement("oneline-room-card");

--- a/tests/runtime-behavior.test.mjs
+++ b/tests/runtime-behavior.test.mjs
@@ -5,18 +5,7 @@ import { createHass, importRoomCard, installDomEnvironment } from "./support/dom
 
 installDomEnvironment();
 
-const helpers = [
-  "clampNum",
-  "convertTemperatureValue",
-  "evalTemplateString",
-  "formatConvertedTemperature",
-  "formatEntityStateForDisplay",
-  "hexToRgba",
-  "normalizeTemperatureUnit",
-  "readableTextForHex",
-  "replaceTemplateExpressions"
-];
-const roomCardModule = await importRoomCard(helpers);
+const roomCardModule = await importRoomCard();
 const RoomCard = customElements.get("oneline-room-card");
 
 const createCard = (hass = createHass()) => {

--- a/tests/sparkline-detail.test.mjs
+++ b/tests/sparkline-detail.test.mjs
@@ -9,12 +9,7 @@ const {
   SHARED_SPARKLINE_PENDING,
   normalizeSparklineSamples,
   getSparklineStats
-} = await importRoomCard([
-  "SHARED_SPARKLINE_CACHE",
-  "SHARED_SPARKLINE_PENDING",
-  "normalizeSparklineSamples",
-  "getSparklineStats"
-]);
+} = await importRoomCard();
 
 const createRenderedCard = (config, hass) => {
   const card = document.createElement("oneline-room-card");

--- a/tests/status-groups.test.mjs
+++ b/tests/status-groups.test.mjs
@@ -4,10 +4,7 @@ import test from "node:test";
 import { createHass, importRoomCard, installDomEnvironment } from "./support/dom-env.mjs";
 
 installDomEnvironment();
-const { getConditionEntityDependencies, getStatusGroupResult } = await importRoomCard([
-  "getConditionEntityDependencies",
-  "getStatusGroupResult"
-]);
+const { getConditionEntityDependencies, getStatusGroupResult } = await importRoomCard();
 
 const renderCard = (config, hass) => {
   const card = document.createElement("oneline-room-card");

--- a/tests/support/bundle-url-probe.mjs
+++ b/tests/support/bundle-url-probe.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { createContext, SourceTextModule } from "node:vm";
+
+// Execute the unchanged artifact with browser-style module URLs, without any
+// network requests or rewriting import.meta in its source. This runs in a
+// dedicated Node process because SourceTextModule requires an opt-in flag.
+const code = await readFile(new URL("../../dist/room-card.js", import.meta.url), "utf8");
+const { version } = JSON.parse(await readFile(new URL("../../package.json", import.meta.url), "utf8"));
+for (const moduleUrl of [
+  "https://ha.example/hacsfiles/RoomCard/room-card.js?hacstag=140",
+  "https://cdn.jsdelivr.net/gh/lop1505/RoomCard@88b2314/dist/room-card.js",
+  "https://ha.example/local/room-card.js?v=test"
+]) {
+  const registrations = new Map();
+  const context = createContext({
+    HTMLElement: class {},
+    window: {},
+    console: { info() {} },
+    URL,
+    location: { href: "https://ha.example/lovelace/0" },
+    customElements: {
+      define: (name, constructor) => registrations.set(name, constructor),
+      get: (name) => registrations.get(name)
+    }
+  });
+  const module = new SourceTextModule(code, {
+    context,
+    identifier: moduleUrl,
+    initializeImportMeta: (meta) => { meta.url = moduleUrl; }
+  });
+  await module.link(() => { throw new Error("Unexpected runtime module import"); });
+  await module.evaluate();
+  for (const preset of module.namespace.ROOM_IMAGE_PRESETS) {
+    const actual = new URL(module.namespace.getRoomImagePresetUrl(preset.id));
+    assert.equal(actual.searchParams.get("v"), version);
+    actual.search = "";
+    assert.equal(actual.href, new URL(`./rooms/${preset.file}`, moduleUrl).href);
+    assert.equal(actual.pathname.includes("/lovelace/"), false);
+  }
+}

--- a/tests/support/dom-env.mjs
+++ b/tests/support/dom-env.mjs
@@ -1,4 +1,3 @@
-import { readFile } from "node:fs/promises";
 import { Window } from "happy-dom";
 
 const browserGlobals = [
@@ -49,15 +48,9 @@ export const installDomEnvironment = () => {
   return window;
 };
 
-export const importRoomCard = async (extraExports = []) => {
-  const sourceUrl = new URL("../../dist/room-card.js", import.meta.url);
-  const source = await readFile(sourceUrl, "utf8");
-  const exportStatement = extraExports.length > 0
-    ? `\nexport { ${extraExports.join(", ")} };`
-    : "";
-  const moduleUrl = `data:text/javascript;base64,${Buffer.from(`${source}${exportStatement}`).toString("base64")}`;
-  return import(moduleUrl);
-};
+// Import the unchanged shipped artifact, including explicit named helper exports.
+// No source rewriting and no dependency on bundler-generated private names.
+export const importRoomCard = () => import("../../dist/room-card.js");
 
 export const createHass = (overrides = {}) => {
   const serviceCalls = [];

--- a/tests/translations.test.mjs
+++ b/tests/translations.test.mjs
@@ -4,7 +4,7 @@ import test from "node:test";
 import { installDomEnvironment, importRoomCard } from "./support/dom-env.mjs";
 
 installDomEnvironment();
-const { TRANSLATIONS, getTranslation } = await importRoomCard(["TRANSLATIONS", "getTranslation"]);
+const { TRANSLATIONS, getTranslation } = await importRoomCard();
 
 test("all supported languages have the same non-empty translation keys", () => {
   const keys = Object.keys(TRANSLATIONS.en).sort();


### PR DESCRIPTION
## Scope
First reversible PR for the approved v1.5.0 plan, based on published v1.4.0 (88b2314). Part of #100; intentionally does not close it. No Drawer changes (#127), release, or version bump.

## Changes
- Pin esbuild exactly to 0.28.2; readable single-file browser ESM, ES2022, no minification/tree shaking/code splitting/source maps/runtime imports.
- Replace the source-copy build check with a fresh isolated temporary build comparison, with cleanup and stale-artifact rejection without overwriting dist.
- Preserve all pre-existing source bytes and behavior. The only source addition is explicit named internal test exports, replacing exports appended to bundler-generated code. Tests import the actual shipped artifact.
- Retain dist/room-card.js and all 16 adjacent room-image JPEGs. Verify HACS/CDN/local relative URLs, registration order and duplicate-safe loading.
- Update developer documentation and the staged modularization plan.

## Verification
- [x] Original baseline: 68 passing tests.
- [x] npm ci --ignore-scripts; npm run build; npm run check: 71 passing tests.
- [x] Existing source bytes match v1.4.0 exactly; only named test exports appended.
- [x] Reproducible artifact, no runtime imports/additional outputs, matching/mismatched tag checks, all preset assets present.
- [x] GitHub Validate including HACS: https://github.com/lop1505/RoomCard/actions/runs/33951685130 (success).
- [x] Manual HA gate (user confirmed 2026-09-05; resource replaced, behavior unchanged): cold dashboard load, default/adaptive images, cold editor/live preview/save, existing actions/controls, desktop/mobile and light/dark.

## Test deployment
Replace the existing RoomCard resource URL (do not add a duplicate resource) with this JavaScript module URL:

https://cdn.jsdelivr.net/gh/lop1505/RoomCard@40d56a0ffd505cc4e3a692193c6dfc826b3b1744/dist/room-card.js

The adjacent rooms directory is available at the same pinned commit. No ZIP, tag or release is necessary. Rollback: restore the previous resource URL and fully reload the dashboard.

## Gate
Keep this PR unmerged until CI and the manual HA test pass. Only then begin helper extraction in separate PRs. Version remains 1.4.0 until final v1.5 release preparation.