### PR TITLE
refactor: extract shared state definitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@
 - `src/lib/formatting.js` owns HA state/attribute formatting and existing fallbacks.
 - `src/lib/temperature.js` owns temperature conversion and locale/precision handling.
 - `src/lib/colors.js` owns color parsing, contrast and picker conversion.
+- `src/lib/states.js` owns shared state definitions, domain icons and state predicates.
 - `dist/room-card.js` is the generated HACS artifact and must not be edited directly.
 - `dist/rooms/` contains the additional assets installed by HACS.
 - `tests/` contains automated regression tests.

--- a/dist/room-card.js
+++ b/dist/room-card.js
@@ -223,6 +223,52 @@ var parseColorToPickerHex = (color) => {
   return `#${clamp(rgba[1])}${clamp(rgba[2])}${clamp(rgba[3])}`;
 };
 
+// src/lib/states.js
+var STATE_DEFINITIONS = Object.freeze({
+  OFFLINE_STATES: /* @__PURE__ */ new Set(["unavailable", "unknown"]),
+  ACTIVE_STATES: {
+    default: /* @__PURE__ */ new Set(["on", "open", "playing", "heat", "cool", "auto", "drying", "fan_only", "cleaning", "manual", "boost", "unlocked", "home"]),
+    climate: /* @__PURE__ */ new Set(["heat", "cool", "auto", "drying", "fan_only"]),
+    media_player: /* @__PURE__ */ new Set(["playing"])
+  },
+  INACTIVE_STATES: Object.freeze({
+    off: "off",
+    closed: "closed"
+  }),
+  ON_STATE: "on"
+});
+var DOMAIN_STATE_ICON_MAPS = Object.freeze({
+  light: { on: "mdi:lightbulb", off: "mdi:lightbulb-outline" },
+  switch: { on: "mdi:toggle-switch", off: "mdi:toggle-switch-off-outline" },
+  input_boolean: { on: "mdi:toggle-switch", off: "mdi:toggle-switch-off-outline" },
+  fan: { on: "mdi:fan", off: "mdi:fan-off" },
+  lock: { locked: "mdi:lock", unlocked: "mdi:lock-open-outline" },
+  cover: {
+    open: "mdi:window-shutter-open",
+    closed: "mdi:window-shutter",
+    opening: "mdi:window-shutter-open",
+    closing: "mdi:window-shutter"
+  },
+  media_player: { playing: "mdi:cast-connected", paused: "mdi:cast-connected", idle: "mdi:cast", off: "mdi:cast-off" }
+});
+var getEntityDomain = (entityId) => typeof entityId === "string" && entityId.includes(".") ? entityId.split(".")[0] : "";
+var getEntityStateValue = (stateObj) => stateObj?.state;
+var isOfflineStateValue = (stateValue) => STATE_DEFINITIONS.OFFLINE_STATES.has(stateValue);
+var isEntityOffline = (stateObj) => isOfflineStateValue(getEntityStateValue(stateObj));
+var isEntityOn = (stateObj) => getEntityStateValue(stateObj) === STATE_DEFINITIONS.ON_STATE;
+var isEntityOff = (stateObj) => getEntityStateValue(stateObj) === STATE_DEFINITIONS.INACTIVE_STATES.off;
+var isEntityActive = (stateObj, entityId) => {
+  const stateValue = getEntityStateValue(stateObj);
+  if (stateValue === void 0 || stateValue === null) return false;
+  const domain = getEntityDomain(entityId);
+  const domainActive = STATE_DEFINITIONS.ACTIVE_STATES[domain];
+  if (domainActive?.has(stateValue)) return true;
+  if (STATE_DEFINITIONS.ACTIVE_STATES.default.has(stateValue)) return true;
+  if (domain === "cover") return stateValue !== STATE_DEFINITIONS.INACTIVE_STATES.closed;
+  if (domain === "climate") return stateValue !== STATE_DEFINITIONS.INACTIVE_STATES.off && !isOfflineStateValue(stateValue);
+  return false;
+};
+
 // src/room-card.js
 var VERSION = "1.4.0";
 var EDITOR_DOM_REVISION = "6";
