### PR TITLE
refactor: isolate Home Assistant action payload construction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@
 - `src/lib/states.js` owns shared state definitions, domain icons and state predicates.
 - `src/lib/conditions.js` keeps visibility, room-mode and adaptive-image policies separate; time and screen inputs are supplied by the runtime.
 - `src/lib/alerts.js` owns legacy alert normalization and activation rules.
+- `src/lib/actions.js` builds HA action payloads; the card still owns availability checks and event dispatch.
 - `src/i18n/translations.js` owns the unchanged EN/DE/FR dictionaries and fallback lookup.
 - `dist/room-card.js` is the generated HACS artifact and must not be edited directly.
 - `dist/rooms/` contains the additional assets installed by HACS.

--- a/dist/room-card.js
+++ b/dist/room-card.js
@@ -1451,6 +1451,32 @@ var getTranslation = (hass, key) => {
   return TRANSLATIONS[lang]?.[key] ?? TRANSLATIONS["en"]?.[key] ?? key;
 };
 
+// src/lib/actions.js
+var buildHassActionDetail = (type, config, hass) => {
+  const actionKey = `${type}_action`;
+  let actionConfig = config[actionKey] || {};
+  if (!actionConfig || typeof actionConfig !== "object") actionConfig = { action: "none" };
+  if (!actionConfig.action) actionConfig.action = "none";
+  if (actionConfig.action === "toggle" && config.entity) {
+    const targetEntity = actionConfig.target?.entity_id || config.entity;
+    const domain = targetEntity.split(".")[0];
+    if (domain === "climate" && hass) {
+      const state = hass.states[targetEntity];
+      if (state) {
+        actionConfig = !isEntityOff(state) ? { action: "call-service", service: "climate.set_hvac_mode", data: { hvac_mode: STATE_DEFINITIONS.INACTIVE_STATES.off }, target: { entity_id: targetEntity } } : { action: "call-service", service: "climate.turn_on", target: { entity_id: targetEntity } };
+      }
+    }
+  }
+  const eventDetail = {
+    config: {
+      entity: actionConfig.target?.entity_id || config.entity,
+      [actionKey]: actionConfig
+    },
+    action: type
+  };
+  return eventDetail;
+};
+
 // src/room-card.js
 var VERSION = "1.4.0";
 var EDITOR_DOM_REVISION = "6";
