### PR TITLE
refactor: extract value and string helpers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 ## Repository layout
 
 - `src/room-card.js` is the canonical source file.
+- `src/lib/values.js` owns browser-independent number/string helpers.
 - `dist/room-card.js` is the generated HACS artifact and must not be edited directly.
 - `dist/rooms/` contains the additional assets installed by HACS.
 - `tests/` contains automated regression tests.

--- a/dist/room-card.js
+++ b/dist/room-card.js
@@ -1,3 +1,94 @@
+// src/lib/values.js
+var clampNum = (v, min, max, fallback) => {
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.max(min, Math.min(n, max)) : fallback;
+};
+var replaceTemplateExpressions = (str, evalExpr) => {
+  let out = "";
+  let i = 0;
+  while (i < str.length) {
+    if (str[i] === "$" && str[i + 1] === "{") {
+      i += 2;
+      let expr = "";
+      let depth = 0;
+      let inSingle = false;
+      let inDouble = false;
+      let inBacktick = false;
+      let esc = false;
+      let closed = false;
+      for (; i < str.length; i++) {
+        const ch = str[i];
+        if (esc) {
+          expr += ch;
+          esc = false;
+          continue;
+        }
+        if (ch === "\\") {
+          expr += ch;
+          esc = true;
+          continue;
+        }
+        if (inSingle) {
+          if (ch === "'") inSingle = false;
+          expr += ch;
+          continue;
+        }
+        if (inDouble) {
+          if (ch === '"') inDouble = false;
+          expr += ch;
+          continue;
+        }
+        if (inBacktick) {
+          if (ch === "`") inBacktick = false;
+          expr += ch;
+          continue;
+        }
+        if (ch === "'") {
+          inSingle = true;
+          expr += ch;
+          continue;
+        }
+        if (ch === '"') {
+          inDouble = true;
+          expr += ch;
+          continue;
+        }
+        if (ch === "`") {
+          inBacktick = true;
+          expr += ch;
+          continue;
+        }
+        if (ch === "{") {
+          depth++;
+          expr += ch;
+          continue;
+        }
+        if (ch === "}") {
+          if (depth === 0) {
+            closed = true;
+            i++;
+            break;
+          }
+          depth--;
+          expr += ch;
+          continue;
+        }
+        expr += ch;
+      }
+      if (!closed) {
+        out += "${" + expr;
+        break;
+      }
+      out += evalExpr(expr.trim());
+      continue;
+    }
+    out += str[i];
+    i++;
+  }
+  return out;
+};
+var trimStr = (v) => typeof v === "string" ? v.trim() : v;
+
 // src/room-card.js
 var VERSION = "1.4.0";
 var EDITOR_DOM_REVISION = "6";
@@ -1461,95 +1552,6 @@ var getTranslation = (hass, key) => {
   const lang = hass?.language?.split("-")[0] || "en";
   return TRANSLATIONS[lang]?.[key] ?? TRANSLATIONS["en"]?.[key] ?? key;
 };
