### PR TITLE
refactor: extract temperature helpers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@
 - `src/room-card.js` is the canonical source file.
 - `src/lib/values.js` owns browser-independent number/string helpers.
 - `src/lib/formatting.js` owns HA state/attribute formatting and existing fallbacks.
+- `src/lib/temperature.js` owns temperature conversion and locale/precision handling.
 - `dist/room-card.js` is the generated HACS artifact and must not be edited directly.
 - `dist/rooms/` contains the additional assets installed by HACS.
 - `tests/` contains automated regression tests.

--- a/dist/room-card.js
+++ b/dist/room-card.js
@@ -115,6 +115,85 @@ var formatEntityAttributeForDisplay = (hass, stateObj, attribute, value, fallbac
   return `${value}${fallbackUnit || ""}`;
 };
 
+// src/lib/temperature.js
+var normalizeTemperatureUnit = (unit) => {
+  const normalized = String(unit || "").trim().replace(/\s+/g, "").replace("º", "°").toUpperCase();
+  if (normalized === "C" || normalized === "°C") return "°C";
+  if (normalized === "F" || normalized === "°F") return "°F";
+  return "";
+};
+var convertTemperatureValue = (value, sourceUnit, targetUnit) => {
+  const numeric = Number(value);
+  const source = normalizeTemperatureUnit(sourceUnit);
+  const target = normalizeTemperatureUnit(targetUnit);
+  if (!Number.isFinite(numeric) || !source || !target) return null;
+  if (source === target) return numeric;
+  return source === "°C" ? numeric * 9 / 5 + 32 : (numeric - 32) * 5 / 9;
+};
+var temperatureNumberLocale = (hass) => {
+  switch (hass?.locale?.number_format) {
+    case "comma_decimal":
+      return ["en-US", "en"];
+    case "decimal_comma":
+      return ["de", "es", "it"];
+    case "space_comma":
+      return ["fr", "sv", "cs"];
+    case "quote_decimal":
+      return ["de-CH"];
+    case "system":
+      return void 0;
+    default:
+      return hass?.locale?.language || hass?.language || void 0;
+  }
+};
+var formatConvertedTemperature = (hass, stateObj, value, sourceUnit, targetUnit, fallbackPrecision = 1) => {
+  const target = normalizeTemperatureUnit(targetUnit);
+  const converted = convertTemperatureValue(value, sourceUnit, target);
+  if (converted == null) return "";
+  const configuredPrecision = hass?.entities?.[stateObj?.entity_id]?.display_precision;
+  const registryPrecision = configuredPrecision == null ? NaN : Number(configuredPrecision);
+  const precision = Number.isInteger(registryPrecision) && registryPrecision >= 0 ? Math.min(registryPrecision, 6) : fallbackPrecision;
+  const fixedValue = converted.toFixed(precision);
+  const syntheticState = {
+    ...stateObj || {},
+    entity_id: "sensor.room_card_temperature",
+    state: fixedValue,
+    attributes: {
+      ...stateObj?.attributes || {},
+      device_class: "temperature",
+      unit_of_measurement: target
+    }
+  };
+  try {
+    if (typeof hass?.formatEntityState === "function") return hass.formatEntityState(syntheticState);
+  } catch (_e) {
+  }
+  const noGrouping = hass?.locale?.number_format === "none";
+  const formatted = new Intl.NumberFormat(noGrouping ? "en-US" : temperatureNumberLocale(hass), {
+    minimumFractionDigits: precision,
+    maximumFractionDigits: precision,
+    useGrouping: !noGrouping
+  }).format(converted);
+  return `${formatted} ${target}`;
+};
+var formatTemperatureStateForDisplay = (hass, stateObj, targetUnit, fallbackSourceUnit = "°C") => {
+  if (!stateObj) return "";
+  const target = normalizeTemperatureUnit(targetUnit);
+  const source = normalizeTemperatureUnit(stateObj.attributes?.unit_of_measurement) || normalizeTemperatureUnit(fallbackSourceUnit);
+  if (!target || !source || target === source) {
+    return formatEntityStateForDisplay(hass, stateObj, source || fallbackSourceUnit);
+  }
+  return formatConvertedTemperature(hass, stateObj, stateObj.state, source, target, 1) || formatEntityStateForDisplay(hass, stateObj, source || fallbackSourceUnit);
+};
+var formatTemperatureAttributeForDisplay = (hass, stateObj, attribute, value, targetUnit, fallbackSourceUnit = "°C") => {
+  const source = normalizeTemperatureUnit(hass?.config?.unit_system?.temperature) || normalizeTemperatureUnit(fallbackSourceUnit);
+  const target = normalizeTemperatureUnit(targetUnit);
+  if (!target || !source || target === source) {
+    return formatEntityAttributeForDisplay(hass, stateObj, attribute, value, source || fallbackSourceUnit);
+  }
+  return formatConvertedTemperature(hass, stateObj, value, source, target, 1) || formatEntityAttributeForDisplay(hass, stateObj, attribute, value, source || fallbackSourceUnit);
+};
+
 // src/room-card.js
 var VERSION = "1.4.0";
 var EDITOR_DOM_REVISION = "6";
