### PR TITLE
refactor: extract color helpers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
 - `src/lib/values.js` owns browser-independent number/string helpers.
 - `src/lib/formatting.js` owns HA state/attribute formatting and existing fallbacks.
 - `src/lib/temperature.js` owns temperature conversion and locale/precision handling.
+- `src/lib/colors.js` owns color parsing, contrast and picker conversion.
 - `dist/room-card.js` is the generated HACS artifact and must not be edited directly.
 - `dist/rooms/` contains the additional assets installed by HACS.
 - `tests/` contains automated regression tests.

--- a/dist/room-card.js
+++ b/dist/room-card.js
@@ -194,6 +194,35 @@ var formatTemperatureAttributeForDisplay = (hass, stateObj, attribute, value, ta
   return formatConvertedTemperature(hass, stateObj, value, source, target, 1) || formatEntityAttributeForDisplay(hass, stateObj, attribute, value, source || fallbackSourceUnit);
 };
 
+// src/lib/colors.js
+var hexToRgba = (hex, alpha = 0.35) => {
+  const m = /^#?([0-9a-f]{6})$/i.exec(trimStr(hex) || "");
+  if (!m) return "";
+  const raw = m[1];
+  const r = parseInt(raw.slice(0, 2), 16);
+  const g = parseInt(raw.slice(2, 4), 16);
+  const b = parseInt(raw.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+var readableTextForHex = (hex) => {
+  const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(trimStr(hex) || "");
+  if (!m) return "";
+  const raw = m[1].length === 3 ? m[1].split("").map((ch) => ch + ch).join("") : m[1];
+  const r = parseInt(raw.slice(0, 2), 16);
+  const g = parseInt(raw.slice(2, 4), 16);
+  const b = parseInt(raw.slice(4, 6), 16);
+  return (r * 299 + g * 587 + b * 114) / 1e3 >= 140 ? "#000000" : "#ffffff";
+};
+var parseColorToPickerHex = (color) => {
+  const value = trimStr(color) || "";
+  const hex = /^#([0-9a-f]{6})$/i.exec(value);
+  if (hex) return `#${hex[1]}`;
+  const rgba = /^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})(?:\s*,\s*(?:\d*\.?\d+))?\s*\)$/i.exec(value);
+  if (!rgba) return "#000000";
+  const clamp = (n) => Math.max(0, Math.min(255, Number(n) || 0)).toString(16).padStart(2, "0");
+  return `#${clamp(rgba[1])}${clamp(rgba[2])}${clamp(rgba[3])}`;
+};
+
 // src/room-card.js
 var VERSION = "1.4.0";
 var EDITOR_DOM_REVISION = "6";
