### PR TITLE
refactor: isolate condition policies with explicit environment inputs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@
 - `src/lib/temperature.js` owns temperature conversion and locale/precision handling.
 - `src/lib/colors.js` owns color parsing, contrast and picker conversion.
 - `src/lib/states.js` owns shared state definitions, domain icons and state predicates.
+- `src/lib/conditions.js` keeps visibility, room-mode and adaptive-image policies separate; time and screen inputs are supplied by the runtime.
 - `dist/room-card.js` is the generated HACS artifact and must not be edited directly.
 - `dist/rooms/` contains the additional assets installed by HACS.
 - `tests/` contains automated regression tests.

--- a/dist/room-card.js
+++ b/dist/room-card.js
@@ -269,6 +269,186 @@ var isEntityActive = (stateObj, entityId) => {
   return false;
 };
 
+// src/lib/conditions.js
+var parseTimeOfDay = (value) => {
+  const match = typeof value === "string" ? value.trim().match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/) : null;
+  if (!match) return null;
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  const seconds = Number(match[3] || 0);
+  if (hours > 23 || minutes > 59 || seconds > 59) return null;
+  return hours * 3600 + minutes * 60 + seconds;
+};
+var evaluateAdaptiveImageCondition = (condition, hass, now, matchMedia) => {
+  if (!condition || typeof condition !== "object") return { valid: false, active: false };
+  const type = condition.condition;
+  if (type === "state") {
+    const entity = trimStr(condition.entity);
+    if (!entity) return { valid: false, active: false };
+    const stateObj = hass?.states?.[entity];
+    if (!stateObj || isEntityOffline(stateObj)) return { valid: false, active: false };
+    const current = String(stateObj.state ?? "");
+    if (condition.state_not !== void 0 && trimStr(String(condition.state_not)) !== "") {
+      const excluded = (Array.isArray(condition.state_not) ? condition.state_not : [condition.state_not]).map(String);
+      return { valid: true, active: !excluded.includes(current) };
+    }
+    const expected = (Array.isArray(condition.state) ? condition.state : [condition.state]).filter((value) => value !== void 0 && trimStr(String(value)) !== "").map(String);
+    return expected.length > 0 ? { valid: true, active: expected.includes(current) } : { valid: false, active: false };
+  }
+  if (type === "numeric_state") {
+    const entity = trimStr(condition.entity);
+    const resolveThreshold = (threshold) => {
+      const raw = trimStr(String(threshold ?? ""));
+      if (!raw) return null;
+      const direct = Number(raw);
+      if (Number.isFinite(direct)) return direct;
+      const entityValue = Number(hass?.states?.[raw]?.state);
+      return Number.isFinite(entityValue) ? entityValue : null;
+    };
+    const above = resolveThreshold(condition.above);
+    const below = resolveThreshold(condition.below);
+    const stateObj = entity ? hass?.states?.[entity] : null;
+    const value = Number(stateObj?.state);
+    if (!entity || above === null && below === null || !stateObj || isEntityOffline(stateObj) || !Number.isFinite(value)) return { valid: false, active: false };
+    return { valid: true, active: (above === null || value > above) && (below === null || value < below) };
+  }
+  if (type === "time") {
+    const after = condition.after === void 0 ? null : parseTimeOfDay(condition.after);
+    const before = condition.before === void 0 ? null : parseTimeOfDay(condition.before);
+    const weekdays = Array.isArray(condition.weekday) ? condition.weekday.map((day) => String(day).toLowerCase()) : [];
+    const weekdayNames = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
+    if (after === null && before === null && weekdays.length === 0) return { valid: false, active: false };
+    if (condition.after !== void 0 && after === null || condition.before !== void 0 && before === null) return { valid: false, active: false };
+    if (weekdays.some((day) => !weekdayNames.includes(day))) return { valid: false, active: false };
+    const current = now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds();
+    const timeActive = after !== null && before !== null && after > before ? current > after || current < before : (after === null || current > after) && (before === null || current < before);
+    return { valid: true, active: timeActive && (weekdays.length === 0 || weekdays.includes(weekdayNames[now.getDay()])) };
+  }
+  if (type === "screen") {
+    const query = trimStr(condition.media_query);
+    if (!query || typeof matchMedia !== "function") return { valid: false, active: false };
+    try {
+      return { valid: true, active: matchMedia(query).matches };
+    } catch (_error) {
+      return { valid: false, active: false };
+    }
+  }
+  if (type === "user") {
+    if (!Array.isArray(condition.users) || condition.users.length === 0 || !hass?.user?.id) return { valid: false, active: false };
+    return { valid: true, active: condition.users.includes(hass.user.id) };
+  }
+  if (["and", "or", "not"].includes(type)) {
+    if (!Array.isArray(condition.conditions) || condition.conditions.length === 0) return { valid: false, active: false };
+    const nested = condition.conditions.map((item) => evaluateAdaptiveImageCondition(item, hass, now, matchMedia));
+    if (nested.some((result) => !result.valid)) return { valid: false, active: false };
+    if (type === "and") return { valid: true, active: nested.every((result) => result.active) };
+    if (type === "or") return { valid: true, active: nested.some((result) => result.active) };
+    return { valid: true, active: nested.every((result) => !result.active) };
+  }
+  return { valid: false, active: false };
+};
+var evaluateAdaptiveImageConditions = (conditions, hass, now, matchMedia) => {
+  if (!Array.isArray(conditions) || conditions.length === 0) return { valid: false, active: false };
+  const results = conditions.map((condition) => evaluateAdaptiveImageCondition(condition, hass, now, matchMedia));
+  return { valid: results.every((result) => result.valid), active: results.every((result) => result.valid && result.active) };
+};
+var getConditionEntityDependencies = (conditions) => {
+  const ids = /* @__PURE__ */ new Set();
+  const visit = (condition) => {
+    if (!condition || typeof condition !== "object") return;
+    if (typeof condition.entity === "string" && condition.entity.trim()) ids.add(condition.entity.trim());
+    [condition.above, condition.below].forEach((value) => {
+      if (typeof value === "string" && /^[a-z0-9_]+\.[a-z0-9_]+$/i.test(value.trim())) ids.add(value.trim());
+    });
+    if (Array.isArray(condition.conditions)) condition.conditions.forEach(visit);
+  };
+  (Array.isArray(conditions) ? conditions : [conditions]).forEach(visit);
+  return Array.from(ids);
+};
+var evaluateRoomModeCondition = (condition, hass) => {
+  if (!condition || typeof condition !== "object") return { valid: false, active: false };
+  const type = condition.condition;
+  if (type === "state") {
+    const entity = trimStr(condition.entity);
+    const expected = (Array.isArray(condition.state) ? condition.state : [condition.state]).filter((value) => value !== void 0 && trimStr(String(value)) !== "").map(String);
+    if (!entity || expected.length === 0) return { valid: false, active: false };
+    const stateObj = hass?.states?.[entity];
+    if (!stateObj || isEntityOffline(stateObj)) return { valid: false, active: false };
+    return { valid: true, active: expected.includes(String(stateObj.state ?? "")) };
+  }
+  if (type === "numeric_state") {
+    const entity = trimStr(condition.entity);
+    const hasAbove = condition.above !== void 0 && trimStr(String(condition.above)) !== "" && Number.isFinite(Number(condition.above));
+    const hasBelow = condition.below !== void 0 && trimStr(String(condition.below)) !== "" && Number.isFinite(Number(condition.below));
+    if (!entity || !hasAbove && !hasBelow) return { valid: false, active: false };
+    const stateObj = hass?.states?.[entity];
+    if (!stateObj || isEntityOffline(stateObj)) return { valid: false, active: false };
+    const value = Number(stateObj.state);
+    if (!Number.isFinite(value)) return { valid: false, active: false };
+    return {
+      valid: true,
+      active: (!hasAbove || value > Number(condition.above)) && (!hasBelow || value < Number(condition.below))
+    };
+  }
+  if (["and", "or", "not"].includes(type)) {
+    if (!Array.isArray(condition.conditions) || condition.conditions.length === 0) return { valid: false, active: false };
+    const nested = condition.conditions.map((item) => evaluateRoomModeCondition(item, hass));
+    if (nested.some((result) => !result.valid)) return { valid: false, active: false };
+    if (type === "and") return { valid: true, active: nested.every((result) => result.active) };
+    if (type === "or") return { valid: true, active: nested.some((result) => result.active) };
+    return { valid: true, active: nested.every((result) => !result.active) };
+  }
+  return { valid: false, active: false };
+};
+var evaluateRoomModeActiveWhen = (activeWhen, hass) => {
+  const conditions = Array.isArray(activeWhen) ? activeWhen : activeWhen ? [activeWhen] : [];
+  if (conditions.length === 0) return { valid: false, active: false };
+  const results = conditions.map((condition) => evaluateRoomModeCondition(condition, hass));
+  return {
+    valid: results.every((result) => result.valid),
+    active: results.every((result) => result.valid && result.active)
+  };
+};
+var evaluateVisibilityCondition = (c, h, matchMedia, checkCondition = (condition) => evaluateVisibilityCondition(condition, h, matchMedia)) => {
+  if (!c || !c.condition) return true;
+  const type = c.condition;
+  if (type === "state") {
+    if (!c.entity) return true;
+    const st = h.states[c.entity]?.state;
+    if (c.state_not !== void 0) return st !== c.state_not;
+    return st === c.state;
+  }
+  if (type === "numeric_state") {
+    if (!c.entity) return true;
+    const val = parseFloat(h.states[c.entity]?.state);
+    if (isNaN(val)) return false;
+    if (c.above !== void 0 && val <= parseFloat(c.above)) return false;
+    if (c.below !== void 0 && val >= parseFloat(c.below)) return false;
+    return true;
+  }
+  if (type === "screen") {
+    if (!c.media_query) return true;
+    return matchMedia(c.media_query).matches;
+  }
+  if (type === "user") {
+    if (!Array.isArray(c.users) || !h.user) return true;
+    return c.users.includes(h.user.id);
+  }
+  if (type === "and") {
+    if (!Array.isArray(c.conditions)) return true;
+    return c.conditions.every((cond) => checkCondition(cond));
+  }
+  if (type === "or") {
+    if (!Array.isArray(c.conditions)) return true;
+    return c.conditions.some((cond) => checkCondition(cond));
+  }
+  if (type === "not") {
+    if (!Array.isArray(c.conditions)) return true;
+    return c.conditions.every((cond) => !checkCondition(cond));
+  }
+  return true;
+};
+
 // src/room-card.js
 var VERSION = "1.4.0";
 var EDITOR_DOM_REVISION = "6";