@@ -1577,83 +1656,6 @@ var TRANSLATIONS = {
 var getTranslation = (hass, key) => {
   const lang = hass?.language?.split("-")[0] || "en";
   return TRANSLATIONS[lang]?.[key] ?? TRANSLATIONS["en"]?.[key] ?? key;
-};
-var normalizeTemperatureUnit = (unit) => {
-  const normalized = String(unit || "").trim().replace(/\s+/g, "").replace("º", "°").toUpperCase();
-  if (normalized === "C" || normalized === "°C") return "°C";
-  if (normalized === "F" || normalized === "°F") return "°F";
-  return "";
-};
-var convertTemperatureValue = (value, sourceUnit, targetUnit) => {
-  const numeric = Number(value);
-  const source = normalizeTemperatureUnit(sourceUnit);
-  const target = normalizeTemperatureUnit(targetUnit);
-  if (!Number.isFinite(numeric) || !source || !target) return null;
-  if (source === target) return numeric;
-  return source === "°C" ? numeric * 9 / 5 + 32 : (numeric - 32) * 5 / 9;
-};
-var temperatureNumberLocale = (hass) => {
-  switch (hass?.locale?.number_format) {
-    case "comma_decimal":
-      return ["en-US", "en"];
-    case "decimal_comma":
-      return ["de", "es", "it"];
-    case "space_comma":
-      return ["fr", "sv", "cs"];
-    case "quote_decimal":
-      return ["de-CH"];
-    case "system":
-      return void 0;
-    default:
-      return hass?.locale?.language || hass?.language || void 0;
-  }
-};
-var formatConvertedTemperature = (hass, stateObj, value, sourceUnit, targetUnit, fallbackPrecision = 1) => {
-  const target = normalizeTemperatureUnit(targetUnit);
-  const converted = convertTemperatureValue(value, sourceUnit, target);
-  if (converted == null) return "";
-  const configuredPrecision = hass?.entities?.[stateObj?.entity_id]?.display_precision;
-  const registryPrecision = configuredPrecision == null ? NaN : Number(configuredPrecision);
-  const precision = Number.isInteger(registryPrecision) && registryPrecision >= 0 ? Math.min(registryPrecision, 6) : fallbackPrecision;
-  const fixedValue = converted.toFixed(precision);
-  const syntheticState = {
-    ...stateObj || {},
-    entity_id: "sensor.room_card_temperature",
-    state: fixedValue,
-    attributes: {
-      ...stateObj?.attributes || {},
-      device_class: "temperature",
-      unit_of_measurement: target
-    }
-  };
-  try {
-    if (typeof hass?.formatEntityState === "function") return hass.formatEntityState(syntheticState);
-  } catch (_e) {
-  }
-  const noGrouping = hass?.locale?.number_format === "none";
-  const formatted = new Intl.NumberFormat(noGrouping ? "en-US" : temperatureNumberLocale(hass), {
-    minimumFractionDigits: precision,
-    maximumFractionDigits: precision,
-    useGrouping: !noGrouping
-  }).format(converted);
-  return `${formatted} ${target}`;
-};
-var formatTemperatureStateForDisplay = (hass, stateObj, targetUnit, fallbackSourceUnit = "°C") => {
-  if (!stateObj) return "";
-  const target = normalizeTemperatureUnit(targetUnit);
-  const source = normalizeTemperatureUnit(stateObj.attributes?.unit_of_measurement) || normalizeTemperatureUnit(fallbackSourceUnit);
-  if (!target || !source || target === source) {
-    return formatEntityStateForDisplay(hass, stateObj, source || fallbackSourceUnit);
-  }
-  return formatConvertedTemperature(hass, stateObj, stateObj.state, source, target, 1) || formatEntityStateForDisplay(hass, stateObj, source || fallbackSourceUnit);
-};
-var formatTemperatureAttributeForDisplay = (hass, stateObj, attribute, value, targetUnit, fallbackSourceUnit = "°C") => {
-  const source = normalizeTemperatureUnit(hass?.config?.unit_system?.temperature) || normalizeTemperatureUnit(fallbackSourceUnit);
-  const target = normalizeTemperatureUnit(targetUnit);
-  if (!target || !source || target === source) {
-    return formatEntityAttributeForDisplay(hass, stateObj, attribute, value, source || fallbackSourceUnit);
-  }
-  return formatConvertedTemperature(hass, stateObj, value, source, target, 1) || formatEntityAttributeForDisplay(hass, stateObj, attribute, value, source || fallbackSourceUnit);
 };
 var hexToRgba = (hex, alpha = 0.35) => {
   const m = /^#?([0-9a-f]{6})$/i.exec(trimStr(hex) || "");

--- a/src/lib/temperature.js
+++ b/src/lib/temperature.js
@@ -1,0 +1,87 @@
+import { formatEntityStateForDisplay, formatEntityAttributeForDisplay } from "./formatting.js";
+
+const normalizeTemperatureUnit = (unit) => {
+  const normalized = String(unit || "").trim().replace(/\s+/g, "").replace("º", "°").toUpperCase();
+  if (normalized === "C" || normalized === "°C") return "°C";
+  if (normalized === "F" || normalized === "°F") return "°F";
+  return "";
+};
+
+const convertTemperatureValue = (value, sourceUnit, targetUnit) => {
+  const numeric = Number(value);
+  const source = normalizeTemperatureUnit(sourceUnit);
+  const target = normalizeTemperatureUnit(targetUnit);
+  if (!Number.isFinite(numeric) || !source || !target) return null;
+  if (source === target) return numeric;
+  return source === "°C"
+    ? (numeric * 9 / 5) + 32
+    : (numeric - 32) * 5 / 9;
+};
+
+const temperatureNumberLocale = (hass) => {
+  switch (hass?.locale?.number_format) {
+    case "comma_decimal": return ["en-US", "en"];
+    case "decimal_comma": return ["de", "es", "it"];
+    case "space_comma": return ["fr", "sv", "cs"];
+    case "quote_decimal": return ["de-CH"];
+    case "system": return undefined;
+    default: return hass?.locale?.language || hass?.language || undefined;
+  }
+};
+
+const formatConvertedTemperature = (hass, stateObj, value, sourceUnit, targetUnit, fallbackPrecision = 1) => {
+  const target = normalizeTemperatureUnit(targetUnit);
+  const converted = convertTemperatureValue(value, sourceUnit, target);
+  if (converted == null) return "";
+  const configuredPrecision = hass?.entities?.[stateObj?.entity_id]?.display_precision;
+  const registryPrecision = configuredPrecision == null ? NaN : Number(configuredPrecision);
+  const precision = Number.isInteger(registryPrecision) && registryPrecision >= 0
+    ? Math.min(registryPrecision, 6)
+    : fallbackPrecision;
+  const fixedValue = converted.toFixed(precision);
+  const syntheticState = {
+    ...(stateObj || {}),
+    entity_id: "sensor.room_card_temperature",
+    state: fixedValue,
+    attributes: {
+      ...(stateObj?.attributes || {}),
+      device_class: "temperature",
+      unit_of_measurement: target
+    }
+  };
+  try {
+    if (typeof hass?.formatEntityState === "function") return hass.formatEntityState(syntheticState);
+  } catch (_e) { }
+  const noGrouping = hass?.locale?.number_format === "none";
+  const formatted = new Intl.NumberFormat(noGrouping ? "en-US" : temperatureNumberLocale(hass), {
+    minimumFractionDigits: precision,
+    maximumFractionDigits: precision,
+    useGrouping: !noGrouping
+  }).format(converted);
+  return `${formatted}\u00a0${target}`;
+};
+
+const formatTemperatureStateForDisplay = (hass, stateObj, targetUnit, fallbackSourceUnit = "°C") => {
+  if (!stateObj) return "";
+  const target = normalizeTemperatureUnit(targetUnit);
+  const source = normalizeTemperatureUnit(stateObj.attributes?.unit_of_measurement)
+    || normalizeTemperatureUnit(fallbackSourceUnit);
+  if (!target || !source || target === source) {
+    return formatEntityStateForDisplay(hass, stateObj, source || fallbackSourceUnit);
+  }
+  return formatConvertedTemperature(hass, stateObj, stateObj.state, source, target, 1)
+    || formatEntityStateForDisplay(hass, stateObj, source || fallbackSourceUnit);
+};
+
+const formatTemperatureAttributeForDisplay = (hass, stateObj, attribute, value, targetUnit, fallbackSourceUnit = "°C") => {
+  const source = normalizeTemperatureUnit(hass?.config?.unit_system?.temperature)
+    || normalizeTemperatureUnit(fallbackSourceUnit);
+  const target = normalizeTemperatureUnit(targetUnit);
+  if (!target || !source || target === source) {
+    return formatEntityAttributeForDisplay(hass, stateObj, attribute, value, source || fallbackSourceUnit);
+  }
+  return formatConvertedTemperature(hass, stateObj, value, source, target, 1)
+    || formatEntityAttributeForDisplay(hass, stateObj, attribute, value, source || fallbackSourceUnit);
+};
+
+export { normalizeTemperatureUnit, convertTemperatureValue, temperatureNumberLocale, formatConvertedTemperature, formatTemperatureStateForDisplay, formatTemperatureAttributeForDisplay };

--- a/src/room-card.js
+++ b/src/room-card.js
@@ -2,6 +2,8 @@ import { clampNum, replaceTemplateExpressions, trimStr } from "./lib/values.js";
 
 import { formatEntityStateForDisplay, formatEntityAttributeForDisplay } from "./lib/formatting.js";
 
+import { normalizeTemperatureUnit, convertTemperatureValue, temperatureNumberLocale, formatConvertedTemperature, formatTemperatureStateForDisplay, formatTemperatureAttributeForDisplay } from "./lib/temperature.js";
+
 const VERSION = "1.4.0";
 const EDITOR_DOM_REVISION = "6";
 const LOG_FLAG = `customCards_RoomCard_Logged_${VERSION}`;
@@ -793,89 +795,6 @@ const getTranslation = (hass, key) => {
 
 
 
-const normalizeTemperatureUnit = (unit) => {
-  const normalized = String(unit || "").trim().replace(/\s+/g, "").replace("º", "°").toUpperCase();
-  if (normalized === "C" || normalized === "°C") return "°C";
-  if (normalized === "F" || normalized === "°F") return "°F";
-  return "";
-};
-
-const convertTemperatureValue = (value, sourceUnit, targetUnit) => {
-  const numeric = Number(value);
-  const source = normalizeTemperatureUnit(sourceUnit);
-  const target = normalizeTemperatureUnit(targetUnit);
-  if (!Number.isFinite(numeric) || !source || !target) return null;
-  if (source === target) return numeric;
-  return source === "°C"
-    ? (numeric * 9 / 5) + 32
-    : (numeric - 32) * 5 / 9;
-};
-
-const temperatureNumberLocale = (hass) => {
-  switch (hass?.locale?.number_format) {
-    case "comma_decimal": return ["en-US", "en"];
-    case "decimal_comma": return ["de", "es", "it"];
-    case "space_comma": return ["fr", "sv", "cs"];
-    case "quote_decimal": return ["de-CH"];
-    case "system": return undefined;
-    default: return hass?.locale?.language || hass?.language || undefined;
-  }
-};
-
-const formatConvertedTemperature = (hass, stateObj, value, sourceUnit, targetUnit, fallbackPrecision = 1) => {
-  const target = normalizeTemperatureUnit(targetUnit);
-  const converted = convertTemperatureValue(value, sourceUnit, target);
-  if (converted == null) return "";
-  const configuredPrecision = hass?.entities?.[stateObj?.entity_id]?.display_precision;
-  const registryPrecision = configuredPrecision == null ? NaN : Number(configuredPrecision);
-  const precision = Number.isInteger(registryPrecision) && registryPrecision >= 0
-    ? Math.min(registryPrecision, 6)
-    : fallbackPrecision;
-  const fixedValue = converted.toFixed(precision);
-  const syntheticState = {
-    ...(stateObj || {}),
-    entity_id: "sensor.room_card_temperature",
-    state: fixedValue,
-    attributes: {
-      ...(stateObj?.attributes || {}),
-      device_class: "temperature",
-      unit_of_measurement: target
-    }
-  };
-  try {
-    if (typeof hass?.formatEntityState === "function") return hass.formatEntityState(syntheticState);
-  } catch (_e) { }
-  const noGrouping = hass?.locale?.number_format === "none";
-  const formatted = new Intl.NumberFormat(noGrouping ? "en-US" : temperatureNumberLocale(hass), {
-    minimumFractionDigits: precision,
-    maximumFractionDigits: precision,
-    useGrouping: !noGrouping
-  }).format(converted);
-  return `${formatted}\u00a0${target}`;
-};
-
-const formatTemperatureStateForDisplay = (hass, stateObj, targetUnit, fallbackSourceUnit = "°C") => {
-  if (!stateObj) return "";
-  const target = normalizeTemperatureUnit(targetUnit);
-  const source = normalizeTemperatureUnit(stateObj.attributes?.unit_of_measurement)
-    || normalizeTemperatureUnit(fallbackSourceUnit);
-  if (!target || !source || target === source) {
-    return formatEntityStateForDisplay(hass, stateObj, source || fallbackSourceUnit);
-  }
-  return formatConvertedTemperature(hass, stateObj, stateObj.state, source, target, 1)
-    || formatEntityStateForDisplay(hass, stateObj, source || fallbackSourceUnit);
-};
-
-const formatTemperatureAttributeForDisplay = (hass, stateObj, attribute, value, targetUnit, fallbackSourceUnit = "°C") => {
-  const source = normalizeTemperatureUnit(hass?.config?.unit_system?.temperature)
-    || normalizeTemperatureUnit(fallbackSourceUnit);
-  const target = normalizeTemperatureUnit(targetUnit);
-  if (!target || !source || target === source) {
-    return formatEntityAttributeForDisplay(hass, stateObj, attribute, value, source || fallbackSourceUnit);
-  }
-  return formatConvertedTemperature(hass, stateObj, value, source, target, 1)
-    || formatEntityAttributeForDisplay(hass, stateObj, attribute, value, source || fallbackSourceUnit);
-};
 
 const hexToRgba = (hex, alpha = 0.35) => {
   const m = /^#?([0-9a-f]{6})$/i.exec(trimStr(hex) || "");

--- a/tests/temperature-helpers.test.mjs
+++ b/tests/temperature-helpers.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { normalizeTemperatureUnit, convertTemperatureValue, temperatureNumberLocale,
+  formatConvertedTemperature, formatTemperatureStateForDisplay, formatTemperatureAttributeForDisplay
+} from "../src/lib/temperature.js";
+
+test("temperature helpers normalize supported units and reject unsupported conversions", () => {
+  assert.equal(normalizeTemperatureUnit(" º f "), "°F");
+  assert.equal(normalizeTemperatureUnit("kelvin"), "");
+  assert.equal(convertTemperatureValue(0, "C", "F"), 32);
+  assert.equal(convertTemperatureValue(212, "F", "C"), 100);
+  assert.equal(convertTemperatureValue("bad", "C", "F"), null);
+  assert.equal(convertTemperatureValue(21, "K", "C"), null);
+  assert.deepEqual(temperatureNumberLocale({ locale: { number_format: "space_comma" } }), ["fr", "sv", "cs"]);
+});
+
+test("converted temperature delegates synthetic state and registry precision to HA", () => {
+  const sensor = { entity_id: "sensor.temp", state: "0", attributes: { unit_of_measurement: "°C" } };
+  const hass = { entities: { "sensor.temp": { display_precision: 2 } }, formatEntityState(state) {
+    assert.equal(state.entity_id, "sensor.room_card_temperature");
+    assert.equal(state.state, "32.00");
+    assert.equal(state.attributes.unit_of_measurement, "°F");
+    return "HA 32.00 °F";
+  } };
+  assert.equal(formatConvertedTemperature(hass, sensor, 0, "C", "F"), "HA 32.00 °F");
+  assert.equal(sensor.state, "0");
+  assert.equal(formatConvertedTemperature({ locale: { number_format: "none" } }, sensor, 0, "C", "F"), "32.0\u00a0°F");
+});
+
+test("temperature state and attribute fallbacks keep the previous behavior", () => {
+  const sensor = { state: "invalid", attributes: { unit_of_measurement: "°C" } };
+  assert.equal(formatTemperatureStateForDisplay({}, sensor, "F"), "invalid°C");
+  assert.equal(formatTemperatureStateForDisplay({}, null, "F"), "");
+  assert.equal(formatTemperatureAttributeForDisplay({ config: { unit_system: { temperature: "°F" } } }, sensor, "temperature", 32, "C"), "0.0\u00a0°C");
+  assert.equal(formatTemperatureAttributeForDisplay({}, sensor, "temperature", 21, "C"), "21°C");
+});


### PR DESCRIPTION
Part of #100. Moves temperature conversion, display precision and locale handling without changing function bodies. Dependencies point only to lib/formatting.js. Direct helper tests cover supported and invalid units, HA synthetic states, registry precision, locale handling and invalid-value fallbacks. Full build/check pass (78 tests). Existing artifact, actions, YAML and visual layout remain unchanged. Separate squash rollback point; no version bump or Drawer changes.