@@ -4720,27 +4746,7 @@ var OneLineRoomCard = class extends HTMLElement {
   }
   _fireAction(type, config) {
     if (config.entity && this._isEntityUnavailable(config.entity)) return;
-    const actionKey = `${type}_action`;
-    let actionConfig = config[actionKey] || {};
-    if (!actionConfig || typeof actionConfig !== "object") actionConfig = { action: "none" };
-    if (!actionConfig.action) actionConfig.action = "none";
-    if (actionConfig.action === "toggle" && config.entity) {
-      const targetEntity = actionConfig.target?.entity_id || config.entity;
-      const domain = targetEntity.split(".")[0];
-      if (domain === "climate" && this._hass) {
-        const state = this._hass.states[targetEntity];
-        if (state) {
-          actionConfig = !isEntityOff(state) ? { action: "call-service", service: "climate.set_hvac_mode", data: { hvac_mode: STATE_DEFINITIONS.INACTIVE_STATES.off }, target: { entity_id: targetEntity } } : { action: "call-service", service: "climate.turn_on", target: { entity_id: targetEntity } };
-        }
-      }
-    }
-    const eventDetail = {
-      config: {
-        entity: actionConfig.target?.entity_id || config.entity,
-        [actionKey]: actionConfig
-      },
-      action: type
-    };
+    const eventDetail = buildHassActionDetail(type, config, this._hass);
     this.dispatchEvent(new CustomEvent("hass-action", { bubbles: true, composed: true, detail: eventDetail }));
   }
   _toggleCollapse() {

--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -1,0 +1,30 @@
+import { isEntityOff, STATE_DEFINITIONS } from "./states.js";
+
+const buildHassActionDetail = (type, config, hass) => {
+  const actionKey = `${type}_action`;
+  let actionConfig = config[actionKey] || {};
+  if (!actionConfig || typeof actionConfig !== 'object') actionConfig = { action: 'none' };
+  if (!actionConfig.action) actionConfig.action = "none";
+  if (actionConfig.action === "toggle" && config.entity) {
+    const targetEntity = actionConfig.target?.entity_id || config.entity;
+    const domain = targetEntity.split(".")[0];
+    if (domain === "climate" && hass) {
+      const state = hass.states[targetEntity];
+      if (state) {
+        actionConfig = !isEntityOff(state)
+          ? { action: "call-service", service: "climate.set_hvac_mode", data: { hvac_mode: STATE_DEFINITIONS.INACTIVE_STATES.off }, target: { entity_id: targetEntity } }
+          : { action: "call-service", service: "climate.turn_on", target: { entity_id: targetEntity } };
+      }
+    }
+  }
+const eventDetail = {
+    config: {
+      entity: actionConfig.target?.entity_id || config.entity,
+      [actionKey]: actionConfig
+    },
+    action: type
+  };
+  return eventDetail;
+};
+
+export { buildHassActionDetail };

--- a/src/room-card.js
+++ b/src/room-card.js
@@ -14,6 +14,8 @@ import { normalizeAlertSensorConfig, isAlertSensorActive } from "./lib/alerts.js
 
 import { TRANSLATIONS, getTranslation } from "./i18n/translations.js";
 
+import { buildHassActionDetail } from "./lib/actions.js";
+
 const VERSION = "1.4.0";
 const EDITOR_DOM_REVISION = "6";
 const LOG_FLAG = `customCards_RoomCard_Logged_${VERSION}`;
@@ -3437,29 +3439,7 @@ class OneLineRoomCard extends HTMLElement {
 
   _fireAction(type, config) {
     if (config.entity && this._isEntityUnavailable(config.entity)) return;
-    const actionKey = `${type}_action`;
-    let actionConfig = config[actionKey] || {};
-    if (!actionConfig || typeof actionConfig !== 'object') actionConfig = { action: 'none' };
-    if (!actionConfig.action) actionConfig.action = "none";
-    if (actionConfig.action === "toggle" && config.entity) {
-      const targetEntity = actionConfig.target?.entity_id || config.entity;
-      const domain = targetEntity.split(".")[0];
-      if (domain === "climate" && this._hass) {
-        const state = this._hass.states[targetEntity];
-        if (state) {
-          actionConfig = !isEntityOff(state)
-            ? { action: "call-service", service: "climate.set_hvac_mode", data: { hvac_mode: STATE_DEFINITIONS.INACTIVE_STATES.off }, target: { entity_id: targetEntity } }
-            : { action: "call-service", service: "climate.turn_on", target: { entity_id: targetEntity } };
-        }
-      }
-    }
-const eventDetail = {
-      config: {
-        entity: actionConfig.target?.entity_id || config.entity,
-        [actionKey]: actionConfig
-      },
-      action: type
-    };
+    const eventDetail = buildHassActionDetail(type, config, this._hass);
     this.dispatchEvent(new CustomEvent("hass-action", { bubbles: true, composed: true, detail: eventDetail }));
   }
 

--- a/tests/action-helpers.test.mjs
+++ b/tests/action-helpers.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildHassActionDetail } from "../src/lib/actions.js";
+
+test("action payload construction retains action type, target and explicit configuration", () => {
+  const action = { action: "call-service", service: "light.turn_on", target: { entity_id: "light.target" }, data: { brightness_pct: 42 } };
+  const detail = buildHassActionDetail("double_tap", { entity: "light.original", double_tap_action: action }, {});
+  assert.equal(detail.action, "double_tap");
+  assert.equal(detail.config.entity, "light.target");
+  assert.equal(detail.config.double_tap_action, action);
+});
+
+test("climate toggles retain the existing explicit service translation", () => {
+  const config = { entity: "climate.room", hold_action: { action: "toggle" } };
+  const on = buildHassActionDetail("hold", config, { states: { "climate.room": { state: "heat" } } });
+  assert.deepEqual(on.config.hold_action, { action: "call-service", service: "climate.set_hvac_mode", data: { hvac_mode: "off" }, target: { entity_id: "climate.room" } });
+  const off = buildHassActionDetail("hold", config, { states: { "climate.room": { state: "off" } } });
+  assert.equal(off.config.hold_action.service, "climate.turn_on");
+  assert.equal(config.hold_action.action, "toggle");
+});
+
+test("missing and invalid actions preserve the none fallback and existing normalization", () => {
+  assert.deepEqual(buildHassActionDetail("tap", { entity: "light.room", tap_action: "invalid" }, {}).config.tap_action, { action: "none" });
+  const config = { entity: "light.room", tap_action: {} };
+  assert.equal(buildHassActionDetail("tap", config, {}).config.tap_action.action, "none");
+  assert.equal(config.tap_action.action, "none");
+});


### PR DESCRIPTION
Part of #100. Moves action payload construction to lib/actions.js with explicit type/config/hass inputs. Card retains the original availability guard and single hass-action dispatch. Direct tests cover target/type preservation, climate toggle service translation and existing missing/invalid-action normalization. Full build/check pass (91 tests), including event and service regressions. No action behavior, YAML, version or Drawer changes; separate rollback point.