@@ -336,88 +516,7 @@ var resolveRoomImageUrl = (config) => {
   if (customImage) return customImage;
   return getRoomImagePresetUrl(config?.image_preset);
 };
-var parseTimeOfDay = (value) => {
-  const match = typeof value === "string" ? value.trim().match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/) : null;
-  if (!match) return null;
-  const hours = Number(match[1]);
-  const minutes = Number(match[2]);
-  const seconds = Number(match[3] || 0);
-  if (hours > 23 || minutes > 59 || seconds > 59) return null;
-  return hours * 3600 + minutes * 60 + seconds;
-};
-var evaluateAdaptiveImageCondition = (condition, hass, now = /* @__PURE__ */ new Date()) => {
-  if (!condition || typeof condition !== "object") return { valid: false, active: false };
-  const type = condition.condition;
-  if (type === "state") {
-    const entity = trimStr(condition.entity);
-    if (!entity) return { valid: false, active: false };
-    const stateObj = hass?.states?.[entity];
-    if (!stateObj || isEntityOffline(stateObj)) return { valid: false, active: false };
-    const current = String(stateObj.state ?? "");
-    if (condition.state_not !== void 0 && trimStr(String(condition.state_not)) !== "") {
-      const excluded = (Array.isArray(condition.state_not) ? condition.state_not : [condition.state_not]).map(String);
-      return { valid: true, active: !excluded.includes(current) };
-    }
-    const expected = (Array.isArray(condition.state) ? condition.state : [condition.state]).filter((value) => value !== void 0 && trimStr(String(value)) !== "").map(String);
-    return expected.length > 0 ? { valid: true, active: expected.includes(current) } : { valid: false, active: false };
-  }
-  if (type === "numeric_state") {
-    const entity = trimStr(condition.entity);
-    const resolveThreshold = (threshold) => {
-      const raw = trimStr(String(threshold ?? ""));
-      if (!raw) return null;
-      const direct = Number(raw);
-      if (Number.isFinite(direct)) return direct;
-      const entityValue = Number(hass?.states?.[raw]?.state);
-      return Number.isFinite(entityValue) ? entityValue : null;
-    };
-    const above = resolveThreshold(condition.above);
-    const below = resolveThreshold(condition.below);
-    const stateObj = entity ? hass?.states?.[entity] : null;
-    const value = Number(stateObj?.state);
-    if (!entity || above === null && below === null || !stateObj || isEntityOffline(stateObj) || !Number.isFinite(value)) return { valid: false, active: false };
-    return { valid: true, active: (above === null || value > above) && (below === null || value < below) };
-  }
-  if (type === "time") {
-    const after = condition.after === void 0 ? null : parseTimeOfDay(condition.after);
-    const before = condition.before === void 0 ? null : parseTimeOfDay(condition.before);
-    const weekdays = Array.isArray(condition.weekday) ? condition.weekday.map((day) => String(day).toLowerCase()) : [];
-    const weekdayNames = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
-    if (after === null && before === null && weekdays.length === 0) return { valid: false, active: false };
-    if (condition.after !== void 0 && after === null || condition.before !== void 0 && before === null) return { valid: false, active: false };
-    if (weekdays.some((day) => !weekdayNames.includes(day))) return { valid: false, active: false };
-    const current = now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds();
-    const timeActive = after !== null && before !== null && after > before ? current > after || current < before : (after === null || current > after) && (before === null || current < before);
-    return { valid: true, active: timeActive && (weekdays.length === 0 || weekdays.includes(weekdayNames[now.getDay()])) };
-  }
-  if (type === "screen") {
-    const query = trimStr(condition.media_query);
-    if (!query || typeof window.matchMedia !== "function") return { valid: false, active: false };
-    try {
-      return { valid: true, active: window.matchMedia(query).matches };
-    } catch (_error) {
-      return { valid: false, active: false };
-    }
-  }
-  if (type === "user") {
-    if (!Array.isArray(condition.users) || condition.users.length === 0 || !hass?.user?.id) return { valid: false, active: false };
-    return { valid: true, active: condition.users.includes(hass.user.id) };
-  }
-  if (["and", "or", "not"].includes(type)) {
-    if (!Array.isArray(condition.conditions) || condition.conditions.length === 0) return { valid: false, active: false };
-    const nested = condition.conditions.map((item) => evaluateAdaptiveImageCondition(item, hass, now));
-    if (nested.some((result) => !result.valid)) return { valid: false, active: false };
-    if (type === "and") return { valid: true, active: nested.every((result) => result.active) };
-    if (type === "or") return { valid: true, active: nested.some((result) => result.active) };
-    return { valid: true, active: nested.every((result) => !result.active) };
-  }
-  return { valid: false, active: false };
-};
-var evaluateAdaptiveImageConditions = (conditions, hass, now = /* @__PURE__ */ new Date()) => {
-  if (!Array.isArray(conditions) || conditions.length === 0) return { valid: false, active: false };
-  const results = conditions.map((condition) => evaluateAdaptiveImageCondition(condition, hass, now));
-  return { valid: results.every((result) => result.valid), active: results.every((result) => result.valid && result.active) };
-};
+var evaluateAdaptiveImageConditions2 = (conditions, hass, now = /* @__PURE__ */ new Date()) => evaluateAdaptiveImageConditions(conditions, hass, now, typeof window.matchMedia === "function" ? window.matchMedia.bind(window) : void 0);
 var resolveAdaptiveRoomImage = (config, hass, now = /* @__PURE__ */ new Date()) => {
   const fallback = {
     url: resolveRoomImageUrl(config),
@@ -428,7 +527,7 @@ var resolveAdaptiveRoomImage = (config, hass, now = /* @__PURE__ */ new Date()) 
   for (let index = 0; index < rules.length; index += 1) {
     const rule = rules[index];
     if (!rule || typeof rule !== "object") continue;
-    const condition = evaluateAdaptiveImageConditions(rule.conditions, hass, now);
+    const condition = evaluateAdaptiveImageConditions2(rule.conditions, hass, now);
     if (!condition.valid || !condition.active) continue;
     const url = resolveRoomImageUrl(rule);
     if (!url) continue;
@@ -445,7 +544,7 @@ var getStatusGroupResult = (group, hass) => {
   const empty = { visible: false, value: "", numericValue: 0, contributors: [], error: "" };
   if (!group || typeof group !== "object") return empty;
   if (Array.isArray(group.conditions) && group.conditions.length > 0) {
-    const gate = evaluateAdaptiveImageConditions(group.conditions, hass);
+    const gate = evaluateAdaptiveImageConditions2(group.conditions, hass);
     if (!gate.valid || !gate.active) return empty;
   }
   const entries = (Array.isArray(group.entities) ? group.entities : []).map((item) => typeof item === "string" ? { entity: item } : item).filter((item) => item && typeof item.entity === "string" && item.entity.trim());
@@ -456,7 +555,7 @@ var getStatusGroupResult = (group, hass) => {
     const stateObj = hass?.states?.[entityId];
     if (!stateObj || isEntityOffline(stateObj)) return;
     if (Array.isArray(entry.conditions) && entry.conditions.length > 0) {
-      const condition = evaluateAdaptiveImageConditions(entry.conditions, hass);
+      const condition = evaluateAdaptiveImageConditions2(entry.conditions, hass);
       if (!condition.valid || !condition.active) return;
     }
     const configuredStates = Array.isArray(entry.active_states) ? entry.active_states : Array.isArray(group.active_states) ? group.active_states : numericMode ? [] : ["on"];
@@ -1857,63 +1956,6 @@ var getTemplateEntityDependencies = (ctrl) => {
 var templateNeedsEveryHassUpdate = (ctrl) => {
   const source = TEMPLATE_VALUE_KEYS.map((key) => String(ctrl?.[key] ?? "")).join("\n");
   return source.includes("${") && getTemplateEntityDependencies(ctrl).length === 0;
-};
-var getConditionEntityDependencies = (conditions) => {
-  const ids = /* @__PURE__ */ new Set();
-  const visit = (condition) => {
-    if (!condition || typeof condition !== "object") return;
-    if (typeof condition.entity === "string" && condition.entity.trim()) ids.add(condition.entity.trim());
-    [condition.above, condition.below].forEach((value) => {
-      if (typeof value === "string" && /^[a-z0-9_]+\.[a-z0-9_]+$/i.test(value.trim())) ids.add(value.trim());
-    });
-    if (Array.isArray(condition.conditions)) condition.conditions.forEach(visit);
-  };
-  (Array.isArray(conditions) ? conditions : [conditions]).forEach(visit);
-  return Array.from(ids);
-};
-var evaluateRoomModeCondition = (condition, hass) => {
-  if (!condition || typeof condition !== "object") return { valid: false, active: false };
-  const type = condition.condition;
-  if (type === "state") {
-    const entity = trimStr(condition.entity);
-    const expected = (Array.isArray(condition.state) ? condition.state : [condition.state]).filter((value) => value !== void 0 && trimStr(String(value)) !== "").map(String);
-    if (!entity || expected.length === 0) return { valid: false, active: false };
-    const stateObj = hass?.states?.[entity];
-    if (!stateObj || isEntityOffline(stateObj)) return { valid: false, active: false };
-    return { valid: true, active: expected.includes(String(stateObj.state ?? "")) };
-  }
-  if (type === "numeric_state") {
-    const entity = trimStr(condition.entity);
-    const hasAbove = condition.above !== void 0 && trimStr(String(condition.above)) !== "" && Number.isFinite(Number(condition.above));
-    const hasBelow = condition.below !== void 0 && trimStr(String(condition.below)) !== "" && Number.isFinite(Number(condition.below));
-    if (!entity || !hasAbove && !hasBelow) return { valid: false, active: false };
-    const stateObj = hass?.states?.[entity];
-    if (!stateObj || isEntityOffline(stateObj)) return { valid: false, active: false };
-    const value = Number(stateObj.state);
-    if (!Number.isFinite(value)) return { valid: false, active: false };
-    return {
-      valid: true,
-      active: (!hasAbove || value > Number(condition.above)) && (!hasBelow || value < Number(condition.below))
-    };
-  }
-  if (["and", "or", "not"].includes(type)) {
-    if (!Array.isArray(condition.conditions) || condition.conditions.length === 0) return { valid: false, active: false };
-    const nested = condition.conditions.map((item) => evaluateRoomModeCondition(item, hass));
-    if (nested.some((result) => !result.valid)) return { valid: false, active: false };
-    if (type === "and") return { valid: true, active: nested.every((result) => result.active) };
-    if (type === "or") return { valid: true, active: nested.some((result) => result.active) };
-    return { valid: true, active: nested.every((result) => !result.active) };
-  }
-  return { valid: false, active: false };
-};
-var evaluateRoomModeActiveWhen = (activeWhen, hass) => {
-  const conditions = Array.isArray(activeWhen) ? activeWhen : activeWhen ? [activeWhen] : [];
-  if (conditions.length === 0) return { valid: false, active: false };
-  const results = conditions.map((condition) => evaluateRoomModeCondition(condition, hass));
-  return {
-    valid: results.every((result) => result.valid),
-    active: results.every((result) => result.valid && result.active)
-  };
 };
 var SHARED_SPARKLINE_CACHE = /* @__PURE__ */ new Map();
 var SHARED_SPARKLINE_PENDING = /* @__PURE__ */ new Map();
@@ -3537,43 +3579,7 @@ var OneLineRoomCard = class extends HTMLElement {
     return conditions.every((c) => this._checkCondition(c, h));
   }
   _checkCondition(c, h) {
-    if (!c || !c.condition) return true;
-    const type = c.condition;
-    if (type === "state") {
-      if (!c.entity) return true;
-      const st = h.states[c.entity]?.state;
-      if (c.state_not !== void 0) return st !== c.state_not;
-      return st === c.state;
-    }
-    if (type === "numeric_state") {
-      if (!c.entity) return true;
-      const val = parseFloat(h.states[c.entity]?.state);
-      if (isNaN(val)) return false;
-      if (c.above !== void 0 && val <= parseFloat(c.above)) return false;
-      if (c.below !== void 0 && val >= parseFloat(c.below)) return false;
-      return true;
-    }
-    if (type === "screen") {
-      if (!c.media_query) return true;
-      return window.matchMedia(c.media_query).matches;
-    }
-    if (type === "user") {
-      if (!Array.isArray(c.users) || !h.user) return true;
-      return c.users.includes(h.user.id);
-    }
-    if (type === "and") {
-      if (!Array.isArray(c.conditions)) return true;
-      return c.conditions.every((cond) => this._checkCondition(cond, h));
-    }
-    if (type === "or") {
-      if (!Array.isArray(c.conditions)) return true;
-      return c.conditions.some((cond) => this._checkCondition(cond, h));
-    }
-    if (type === "not") {
-      if (!Array.isArray(c.conditions)) return true;
-      return c.conditions.every((cond) => !this._checkCondition(cond, h));
-    }
-    return true;
+    return evaluateVisibilityCondition(c, h, (query) => window.matchMedia(query), (condition) => this._checkCondition(condition, h));
   }
   _getSliderCapabilities(domain, st, ctrl) {
     let supported = false, min = 0, max = 100, step = 1, value = 0, pct = 0, action = null;
@@ -10039,7 +10045,7 @@ export {
   clampNum,
   convertTemperatureValue,
   evalTemplateString,
-  evaluateAdaptiveImageConditions,
+  evaluateAdaptiveImageConditions2 as evaluateAdaptiveImageConditions,
   evaluateRoomModeActiveWhen,
   formatConvertedTemperature,
   formatEntityStateForDisplay,

--- a/src/lib/conditions.js
+++ b/src/lib/conditions.js
@@ -1,0 +1,202 @@
+import { trimStr } from "./values.js";
+import { isEntityOffline } from "./states.js";
+
+// Keep the three legacy policies separate: permissive visibility versus
+// strict room-mode/adaptive validity, with distinct numeric threshold rules.
+const parseTimeOfDay = (value) => {
+  const match = typeof value === "string" ? value.trim().match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/) : null;
+  if (!match) return null;
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  const seconds = Number(match[3] || 0);
+  if (hours > 23 || minutes > 59 || seconds > 59) return null;
+  return (hours * 3600) + (minutes * 60) + seconds;
+};
+
+const evaluateAdaptiveImageCondition = (condition, hass, now, matchMedia) => {
+  if (!condition || typeof condition !== "object") return { valid: false, active: false };
+  const type = condition.condition;
+  if (type === "state") {
+    const entity = trimStr(condition.entity);
+    if (!entity) return { valid: false, active: false };
+    const stateObj = hass?.states?.[entity];
+    if (!stateObj || isEntityOffline(stateObj)) return { valid: false, active: false };
+    const current = String(stateObj.state ?? "");
+    if (condition.state_not !== undefined && trimStr(String(condition.state_not)) !== "") {
+      const excluded = (Array.isArray(condition.state_not) ? condition.state_not : [condition.state_not]).map(String);
+      return { valid: true, active: !excluded.includes(current) };
+    }
+    const expected = (Array.isArray(condition.state) ? condition.state : [condition.state])
+      .filter((value) => value !== undefined && trimStr(String(value)) !== "")
+      .map(String);
+    return expected.length > 0 ? { valid: true, active: expected.includes(current) } : { valid: false, active: false };
+  }
+  if (type === "numeric_state") {
+    const entity = trimStr(condition.entity);
+    const resolveThreshold = (threshold) => {
+      const raw = trimStr(String(threshold ?? ""));
+      if (!raw) return null;
+      const direct = Number(raw);
+      if (Number.isFinite(direct)) return direct;
+      const entityValue = Number(hass?.states?.[raw]?.state);
+      return Number.isFinite(entityValue) ? entityValue : null;
+    };
+    const above = resolveThreshold(condition.above);
+    const below = resolveThreshold(condition.below);
+    const stateObj = entity ? hass?.states?.[entity] : null;
+    const value = Number(stateObj?.state);
+    if (!entity || (above === null && below === null) || !stateObj || isEntityOffline(stateObj) || !Number.isFinite(value)) return { valid: false, active: false };
+    return { valid: true, active: (above === null || value > above) && (below === null || value < below) };
+  }
+  if (type === "time") {
+    const after = condition.after === undefined ? null : parseTimeOfDay(condition.after);
+    const before = condition.before === undefined ? null : parseTimeOfDay(condition.before);
+    const weekdays = Array.isArray(condition.weekday) ? condition.weekday.map((day) => String(day).toLowerCase()) : [];
+    const weekdayNames = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
+    if (after === null && before === null && weekdays.length === 0) return { valid: false, active: false };
+    if ((condition.after !== undefined && after === null) || (condition.before !== undefined && before === null)) return { valid: false, active: false };
+    if (weekdays.some((day) => !weekdayNames.includes(day))) return { valid: false, active: false };
+    const current = (now.getHours() * 3600) + (now.getMinutes() * 60) + now.getSeconds();
+    const timeActive = after !== null && before !== null && after > before
+      ? current > after || current < before
+      : (after === null || current > after) && (before === null || current < before);
+    return { valid: true, active: timeActive && (weekdays.length === 0 || weekdays.includes(weekdayNames[now.getDay()])) };
+  }
+  if (type === "screen") {
+    const query = trimStr(condition.media_query);
+    if (!query || typeof matchMedia !== "function") return { valid: false, active: false };
+    try { return { valid: true, active: matchMedia(query).matches }; }
+    catch (_error) { return { valid: false, active: false }; }
+  }
+  if (type === "user") {
+    if (!Array.isArray(condition.users) || condition.users.length === 0 || !hass?.user?.id) return { valid: false, active: false };
+    return { valid: true, active: condition.users.includes(hass.user.id) };
+  }
+  if (["and", "or", "not"].includes(type)) {
+    if (!Array.isArray(condition.conditions) || condition.conditions.length === 0) return { valid: false, active: false };
+    const nested = condition.conditions.map((item) => evaluateAdaptiveImageCondition(item, hass, now, matchMedia));
+    if (nested.some((result) => !result.valid)) return { valid: false, active: false };
+    if (type === "and") return { valid: true, active: nested.every((result) => result.active) };
+    if (type === "or") return { valid: true, active: nested.some((result) => result.active) };
+    return { valid: true, active: nested.every((result) => !result.active) };
+  }
+  return { valid: false, active: false };
+};
+
+const evaluateAdaptiveImageConditions = (conditions, hass, now, matchMedia) => {
+  if (!Array.isArray(conditions) || conditions.length === 0) return { valid: false, active: false };
+  const results = conditions.map((condition) => evaluateAdaptiveImageCondition(condition, hass, now, matchMedia));
+  return { valid: results.every((result) => result.valid), active: results.every((result) => result.valid && result.active) };
+};
+
+const getConditionEntityDependencies = (conditions) => {
+  const ids = new Set();
+  const visit = (condition) => {
+    if (!condition || typeof condition !== "object") return;
+    if (typeof condition.entity === "string" && condition.entity.trim()) ids.add(condition.entity.trim());
+    [condition.above, condition.below].forEach((value) => {
+      if (typeof value === "string" && /^[a-z0-9_]+\.[a-z0-9_]+$/i.test(value.trim())) ids.add(value.trim());
+    });
+    if (Array.isArray(condition.conditions)) condition.conditions.forEach(visit);
+  };
+  (Array.isArray(conditions) ? conditions : [conditions]).forEach(visit);
+  return Array.from(ids);
+};
+
+const evaluateRoomModeCondition = (condition, hass) => {
+  if (!condition || typeof condition !== "object") return { valid: false, active: false };
+  const type = condition.condition;
+  if (type === "state") {
+    const entity = trimStr(condition.entity);
+    const expected = (Array.isArray(condition.state) ? condition.state : [condition.state])
+      .filter((value) => value !== undefined && trimStr(String(value)) !== "")
+      .map(String);
+    if (!entity || expected.length === 0) return { valid: false, active: false };
+    const stateObj = hass?.states?.[entity];
+    if (!stateObj || isEntityOffline(stateObj)) return { valid: false, active: false };
+    return { valid: true, active: expected.includes(String(stateObj.state ?? "")) };
+  }
+  if (type === "numeric_state") {
+    const entity = trimStr(condition.entity);
+    const hasAbove = condition.above !== undefined && trimStr(String(condition.above)) !== "" && Number.isFinite(Number(condition.above));
+    const hasBelow = condition.below !== undefined && trimStr(String(condition.below)) !== "" && Number.isFinite(Number(condition.below));
+    if (!entity || (!hasAbove && !hasBelow)) return { valid: false, active: false };
+    const stateObj = hass?.states?.[entity];
+    if (!stateObj || isEntityOffline(stateObj)) return { valid: false, active: false };
+    const value = Number(stateObj.state);
+    if (!Number.isFinite(value)) return { valid: false, active: false };
+    return {
+      valid: true,
+      active: (!hasAbove || value > Number(condition.above)) && (!hasBelow || value < Number(condition.below))
+    };
+  }
+  if (["and", "or", "not"].includes(type)) {
+    if (!Array.isArray(condition.conditions) || condition.conditions.length === 0) return { valid: false, active: false };
+    const nested = condition.conditions.map((item) => evaluateRoomModeCondition(item, hass));
+    if (nested.some((result) => !result.valid)) return { valid: false, active: false };
+    if (type === "and") return { valid: true, active: nested.every((result) => result.active) };
+    if (type === "or") return { valid: true, active: nested.some((result) => result.active) };
+    return { valid: true, active: nested.every((result) => !result.active) };
+  }
+  return { valid: false, active: false };
+};
+
+const evaluateRoomModeActiveWhen = (activeWhen, hass) => {
+  const conditions = Array.isArray(activeWhen) ? activeWhen : (activeWhen ? [activeWhen] : []);
+  if (conditions.length === 0) return { valid: false, active: false };
+  const results = conditions.map((condition) => evaluateRoomModeCondition(condition, hass));
+  return {
+    valid: results.every((result) => result.valid),
+    active: results.every((result) => result.valid && result.active)
+  };
+};
+
+const evaluateVisibilityCondition = (c, h, matchMedia, checkCondition = (condition) => evaluateVisibilityCondition(condition, h, matchMedia)) => {
+  if (!c || !c.condition) return true;
+  const type = c.condition;
+
+  if (type === "state") {
+    if (!c.entity) return true; // Incomplete condition — treat as always visible
+    const st = h.states[c.entity]?.state;
+    if (c.state_not !== undefined) return st !== c.state_not;
+    return st === c.state;
+  }
+
+  if (type === "numeric_state") {
+    if (!c.entity) return true; // Incomplete condition
+    const val = parseFloat(h.states[c.entity]?.state);
+    if (isNaN(val)) return false;
+    if (c.above !== undefined && val <= parseFloat(c.above)) return false;
+    if (c.below !== undefined && val >= parseFloat(c.below)) return false;
+    return true;
+  }
+
+  if (type === "screen") {
+    if (!c.media_query) return true;
+    return matchMedia(c.media_query).matches;
+  }
+
+  if (type === "user") {
+    if (!Array.isArray(c.users) || !h.user) return true;
+    return c.users.includes(h.user.id);
+  }
+
+  if (type === "and") {
+    if (!Array.isArray(c.conditions)) return true;
+    return c.conditions.every(cond => checkCondition(cond));
+  }
+
+  if (type === "or") {
+    if (!Array.isArray(c.conditions)) return true;
+    return c.conditions.some(cond => checkCondition(cond));
+  }
+
+  if (type === "not") {
+    if (!Array.isArray(c.conditions)) return true;
+    return c.conditions.every(cond => !checkCondition(cond));
+  }
+
+  return true;
+};
+
+export { parseTimeOfDay, evaluateAdaptiveImageConditions, getConditionEntityDependencies, evaluateRoomModeActiveWhen, evaluateVisibilityCondition };

--- a/src/room-card.js
+++ b/src/room-card.js
@@ -8,6 +8,8 @@ import { hexToRgba, readableTextForHex, parseColorToPickerHex } from "./lib/colo
 
 import { STATE_DEFINITIONS, DOMAIN_STATE_ICON_MAPS, getEntityDomain, getEntityStateValue, isOfflineStateValue, isEntityOffline, isEntityOn, isEntityOff, isEntityActive } from "./lib/states.js";
 
+import { evaluateAdaptiveImageConditions as evaluateAdaptiveConditions, getConditionEntityDependencies, evaluateRoomModeActiveWhen, evaluateVisibilityCondition } from "./lib/conditions.js";
+
 const VERSION = "1.4.0";
 const EDITOR_DOM_REVISION = "6";
 const LOG_FLAG = `customCards_RoomCard_Logged_${VERSION}`;
@@ -84,91 +86,8 @@ const resolveRoomImageUrl = (config) => {
   return getRoomImagePresetUrl(config?.image_preset);
 };
 
-const parseTimeOfDay = (value) => {
-  const match = typeof value === "string" ? value.trim().match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/) : null;
-  if (!match) return null;
-  const hours = Number(match[1]);
-  const minutes = Number(match[2]);
-  const seconds = Number(match[3] || 0);
-  if (hours > 23 || minutes > 59 || seconds > 59) return null;
-  return (hours * 3600) + (minutes * 60) + seconds;
-};
-
-const evaluateAdaptiveImageCondition = (condition, hass, now = new Date()) => {
-  if (!condition || typeof condition !== "object") return { valid: false, active: false };
-  const type = condition.condition;
-  if (type === "state") {
-    const entity = trimStr(condition.entity);
-    if (!entity) return { valid: false, active: false };
-    const stateObj = hass?.states?.[entity];
-    if (!stateObj || isEntityOffline(stateObj)) return { valid: false, active: false };
-    const current = String(stateObj.state ?? "");
-    if (condition.state_not !== undefined && trimStr(String(condition.state_not)) !== "") {
-      const excluded = (Array.isArray(condition.state_not) ? condition.state_not : [condition.state_not]).map(String);
-      return { valid: true, active: !excluded.includes(current) };
-    }
-    const expected = (Array.isArray(condition.state) ? condition.state : [condition.state])
-      .filter((value) => value !== undefined && trimStr(String(value)) !== "")
-      .map(String);
-    return expected.length > 0 ? { valid: true, active: expected.includes(current) } : { valid: false, active: false };
-  }
-  if (type === "numeric_state") {
-    const entity = trimStr(condition.entity);
-    const resolveThreshold = (threshold) => {
-      const raw = trimStr(String(threshold ?? ""));
-      if (!raw) return null;
-      const direct = Number(raw);
-      if (Number.isFinite(direct)) return direct;
-      const entityValue = Number(hass?.states?.[raw]?.state);
-      return Number.isFinite(entityValue) ? entityValue : null;
-    };
-    const above = resolveThreshold(condition.above);
-    const below = resolveThreshold(condition.below);
-    const stateObj = entity ? hass?.states?.[entity] : null;
-    const value = Number(stateObj?.state);
-    if (!entity || (above === null && below === null) || !stateObj || isEntityOffline(stateObj) || !Number.isFinite(value)) return { valid: false, active: false };
-    return { valid: true, active: (above === null || value > above) && (below === null || value < below) };
-  }
-  if (type === "time") {
-    const after = condition.after === undefined ? null : parseTimeOfDay(condition.after);
-    const before = condition.before === undefined ? null : parseTimeOfDay(condition.before);
-    const weekdays = Array.isArray(condition.weekday) ? condition.weekday.map((day) => String(day).toLowerCase()) : [];
-    const weekdayNames = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
-    if (after === null && before === null && weekdays.length === 0) return { valid: false, active: false };
-    if ((condition.after !== undefined && after === null) || (condition.before !== undefined && before === null)) return { valid: false, active: false };
-    if (weekdays.some((day) => !weekdayNames.includes(day))) return { valid: false, active: false };
-    const current = (now.getHours() * 3600) + (now.getMinutes() * 60) + now.getSeconds();
-    const timeActive = after !== null && before !== null && after > before
-      ? current > after || current < before
-      : (after === null || current > after) && (before === null || current < before);
-    return { valid: true, active: timeActive && (weekdays.length === 0 || weekdays.includes(weekdayNames[now.getDay()])) };
-  }
-  if (type === "screen") {
-    const query = trimStr(condition.media_query);
-    if (!query || typeof window.matchMedia !== "function") return { valid: false, active: false };
-    try { return { valid: true, active: window.matchMedia(query).matches }; }
-    catch (_error) { return { valid: false, active: false }; }
-  }
-  if (type === "user") {
-    if (!Array.isArray(condition.users) || condition.users.length === 0 || !hass?.user?.id) return { valid: false, active: false };
-    return { valid: true, active: condition.users.includes(hass.user.id) };
-  }
-  if (["and", "or", "not"].includes(type)) {
-    if (!Array.isArray(condition.conditions) || condition.conditions.length === 0) return { valid: false, active: false };
-    const nested = condition.conditions.map((item) => evaluateAdaptiveImageCondition(item, hass, now));
-    if (nested.some((result) => !result.valid)) return { valid: false, active: false };
-    if (type === "and") return { valid: true, active: nested.every((result) => result.active) };
-    if (type === "or") return { valid: true, active: nested.some((result) => result.active) };
-    return { valid: true, active: nested.every((result) => !result.active) };
-  }
-  return { valid: false, active: false };
-};
-
-const evaluateAdaptiveImageConditions = (conditions, hass, now = new Date()) => {
-  if (!Array.isArray(conditions) || conditions.length === 0) return { valid: false, active: false };
-  const results = conditions.map((condition) => evaluateAdaptiveImageCondition(condition, hass, now));
-  return { valid: results.every((result) => result.valid), active: results.every((result) => result.valid && result.active) };
-};
+const evaluateAdaptiveImageConditions = (conditions, hass, now = new Date()) =>
+  evaluateAdaptiveConditions(conditions, hass, now, typeof window.matchMedia === "function" ? window.matchMedia.bind(window) : undefined);
 
 const resolveAdaptiveRoomImage = (config, hass, now = new Date()) => {
   const fallback = {
@@ -949,67 +868,6 @@ const templateNeedsEveryHassUpdate = (ctrl) => {
   return source.includes("${") && getTemplateEntityDependencies(ctrl).length === 0;
 };
 
-const getConditionEntityDependencies = (conditions) => {
-  const ids = new Set();
-  const visit = (condition) => {
-    if (!condition || typeof condition !== "object") return;
-    if (typeof condition.entity === "string" && condition.entity.trim()) ids.add(condition.entity.trim());
-    [condition.above, condition.below].forEach((value) => {
-      if (typeof value === "string" && /^[a-z0-9_]+\.[a-z0-9_]+$/i.test(value.trim())) ids.add(value.trim());
-    });
-    if (Array.isArray(condition.conditions)) condition.conditions.forEach(visit);
-  };
-  (Array.isArray(conditions) ? conditions : [conditions]).forEach(visit);
-  return Array.from(ids);
-};
-
-const evaluateRoomModeCondition = (condition, hass) => {
-  if (!condition || typeof condition !== "object") return { valid: false, active: false };
-  const type = condition.condition;
-  if (type === "state") {
-    const entity = trimStr(condition.entity);
-    const expected = (Array.isArray(condition.state) ? condition.state : [condition.state])
-      .filter((value) => value !== undefined && trimStr(String(value)) !== "")
-      .map(String);
-    if (!entity || expected.length === 0) return { valid: false, active: false };
-    const stateObj = hass?.states?.[entity];
-    if (!stateObj || isEntityOffline(stateObj)) return { valid: false, active: false };
-    return { valid: true, active: expected.includes(String(stateObj.state ?? "")) };
-  }
-  if (type === "numeric_state") {
-    const entity = trimStr(condition.entity);
-    const hasAbove = condition.above !== undefined && trimStr(String(condition.above)) !== "" && Number.isFinite(Number(condition.above));
-    const hasBelow = condition.below !== undefined && trimStr(String(condition.below)) !== "" && Number.isFinite(Number(condition.below));
-    if (!entity || (!hasAbove && !hasBelow)) return { valid: false, active: false };
-    const stateObj = hass?.states?.[entity];
-    if (!stateObj || isEntityOffline(stateObj)) return { valid: false, active: false };
-    const value = Number(stateObj.state);
-    if (!Number.isFinite(value)) return { valid: false, active: false };
-    return {
-      valid: true,
-      active: (!hasAbove || value > Number(condition.above)) && (!hasBelow || value < Number(condition.below))
-    };
-  }
-  if (["and", "or", "not"].includes(type)) {
-    if (!Array.isArray(condition.conditions) || condition.conditions.length === 0) return { valid: false, active: false };
-    const nested = condition.conditions.map((item) => evaluateRoomModeCondition(item, hass));
-    if (nested.some((result) => !result.valid)) return { valid: false, active: false };
-    if (type === "and") return { valid: true, active: nested.every((result) => result.active) };
-    if (type === "or") return { valid: true, active: nested.some((result) => result.active) };
-    return { valid: true, active: nested.every((result) => !result.active) };
-  }
-  return { valid: false, active: false };
-};
-
-const evaluateRoomModeActiveWhen = (activeWhen, hass) => {
-  const conditions = Array.isArray(activeWhen) ? activeWhen : (activeWhen ? [activeWhen] : []);
-  if (conditions.length === 0) return { valid: false, active: false };
-  const results = conditions.map((condition) => evaluateRoomModeCondition(condition, hass));
-  return {
-    valid: results.every((result) => result.valid),
-    active: results.every((result) => result.valid && result.active)
-  };
-};
 
 const SHARED_SPARKLINE_CACHE = new Map();
 const SHARED_SPARKLINE_PENDING = new Map();
@@ -2764,51 +2622,7 @@ class OneLineRoomCard extends HTMLElement {
   }
 
   _checkCondition(c, h) {
-    if (!c || !c.condition) return true;
-    const type = c.condition;
-
-    if (type === "state") {
-      if (!c.entity) return true; // Incomplete condition — treat as always visible
-      const st = h.states[c.entity]?.state;
-      if (c.state_not !== undefined) return st !== c.state_not;
-      return st === c.state;
-    }
-
-    if (type === "numeric_state") {
-      if (!c.entity) return true; // Incomplete condition
-      const val = parseFloat(h.states[c.entity]?.state);
-      if (isNaN(val)) return false;
-      if (c.above !== undefined && val <= parseFloat(c.above)) return false;
-      if (c.below !== undefined && val >= parseFloat(c.below)) return false;
-      return true;
-    }
-
-    if (type === "screen") {
-      if (!c.media_query) return true;
-      return window.matchMedia(c.media_query).matches;
-    }
-
-    if (type === "user") {
-      if (!Array.isArray(c.users) || !h.user) return true;
-      return c.users.includes(h.user.id);
-    }
-
-    if (type === "and") {
-      if (!Array.isArray(c.conditions)) return true;
-      return c.conditions.every(cond => this._checkCondition(cond, h));
-    }
-
-    if (type === "or") {
-      if (!Array.isArray(c.conditions)) return true;
-      return c.conditions.some(cond => this._checkCondition(cond, h));
-    }
-
-    if (type === "not") {
-      if (!Array.isArray(c.conditions)) return true;
-      return c.conditions.every(cond => !this._checkCondition(cond, h));
-    }
-
-    return true;
+    return evaluateVisibilityCondition(c, h, (query) => window.matchMedia(query), (condition) => this._checkCondition(condition, h));
   }
 
   _getSliderCapabilities(domain, st, ctrl) {

--- a/tests/condition-helpers.test.mjs
+++ b/tests/condition-helpers.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { evaluateAdaptiveImageConditions, evaluateRoomModeActiveWhen,
+  evaluateVisibilityCondition, getConditionEntityDependencies } from "../src/lib/conditions.js";
+
+const hass = { states: {
+  "sensor.value": { state: "12", attributes: {} },
+  "sensor.limit": { state: "10", attributes: {} },
+  "light.room": { state: "off", attributes: {} }
+}, user: { id: "owner" } };
+const now = new Date(2026, 8, 5, 23, 30);
+
+test("condition families retain different incomplete-rule and state-list semantics", () => {
+  const incomplete = { condition: "state" };
+  assert.equal(evaluateVisibilityCondition(incomplete, hass), true);
+  assert.deepEqual(evaluateRoomModeActiveWhen([incomplete], hass), { valid: false, active: false });
+  assert.deepEqual(evaluateAdaptiveImageConditions([incomplete], hass, now), { valid: false, active: false });
+  const list = { condition: "state", entity: "light.room", state: ["off"] };
+  assert.equal(evaluateVisibilityCondition(list, hass), false);
+  assert.equal(evaluateRoomModeActiveWhen([list], hass).active, true);
+  assert.equal(evaluateAdaptiveImageConditions([list], hass, now).active, true);
+  assert.equal(evaluateVisibilityCondition({ condition: "future" }, hass), true);
+  assert.equal(evaluateRoomModeActiveWhen([{ condition: "future" }], hass).valid, false);
+});
+
+test("numeric thresholds are intentionally distinct across condition policies", () => {
+  const condition = { condition: "numeric_state", entity: "sensor.value", above: "sensor.limit" };
+  assert.equal(evaluateVisibilityCondition(condition, hass), true);
+  assert.equal(evaluateRoomModeActiveWhen([condition], hass).valid, false);
+  assert.equal(evaluateAdaptiveImageConditions([condition], hass, now).active, true);
+  assert.equal(evaluateAdaptiveImageConditions([{ ...condition, above: "sensor.missing" }], hass, now).valid, false);
+  const nested = { condition: "and", conditions: [condition] };
+  assert.deepEqual(getConditionEntityDependencies([nested]), ["sensor.value", "sensor.limit"]);
+});
+
+test("screen and time conditions use explicit environment inputs, including nested rules", () => {
+  const screen = { condition: "screen", media_query: "(min-width: 768px)" };
+  const matcher = query => ({ matches: query === screen.media_query });
+  assert.equal(evaluateVisibilityCondition(screen, hass, matcher), true);
+  assert.equal(evaluateAdaptiveImageConditions([{ condition: "and", conditions: [screen] }], hass, now, matcher).active, true);
+  assert.equal(evaluateAdaptiveImageConditions([screen], hass, now).valid, false);
+  const fail = () => { throw Error("invalid media query"); };
+  assert.throws(() => evaluateVisibilityCondition(screen, hass, fail), /invalid media query/);
+  assert.equal(evaluateAdaptiveImageConditions([screen], hass, now, fail).valid, false);
+  assert.equal(evaluateAdaptiveImageConditions([{ condition: "time", after: "22:00", before: "06:00" }], hass, now).active, true);
+});
+
+test("visibility recursion can preserve the card's delegated condition callback", () => {
+  const visited = [];
+  assert.equal(evaluateVisibilityCondition({ condition: "not", conditions: [{ condition: "custom" }] }, hass, undefined, condition => {
+    visited.push(condition.condition);
+    return false;
+  }), true);
+  assert.deepEqual(visited, ["custom"]);
+});


### PR DESCRIPTION
Part of #100. Extracts dependency discovery and the three existing condition policies into lib/conditions.js. Preserves permissive visibility versus strict mode/adaptive validity, differing numeric thresholds, state arrays, nested conditions and error behavior. Time and screen matching are supplied explicitly; no card instance is passed to the helper module. Runtime wrapper preserves delegated visibility callbacks. Full build/check pass (85 tests), including new direct policy/environment tests and all shipped-artifact regressions. No YAML, version or Drawer changes; separate rollback point.