-var clampNum = (v, min, max, fallback) => {
-  const n = Number(v);
-  return Number.isFinite(n) ? Math.max(min, Math.min(n, max)) : fallback;
-};
-var replaceTemplateExpressions = (str, evalExpr) => {
-  let out = "";
-  let i = 0;
-  while (i < str.length) {
-    if (str[i] === "$" && str[i + 1] === "{") {
-      i += 2;
-      let expr = "";
-      let depth = 0;
-      let inSingle = false;
-      let inDouble = false;
-      let inBacktick = false;
-      let esc = false;
-      let closed = false;
-      for (; i < str.length; i++) {
-        const ch = str[i];
-        if (esc) {
-          expr += ch;
-          esc = false;
-          continue;
-        }
-        if (ch === "\\") {
-          expr += ch;
-          esc = true;
-          continue;
-        }
-        if (inSingle) {
-          if (ch === "'") inSingle = false;
-          expr += ch;
-          continue;
-        }
-        if (inDouble) {
-          if (ch === '"') inDouble = false;
-          expr += ch;
-          continue;
-        }
-        if (inBacktick) {
-          if (ch === "`") inBacktick = false;
-          expr += ch;
-          continue;
-        }
-        if (ch === "'") {
-          inSingle = true;
-          expr += ch;
-          continue;
-        }
-        if (ch === '"') {
-          inDouble = true;
-          expr += ch;
-          continue;
-        }
-        if (ch === "`") {
-          inBacktick = true;
-          expr += ch;
-          continue;
-        }
-        if (ch === "{") {
-          depth++;
-          expr += ch;
-          continue;
-        }
-        if (ch === "}") {
-          if (depth === 0) {
-            closed = true;
-            i++;
-            break;
-          }
-          depth--;
-          expr += ch;
-          continue;
-        }
-        expr += ch;
-      }
-      if (!closed) {
-        out += "${" + expr;
-        break;
-      }
-      out += evalExpr(expr.trim());
-      continue;
-    }
-    out += str[i];
-    i++;
-  }
-  return out;
-};
-var trimStr = (v) => typeof v === "string" ? v.trim() : v;
 var formatEntityStateForDisplay = (hass, stateObj, fallbackUnit = "") => {
   if (!stateObj) return "";
   try {

--- a/src/lib/values.js
+++ b/src/lib/values.js
@@ -1,0 +1,71 @@
+const clampNum = (v, min, max, fallback) => {
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.max(min, Math.min(n, max)) : fallback;
+};
+
+const replaceTemplateExpressions = (str, evalExpr) => {
+  let out = "";
+  let i = 0;
+  while (i < str.length) {
+    if (str[i] === "$" && str[i + 1] === "{") {
+      i += 2;
+      let expr = "";
+      let depth = 0;
+      let inSingle = false;
+      let inDouble = false;
+      let inBacktick = false;
+      let esc = false;
+      let closed = false;
+      for (; i < str.length; i++) {
+        const ch = str[i];
+        if (esc) {
+          expr += ch;
+          esc = false;
+          continue;
+        }
+        if (ch === "\\") {
+          expr += ch;
+          esc = true;
+          continue;
+        }
+        if (inSingle) {
+          if (ch === "'") inSingle = false;
+          expr += ch;
+          continue;
+        }
+        if (inDouble) {
+          if (ch === '"') inDouble = false;
+          expr += ch;
+          continue;
+        }
+        if (inBacktick) {
+          if (ch === "`") inBacktick = false;
+          expr += ch;
+          continue;
+        }
+        if (ch === "'") { inSingle = true; expr += ch; continue; }
+        if (ch === '"') { inDouble = true; expr += ch; continue; }
+        if (ch === "`") { inBacktick = true; expr += ch; continue; }
+        if (ch === "{") { depth++; expr += ch; continue; }
+        if (ch === "}") {
+          if (depth === 0) { closed = true; i++; break; }
+          depth--; expr += ch; continue;
+        }
+        expr += ch;
+      }
+      if (!closed) {
+        out += "${" + expr;
+        break;
+      }
+      out += evalExpr(expr.trim());
+      continue;
+    }
+    out += str[i];
+    i++;
+  }
+  return out;
+};
+
+const trimStr = (v) => (typeof v === "string" ? v.trim() : v);
+
+export { clampNum, replaceTemplateExpressions, trimStr };

--- a/src/room-card.js
+++ b/src/room-card.js
@@ -1,3 +1,5 @@
+import { clampNum, replaceTemplateExpressions, trimStr } from "./lib/values.js";
+
 const VERSION = "1.4.0";
 const EDITOR_DOM_REVISION = "6";
 const LOG_FLAG = `customCards_RoomCard_Logged_${VERSION}`;
@@ -787,75 +789,6 @@ const getTranslation = (hass, key) => {
   return TRANSLATIONS[lang]?.[key] ?? TRANSLATIONS["en"]?.[key] ?? key;
 };
 
-const clampNum = (v, min, max, fallback) => {
-  const n = Number(v);
-  return Number.isFinite(n) ? Math.max(min, Math.min(n, max)) : fallback;
-};
-
-const replaceTemplateExpressions = (str, evalExpr) => {
-  let out = "";
-  let i = 0;
-  while (i < str.length) {
-    if (str[i] === "$" && str[i + 1] === "{") {
-      i += 2;
-      let expr = "";
-      let depth = 0;
-      let inSingle = false;
-      let inDouble = false;
-      let inBacktick = false;
-      let esc = false;
-      let closed = false;
-      for (; i < str.length; i++) {
-        const ch = str[i];
-        if (esc) {
-          expr += ch;
-          esc = false;
-          continue;
-        }
-        if (ch === "\\") {
-          expr += ch;
-          esc = true;
-          continue;
-        }
-        if (inSingle) {
-          if (ch === "'") inSingle = false;
-          expr += ch;
-          continue;
-        }
-        if (inDouble) {
-          if (ch === '"') inDouble = false;
-          expr += ch;
-          continue;
-        }
-        if (inBacktick) {
-          if (ch === "`") inBacktick = false;
-          expr += ch;
-          continue;
-        }
-        if (ch === "'") { inSingle = true; expr += ch; continue; }
-        if (ch === '"') { inDouble = true; expr += ch; continue; }
-        if (ch === "`") { inBacktick = true; expr += ch; continue; }
-        if (ch === "{") { depth++; expr += ch; continue; }
-        if (ch === "}") {
-          if (depth === 0) { closed = true; i++; break; }
-          depth--; expr += ch; continue;
-        }
-        expr += ch;
-      }
-      if (!closed) {
-        out += "${" + expr;
-        break;
-      }
-      out += evalExpr(expr.trim());
-      continue;
-    }
-    out += str[i];
-    i++;
-  }
-  return out;
-};
-
-const trimStr = (v) => (typeof v === "string" ? v.trim() : v);
 
 const formatEntityStateForDisplay = (hass, stateObj, fallbackUnit = "") => {
   if (!stateObj) return "";

--- a/tests/value-helpers.test.mjs
+++ b/tests/value-helpers.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { clampNum, trimStr, replaceTemplateExpressions } from "../src/lib/values.js";
+
+test("value helpers import without browser globals and preserve coercion", () => {
+  assert.equal(clampNum(null, 0, 10, 7), 0);
+  assert.equal(clampNum("", 0, 10, 7), 0);
+  assert.equal(clampNum(Infinity, 0, 10, 7), 7);
+  assert.equal(clampNum("-4", 0, 10, 7), 0);
+  assert.equal(clampNum("12", 0, 10, 7), 10);
+  assert.equal(trimStr("  hello  "), "hello");
+  const object = {};
+  assert.equal(trimStr(object), object);
+  assert.equal(trimStr(null), null);
+});
+
+test("template tokenization preserves nested braces, quoted braces and incomplete input", () => {
+  const expressions = [];
+  const input = 'A ${ ({ nested: { value: "}" } }) } B ${ 2 }';
+  assert.equal(replaceTemplateExpressions(input, (expression) => {
+    expressions.push(expression);
+    return "value";
+  }), "A value B value");
+  assert.deepEqual(expressions, ['({ nested: { value: "}" } })', "2"]);
+  assert.equal(replaceTemplateExpressions("before ${ unfinished", () => "unexpected"), "before ${ unfinished");
+});


### PR DESCRIPTION
Part of #100, following the manually confirmed Gate 1 (#133). Moves clampNum, trimStr and replaceTemplateExpressions without changing their bodies. Adds direct browser-free helper tests; runtime/editor tests still load the built artifact. Full npm run build and npm run check pass (73 tests). Separate squash rollback point; no YAML, runtime behavior, version or Drawer changes. The next manual HA gate remains after the completed structural extraction.