### PR TITLE
refactor: extract state formatting helpers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@
 
 - `src/room-card.js` is the canonical source file.
 - `src/lib/values.js` owns browser-independent number/string helpers.
+- `src/lib/formatting.js` owns HA state/attribute formatting and existing fallbacks.
 - `dist/room-card.js` is the generated HACS artifact and must not be edited directly.
 - `dist/rooms/` contains the additional assets installed by HACS.
 - `tests/` contains automated regression tests.

--- a/dist/room-card.js
+++ b/dist/room-card.js
@@ -89,6 +89,32 @@ var replaceTemplateExpressions = (str, evalExpr) => {
 };
 var trimStr = (v) => typeof v === "string" ? v.trim() : v;
 
+// src/lib/formatting.js
+var formatEntityStateForDisplay = (hass, stateObj, fallbackUnit = "") => {
+  if (!stateObj) return "";
+  try {
+    if (typeof hass?.formatEntityState === "function") {
+      const formatted = hass.formatEntityState(stateObj);
+      const entityUnit2 = trimStr(stateObj.attributes?.unit_of_measurement) || "";
+      return !entityUnit2 && fallbackUnit ? `${formatted}${fallbackUnit}` : formatted;
+    }
+  } catch (_e) {
+  }
+  const raw = stateObj.state ?? "";
+  const entityUnit = trimStr(stateObj.attributes?.unit_of_measurement) || fallbackUnit;
+  return `${raw}${entityUnit || ""}`;
+};
+var formatEntityAttributeForDisplay = (hass, stateObj, attribute, value, fallbackUnit = "") => {
+  if (!stateObj || value == null) return "";
+  try {
+    if (typeof hass?.formatEntityAttributeValue === "function") {
+      return hass.formatEntityAttributeValue(stateObj, attribute, value);
+    }
+  } catch (_e) {
+  }
+  return `${value}${fallbackUnit || ""}`;
+};
+
 // src/room-card.js
 var VERSION = "1.4.0";
 var EDITOR_DOM_REVISION = "6";