@@ -1656,33 +1685,6 @@ var TRANSLATIONS = {
 var getTranslation = (hass, key) => {
   const lang = hass?.language?.split("-")[0] || "en";
   return TRANSLATIONS[lang]?.[key] ?? TRANSLATIONS["en"]?.[key] ?? key;
-};
-var hexToRgba = (hex, alpha = 0.35) => {
-  const m = /^#?([0-9a-f]{6})$/i.exec(trimStr(hex) || "");
-  if (!m) return "";
-  const raw = m[1];
-  const r = parseInt(raw.slice(0, 2), 16);
-  const g = parseInt(raw.slice(2, 4), 16);
-  const b = parseInt(raw.slice(4, 6), 16);
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-};
-var readableTextForHex = (hex) => {
-  const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(trimStr(hex) || "");
-  if (!m) return "";
-  const raw = m[1].length === 3 ? m[1].split("").map((ch) => ch + ch).join("") : m[1];
-  const r = parseInt(raw.slice(0, 2), 16);
-  const g = parseInt(raw.slice(2, 4), 16);
-  const b = parseInt(raw.slice(4, 6), 16);
-  return (r * 299 + g * 587 + b * 114) / 1e3 >= 140 ? "#000000" : "#ffffff";
-};
-var parseColorToPickerHex = (color) => {
-  const value = trimStr(color) || "";
-  const hex = /^#([0-9a-f]{6})$/i.exec(value);
-  if (hex) return `#${hex[1]}`;
-  const rgba = /^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})(?:\s*,\s*(?:\d*\.?\d+))?\s*\)$/i.exec(value);
-  if (!rgba) return "#000000";
-  const clamp = (n) => Math.max(0, Math.min(255, Number(n) || 0)).toString(16).padStart(2, "0");
-  return `#${clamp(rgba[1])}${clamp(rgba[2])}${clamp(rgba[3])}`;
 };
 var STATE_DEFINITIONS = Object.freeze({
   OFFLINE_STATES: /* @__PURE__ */ new Set(["unavailable", "unknown"]),

--- a/src/lib/colors.js
+++ b/src/lib/colors.js
@@ -1,0 +1,35 @@
+import { trimStr } from "./values.js";
+
+const hexToRgba = (hex, alpha = 0.35) => {
+  const m = /^#?([0-9a-f]{6})$/i.exec(trimStr(hex) || "");
+  if (!m) return "";
+  const raw = m[1];
+  const r = parseInt(raw.slice(0, 2), 16);
+  const g = parseInt(raw.slice(2, 4), 16);
+  const b = parseInt(raw.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
+const readableTextForHex = (hex) => {
+  const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(trimStr(hex) || "");
+  if (!m) return "";
+  const raw = m[1].length === 3
+    ? m[1].split("").map((ch) => ch + ch).join("")
+    : m[1];
+  const r = parseInt(raw.slice(0, 2), 16);
+  const g = parseInt(raw.slice(2, 4), 16);
+  const b = parseInt(raw.slice(4, 6), 16);
+  return ((r * 299 + g * 587 + b * 114) / 1000) >= 140 ? "#000000" : "#ffffff";
+};
+
+const parseColorToPickerHex = (color) => {
+  const value = trimStr(color) || "";
+  const hex = /^#([0-9a-f]{6})$/i.exec(value);
+  if (hex) return `#${hex[1]}`;
+  const rgba = /^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})(?:\s*,\s*(?:\d*\.?\d+))?\s*\)$/i.exec(value);
+  if (!rgba) return "#000000";
+  const clamp = (n) => Math.max(0, Math.min(255, Number(n) || 0)).toString(16).padStart(2, "0");
+  return `#${clamp(rgba[1])}${clamp(rgba[2])}${clamp(rgba[3])}`;
+};
+
+export { hexToRgba, readableTextForHex, parseColorToPickerHex };

--- a/src/room-card.js
+++ b/src/room-card.js
@@ -4,6 +4,8 @@ import { formatEntityStateForDisplay, formatEntityAttributeForDisplay } from "./
 
 import { normalizeTemperatureUnit, convertTemperatureValue, temperatureNumberLocale, formatConvertedTemperature, formatTemperatureStateForDisplay, formatTemperatureAttributeForDisplay } from "./lib/temperature.js";
 
+import { hexToRgba, readableTextForHex, parseColorToPickerHex } from "./lib/colors.js";
+
 const VERSION = "1.4.0";
 const EDITOR_DOM_REVISION = "6";
 const LOG_FLAG = `customCards_RoomCard_Logged_${VERSION}`;
@@ -796,37 +798,6 @@ const getTranslation = (hass, key) => {
 
 
 
-const hexToRgba = (hex, alpha = 0.35) => {
-  const m = /^#?([0-9a-f]{6})$/i.exec(trimStr(hex) || "");
-  if (!m) return "";
-  const raw = m[1];
-  const r = parseInt(raw.slice(0, 2), 16);
-  const g = parseInt(raw.slice(2, 4), 16);
-  const b = parseInt(raw.slice(4, 6), 16);
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-};
-
-const readableTextForHex = (hex) => {
-  const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(trimStr(hex) || "");
-  if (!m) return "";
-  const raw = m[1].length === 3
-    ? m[1].split("").map((ch) => ch + ch).join("")
-    : m[1];
-  const r = parseInt(raw.slice(0, 2), 16);
-  const g = parseInt(raw.slice(2, 4), 16);
-  const b = parseInt(raw.slice(4, 6), 16);
-  return ((r * 299 + g * 587 + b * 114) / 1000) >= 140 ? "#000000" : "#ffffff";
-};
-
-const parseColorToPickerHex = (color) => {
-  const value = trimStr(color) || "";
-  const hex = /^#([0-9a-f]{6})$/i.exec(value);
-  if (hex) return `#${hex[1]}`;
-  const rgba = /^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})(?:\s*,\s*(?:\d*\.?\d+))?\s*\)$/i.exec(value);
-  if (!rgba) return "#000000";
-  const clamp = (n) => Math.max(0, Math.min(255, Number(n) || 0)).toString(16).padStart(2, "0");
-  return `#${clamp(rgba[1])}${clamp(rgba[2])}${clamp(rgba[3])}`;
-};
 
 const STATE_DEFINITIONS = Object.freeze({
   OFFLINE_STATES: new Set(["unavailable", "unknown"]),

--- a/tests/color-helpers.test.mjs
+++ b/tests/color-helpers.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { hexToRgba, readableTextForHex, parseColorToPickerHex } from "../src/lib/colors.js";
+
+test("color helpers retain accepted formats, contrast threshold and safe fallbacks", () => {
+  assert.equal(hexToRgba(" #336699 ", 0.2), "rgba(51, 102, 153, 0.2)");
+  assert.equal(hexToRgba("#fff"), "");
+  assert.equal(hexToRgba("invalid"), "");
+  assert.equal(readableTextForHex("#fff"), "#000000");
+  assert.equal(readableTextForHex("#000"), "#ffffff");
+  assert.equal(readableTextForHex("#8c8c8c"), "#000000");
+  assert.equal(readableTextForHex("#8b8b8b"), "#ffffff");
+  assert.equal(readableTextForHex("red"), "");
+  assert.equal(parseColorToPickerHex(" #ABCDEF "), "#ABCDEF");
+  assert.equal(parseColorToPickerHex("rgba(999, 0, 42, 0.5)"), "#ff002a");
+  assert.equal(parseColorToPickerHex("#fff"), "#000000");
+  assert.equal(parseColorToPickerHex("invalid"), "#000000");
+});


### PR DESCRIPTION
Part of #100. Moves existing color parsing, readable text contrast and picker conversion unchanged into lib/colors.js. Direct tests preserve accepted formats, contrast boundaries and existing invalid-input fallbacks. Full build/check pass (79 tests), including the shipped artifact regression suite. No visual/YAML/action changes; independent squash rollback point.