@@ -1685,50 +1731,6 @@ var TRANSLATIONS = {
 var getTranslation = (hass, key) => {
   const lang = hass?.language?.split("-")[0] || "en";
   return TRANSLATIONS[lang]?.[key] ?? TRANSLATIONS["en"]?.[key] ?? key;
-};
-var STATE_DEFINITIONS = Object.freeze({
-  OFFLINE_STATES: /* @__PURE__ */ new Set(["unavailable", "unknown"]),
-  ACTIVE_STATES: {
-    default: /* @__PURE__ */ new Set(["on", "open", "playing", "heat", "cool", "auto", "drying", "fan_only", "cleaning", "manual", "boost", "unlocked", "home"]),
-    climate: /* @__PURE__ */ new Set(["heat", "cool", "auto", "drying", "fan_only"]),
-    media_player: /* @__PURE__ */ new Set(["playing"])
-  },
-  INACTIVE_STATES: Object.freeze({
-    off: "off",
-    closed: "closed"
-  }),
-  ON_STATE: "on"
-});
-var DOMAIN_STATE_ICON_MAPS = Object.freeze({
-  light: { on: "mdi:lightbulb", off: "mdi:lightbulb-outline" },
-  switch: { on: "mdi:toggle-switch", off: "mdi:toggle-switch-off-outline" },
-  input_boolean: { on: "mdi:toggle-switch", off: "mdi:toggle-switch-off-outline" },
-  fan: { on: "mdi:fan", off: "mdi:fan-off" },
-  lock: { locked: "mdi:lock", unlocked: "mdi:lock-open-outline" },
-  cover: {
-    open: "mdi:window-shutter-open",
-    closed: "mdi:window-shutter",
-    opening: "mdi:window-shutter-open",
-    closing: "mdi:window-shutter"
-  },
-  media_player: { playing: "mdi:cast-connected", paused: "mdi:cast-connected", idle: "mdi:cast", off: "mdi:cast-off" }
-});
-var getEntityDomain = (entityId) => typeof entityId === "string" && entityId.includes(".") ? entityId.split(".")[0] : "";
-var getEntityStateValue = (stateObj) => stateObj?.state;
-var isOfflineStateValue = (stateValue) => STATE_DEFINITIONS.OFFLINE_STATES.has(stateValue);
-var isEntityOffline = (stateObj) => isOfflineStateValue(getEntityStateValue(stateObj));
-var isEntityOn = (stateObj) => getEntityStateValue(stateObj) === STATE_DEFINITIONS.ON_STATE;
-var isEntityOff = (stateObj) => getEntityStateValue(stateObj) === STATE_DEFINITIONS.INACTIVE_STATES.off;
-var isEntityActive = (stateObj, entityId) => {
-  const stateValue = getEntityStateValue(stateObj);
-  if (stateValue === void 0 || stateValue === null) return false;
-  const domain = getEntityDomain(entityId);
-  const domainActive = STATE_DEFINITIONS.ACTIVE_STATES[domain];
-  if (domainActive?.has(stateValue)) return true;
-  if (STATE_DEFINITIONS.ACTIVE_STATES.default.has(stateValue)) return true;
-  if (domain === "cover") return stateValue !== STATE_DEFINITIONS.INACTIVE_STATES.closed;
-  if (domain === "climate") return stateValue !== STATE_DEFINITIONS.INACTIVE_STATES.off && !isOfflineStateValue(stateValue);
-  return false;
 };
 var isHeaderManualColorEnabled = (config) => !!trimStr(config?.color);
 var resolveLabelPosition = (btn, config) => {

--- a/src/lib/states.js
+++ b/src/lib/states.js
@@ -1,0 +1,53 @@
+const STATE_DEFINITIONS = Object.freeze({
+  OFFLINE_STATES: new Set(["unavailable", "unknown"]),
+  ACTIVE_STATES: {
+    default: new Set(["on", "open", "playing", "heat", "cool", "auto", "drying", "fan_only", "cleaning", "manual", "boost", "unlocked", "home"]),
+    climate: new Set(["heat", "cool", "auto", "drying", "fan_only"]),
+    media_player: new Set(["playing"])
+  },
+  INACTIVE_STATES: Object.freeze({
+    off: "off",
+    closed: "closed"
+  }),
+  ON_STATE: "on"
+});
+
+// Built-in state-dependent icon maps per domain — used when no static icon is configured
+const DOMAIN_STATE_ICON_MAPS = Object.freeze({
+  light: { on: "mdi:lightbulb", off: "mdi:lightbulb-outline" },
+  switch: { on: "mdi:toggle-switch", off: "mdi:toggle-switch-off-outline" },
+  input_boolean: { on: "mdi:toggle-switch", off: "mdi:toggle-switch-off-outline" },
+  fan: { on: "mdi:fan", off: "mdi:fan-off" },
+  lock: { locked: "mdi:lock", unlocked: "mdi:lock-open-outline" },
+  cover: {
+    open: "mdi:window-shutter-open", closed: "mdi:window-shutter",
+    opening: "mdi:window-shutter-open", closing: "mdi:window-shutter"
+  },
+  media_player: { playing: "mdi:cast-connected", paused: "mdi:cast-connected", idle: "mdi:cast", off: "mdi:cast-off" },
+});
+
+const getEntityDomain = (entityId) => (typeof entityId === "string" && entityId.includes(".") ? entityId.split(".")[0] : "");
+
+const getEntityStateValue = (stateObj) => stateObj?.state;
+
+const isOfflineStateValue = (stateValue) => STATE_DEFINITIONS.OFFLINE_STATES.has(stateValue);
+
+const isEntityOffline = (stateObj) => isOfflineStateValue(getEntityStateValue(stateObj));
+
+const isEntityOn = (stateObj) => getEntityStateValue(stateObj) === STATE_DEFINITIONS.ON_STATE;
+
+const isEntityOff = (stateObj) => getEntityStateValue(stateObj) === STATE_DEFINITIONS.INACTIVE_STATES.off;
+
+const isEntityActive = (stateObj, entityId) => {
+  const stateValue = getEntityStateValue(stateObj);
+  if (stateValue === undefined || stateValue === null) return false;
+  const domain = getEntityDomain(entityId);
+  const domainActive = STATE_DEFINITIONS.ACTIVE_STATES[domain];
+  if (domainActive?.has(stateValue)) return true;
+  if (STATE_DEFINITIONS.ACTIVE_STATES.default.has(stateValue)) return true;
+  if (domain === "cover") return stateValue !== STATE_DEFINITIONS.INACTIVE_STATES.closed;
+  if (domain === "climate") return stateValue !== STATE_DEFINITIONS.INACTIVE_STATES.off && !isOfflineStateValue(stateValue);
+  return false;
+};
+
+export { STATE_DEFINITIONS, DOMAIN_STATE_ICON_MAPS, getEntityDomain, getEntityStateValue, isOfflineStateValue, isEntityOffline, isEntityOn, isEntityOff, isEntityActive };

--- a/src/room-card.js
+++ b/src/room-card.js
@@ -6,6 +6,8 @@ import { normalizeTemperatureUnit, convertTemperatureValue, temperatureNumberLoc
 
 import { hexToRgba, readableTextForHex, parseColorToPickerHex } from "./lib/colors.js";
 
+import { STATE_DEFINITIONS, DOMAIN_STATE_ICON_MAPS, getEntityDomain, getEntityStateValue, isOfflineStateValue, isEntityOffline, isEntityOn, isEntityOff, isEntityActive } from "./lib/states.js";
+
 const VERSION = "1.4.0";
 const EDITOR_DOM_REVISION = "6";
 const LOG_FLAG = `customCards_RoomCard_Logged_${VERSION}`;
@@ -799,57 +801,6 @@ const getTranslation = (hass, key) => {
 
 
 
-const STATE_DEFINITIONS = Object.freeze({
-  OFFLINE_STATES: new Set(["unavailable", "unknown"]),
-  ACTIVE_STATES: {
-    default: new Set(["on", "open", "playing", "heat", "cool", "auto", "drying", "fan_only", "cleaning", "manual", "boost", "unlocked", "home"]),
-    climate: new Set(["heat", "cool", "auto", "drying", "fan_only"]),
-    media_player: new Set(["playing"])
-  },
-  INACTIVE_STATES: Object.freeze({
-    off: "off",
-    closed: "closed"
-  }),
-  ON_STATE: "on"
-});
-
-// Built-in state-dependent icon maps per domain — used when no static icon is configured
-const DOMAIN_STATE_ICON_MAPS = Object.freeze({
-  light: { on: "mdi:lightbulb", off: "mdi:lightbulb-outline" },
-  switch: { on: "mdi:toggle-switch", off: "mdi:toggle-switch-off-outline" },
-  input_boolean: { on: "mdi:toggle-switch", off: "mdi:toggle-switch-off-outline" },
-  fan: { on: "mdi:fan", off: "mdi:fan-off" },
-  lock: { locked: "mdi:lock", unlocked: "mdi:lock-open-outline" },
-  cover: {
-    open: "mdi:window-shutter-open", closed: "mdi:window-shutter",
-    opening: "mdi:window-shutter-open", closing: "mdi:window-shutter"
-  },
-  media_player: { playing: "mdi:cast-connected", paused: "mdi:cast-connected", idle: "mdi:cast", off: "mdi:cast-off" },
-});
-
-const getEntityDomain = (entityId) => (typeof entityId === "string" && entityId.includes(".") ? entityId.split(".")[0] : "");
-
-const getEntityStateValue = (stateObj) => stateObj?.state;
-
-const isOfflineStateValue = (stateValue) => STATE_DEFINITIONS.OFFLINE_STATES.has(stateValue);
-
-const isEntityOffline = (stateObj) => isOfflineStateValue(getEntityStateValue(stateObj));
-
-const isEntityOn = (stateObj) => getEntityStateValue(stateObj) === STATE_DEFINITIONS.ON_STATE;
-
-const isEntityOff = (stateObj) => getEntityStateValue(stateObj) === STATE_DEFINITIONS.INACTIVE_STATES.off;
-
-const isEntityActive = (stateObj, entityId) => {
-  const stateValue = getEntityStateValue(stateObj);
-  if (stateValue === undefined || stateValue === null) return false;
-  const domain = getEntityDomain(entityId);
-  const domainActive = STATE_DEFINITIONS.ACTIVE_STATES[domain];
-  if (domainActive?.has(stateValue)) return true;
-  if (STATE_DEFINITIONS.ACTIVE_STATES.default.has(stateValue)) return true;
-  if (domain === "cover") return stateValue !== STATE_DEFINITIONS.INACTIVE_STATES.closed;
-  if (domain === "climate") return stateValue !== STATE_DEFINITIONS.INACTIVE_STATES.off && !isOfflineStateValue(stateValue);
-  return false;
-};
 
 const isHeaderManualColorEnabled = (config) => !!trimStr(config?.color);
 

--- a/tests/state-helpers.test.mjs
+++ b/tests/state-helpers.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { STATE_DEFINITIONS, DOMAIN_STATE_ICON_MAPS, getEntityDomain, isEntityOffline,
+  isEntityOn, isEntityOff, isEntityActive } from "../src/lib/states.js";
+
+test("state definitions retain domain parsing, offline detection and icon mappings", () => {
+  assert.equal(getEntityDomain("light.room"), "light");
+  assert.equal(getEntityDomain(null), "");
+  assert.equal(getEntityDomain("light"), "");
+  assert.equal(isEntityOffline({ state: "unavailable" }), true);
+  assert.equal(isEntityOffline({ state: "unknown" }), true);
+  assert.equal(isEntityOffline(undefined), false);
+  assert.equal(isEntityOn({ state: "on" }), true);
+  assert.equal(isEntityOff({ state: "off" }), true);
+  assert.equal(Object.isFrozen(STATE_DEFINITIONS), true);
+  assert.equal(DOMAIN_STATE_ICON_MAPS.cover.opening, "mdi:window-shutter-open");
+});
+
+test("domain activation keeps legacy fallbacks rather than unifying semantics", () => {
+  assert.equal(isEntityActive(undefined, "light.room"), false);
+  assert.equal(isEntityActive({ state: "paused" }, "media_player.room"), false);
+  assert.equal(isEntityActive({ state: "playing" }, "media_player.room"), true);
+  assert.equal(isEntityActive({ state: "closed" }, "cover.room"), false);
+  assert.equal(isEntityActive({ state: "opening" }, "cover.room"), true);
+  // Preserve the historical domain fallback; availability is checked separately.
+  assert.equal(isEntityActive({ state: "unknown" }, "cover.room"), true);
+  assert.equal(isEntityActive({ state: "unknown" }, "climate.room"), false);
+  assert.equal(isEntityActive({ state: "idle" }, "climate.room"), true);
+});


### PR DESCRIPTION
Part of #100. Moves state definitions, domain icon mappings and state predicates unchanged into lib/states.js. Direct tests preserve existing activation/offline behavior, including intentionally different cover/climate fallback semantics. Full build/check pass (81 tests). No behavior cleanup, YAML changes, version bump or Drawer work. Separate squash rollback point.