@@ -1551,30 +1577,6 @@ var TRANSLATIONS = {
 var getTranslation = (hass, key) => {
   const lang = hass?.language?.split("-")[0] || "en";
   return TRANSLATIONS[lang]?.[key] ?? TRANSLATIONS["en"]?.[key] ?? key;
-};
-var formatEntityStateForDisplay = (hass, stateObj, fallbackUnit = "") => {
-  if (!stateObj) return "";
-  try {
-    if (typeof hass?.formatEntityState === "function") {
-      const formatted = hass.formatEntityState(stateObj);
-      const entityUnit2 = trimStr(stateObj.attributes?.unit_of_measurement) || "";
-      return !entityUnit2 && fallbackUnit ? `${formatted}${fallbackUnit}` : formatted;
-    }
-  } catch (_e) {
-  }
-  const raw = stateObj.state ?? "";
-  const entityUnit = trimStr(stateObj.attributes?.unit_of_measurement) || fallbackUnit;
-  return `${raw}${entityUnit || ""}`;
-};
-var formatEntityAttributeForDisplay = (hass, stateObj, attribute, value, fallbackUnit = "") => {
-  if (!stateObj || value == null) return "";
-  try {
-    if (typeof hass?.formatEntityAttributeValue === "function") {
-      return hass.formatEntityAttributeValue(stateObj, attribute, value);
-    }
-  } catch (_e) {
-  }
-  return `${value}${fallbackUnit || ""}`;
 };
 var normalizeTemperatureUnit = (unit) => {
   const normalized = String(unit || "").trim().replace(/\s+/g, "").replace("º", "°").toUpperCase();

--- a/src/lib/formatting.js
+++ b/src/lib/formatting.js
@@ -1,0 +1,27 @@
+import { trimStr } from "./values.js";
+
+const formatEntityStateForDisplay = (hass, stateObj, fallbackUnit = "") => {
+  if (!stateObj) return "";
+  try {
+    if (typeof hass?.formatEntityState === "function") {
+      const formatted = hass.formatEntityState(stateObj);
+      const entityUnit = trimStr(stateObj.attributes?.unit_of_measurement) || "";
+      return !entityUnit && fallbackUnit ? `${formatted}${fallbackUnit}` : formatted;
+    }
+  } catch (_e) { }
+  const raw = stateObj.state ?? "";
+  const entityUnit = trimStr(stateObj.attributes?.unit_of_measurement) || fallbackUnit;
+  return `${raw}${entityUnit || ""}`;
+};
+
+const formatEntityAttributeForDisplay = (hass, stateObj, attribute, value, fallbackUnit = "") => {
+  if (!stateObj || value == null) return "";
+  try {
+    if (typeof hass?.formatEntityAttributeValue === "function") {
+      return hass.formatEntityAttributeValue(stateObj, attribute, value);
+    }
+  } catch (_e) { }
+  return `${value}${fallbackUnit || ""}`;
+};
+
+export { formatEntityStateForDisplay, formatEntityAttributeForDisplay };

--- a/src/room-card.js
+++ b/src/room-card.js
@@ -1,5 +1,7 @@
 import { clampNum, replaceTemplateExpressions, trimStr } from "./lib/values.js";
 
+import { formatEntityStateForDisplay, formatEntityAttributeForDisplay } from "./lib/formatting.js";
+
 const VERSION = "1.4.0";
 const EDITOR_DOM_REVISION = "6";
 const LOG_FLAG = `customCards_RoomCard_Logged_${VERSION}`;
@@ -790,29 +792,6 @@ const getTranslation = (hass, key) => {
 };
 
 
-const formatEntityStateForDisplay = (hass, stateObj, fallbackUnit = "") => {
-  if (!stateObj) return "";
-  try {
-    if (typeof hass?.formatEntityState === "function") {
-      const formatted = hass.formatEntityState(stateObj);
-      const entityUnit = trimStr(stateObj.attributes?.unit_of_measurement) || "";
-      return !entityUnit && fallbackUnit ? `${formatted}${fallbackUnit}` : formatted;
-    }
-  } catch (_e) { }
-  const raw = stateObj.state ?? "";
-  const entityUnit = trimStr(stateObj.attributes?.unit_of_measurement) || fallbackUnit;
-  return `${raw}${entityUnit || ""}`;
-};
-
-const formatEntityAttributeForDisplay = (hass, stateObj, attribute, value, fallbackUnit = "") => {
-  if (!stateObj || value == null) return "";
-  try {
-    if (typeof hass?.formatEntityAttributeValue === "function") {
-      return hass.formatEntityAttributeValue(stateObj, attribute, value);
-    }
-  } catch (_e) { }
-  return `${value}${fallbackUnit || ""}`;
-};
 
 const normalizeTemperatureUnit = (unit) => {
   const normalized = String(unit || "").trim().replace(/\s+/g, "").replace("º", "°").toUpperCase();

--- a/tests/formatting-helpers.test.mjs
+++ b/tests/formatting-helpers.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatEntityStateForDisplay, formatEntityAttributeForDisplay } from "../src/lib/formatting.js";
+
+test("state formatting prefers HA and preserves existing unit fallback concatenation", () => {
+  const sensor = { state: "21", attributes: {} };
+  assert.equal(formatEntityStateForDisplay({}, null), "");
+  assert.equal(formatEntityStateForDisplay({}, sensor, "°C"), "21°C");
+  assert.equal(formatEntityStateForDisplay({ formatEntityState: () => "21.0" }, sensor, "°C"), "21.0°C");
+  sensor.attributes.unit_of_measurement = " °F ";
+  assert.equal(formatEntityStateForDisplay({}, sensor, "°C"), "21°F");
+  assert.equal(formatEntityStateForDisplay({ formatEntityState() { throw Error(); } }, sensor), "21°F");
+  assert.equal(formatEntityStateForDisplay({ formatEntityState: () => "formatted" }, sensor, "°C"), "formatted");
+});
+
+test("attribute formatting keeps HA arguments and handles missing values and formatter errors", () => {
+  const sensor = { state: "on", attributes: {} };
+  assert.equal(formatEntityAttributeForDisplay({}, sensor, "temperature", null), "");
+  assert.equal(formatEntityAttributeForDisplay({}, sensor, "temperature", 0, "°C"), "0°C");
+  assert.equal(formatEntityAttributeForDisplay({ formatEntityAttributeValue(...args) {
+    assert.deepEqual(args, [sensor, "temperature", 21]);
+    return "HA temperature";
+  } }, sensor, "temperature", 21), "HA temperature");
+  assert.equal(formatEntityAttributeForDisplay({ formatEntityAttributeValue() { throw Error(); } }, sensor, "temperature", 21, "°C"), "21°C");
+});


### PR DESCRIPTION
Part of #100. Moves state and attribute formatting unchanged into src/lib/formatting.js, importing only trimStr from values. Adds direct tests for HA delegation, argument order, fallback units, null values and formatter exceptions. npm run build and npm run check pass (75 tests), including runtime/editor artifact regressions. No YAML, action, translation, version or Drawer changes. Independent squash rollback point after #134.