### PR TITLE
refactor: isolate history requests and shared cache primitives

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@
 - `src/lib/conditions.js` keeps visibility, room-mode and adaptive-image policies separate; time and screen inputs are supplied by the runtime.
 - `src/lib/alerts.js` owns legacy alert normalization and activation rules.
 - `src/lib/actions.js` builds HA action payloads; the card still owns availability checks and event dispatch.
+- `src/lib/history.js` owns shared cache primitives and history parsing/requests through an explicit HA callback. Per-card refresh timers, cache coordination and DOM updates stay in the runtime.
 - `src/i18n/translations.js` owns the unchanged EN/DE/FR dictionaries and fallback lookup.
 - `dist/room-card.js` is the generated HACS artifact and must not be edited directly.
 - `dist/rooms/` contains the additional assets installed by HACS.

--- a/dist/room-card.js
+++ b/dist/room-card.js
@@ -1477,6 +1477,79 @@ var buildHassActionDetail = (type, config, hass) => {
   return eventDetail;
 };
 
+// src/lib/history.js
+var SHARED_SPARKLINE_CACHE = /* @__PURE__ */ new Map();
+var SHARED_SPARKLINE_PENDING = /* @__PURE__ */ new Map();
+var SHARED_SPARKLINE_CACHE_LIMIT = 100;
+var SHARED_SPARKLINE_MAX_AGE_MS = 4 * 60 * 60 * 1e3;
+var normalizeSparklineSamples = (samples) => {
+  const valid = (Array.isArray(samples) ? samples : []).filter((sample) => Number.isFinite(sample?.timestamp) && Number.isFinite(sample?.value)).sort((a, b) => a.timestamp - b.timestamp);
+  if (valid.length === 0) return [];
+  if (valid.length === 1) return [{ x: 0, y: valid[0].value }, { x: 1, y: valid[0].value }];
+  const startTime = valid[0].timestamp;
+  const endTime = Math.max(valid[valid.length - 1].timestamp, startTime + 1);
+  return valid.map((sample) => ({
+    x: (sample.timestamp - startTime) / (endTime - startTime),
+    y: sample.value
+  }));
+};
+var getSparklineStats = (samples) => {
+  const values = (Array.isArray(samples) ? samples : []).map((sample) => sample?.value).filter(Number.isFinite);
+  if (values.length === 0) return null;
+  return {
+    min: Math.min(...values),
+    max: Math.max(...values),
+    average: values.reduce((sum, value) => sum + value, 0) / values.length
+  };
+};
+var pruneSharedSparklineCache = (now = Date.now()) => {
+  for (const [key, entry] of SHARED_SPARKLINE_CACHE.entries()) {
+    if (!entry || now - entry.lastAccess > SHARED_SPARKLINE_MAX_AGE_MS) SHARED_SPARKLINE_CACHE.delete(key);
+  }
+  while (SHARED_SPARKLINE_CACHE.size > SHARED_SPARKLINE_CACHE_LIMIT) {
+    SHARED_SPARKLINE_CACHE.delete(SHARED_SPARKLINE_CACHE.keys().next().value);
+  }
+};
+var fetchHistorySamples = async (callWS, entity, hours) => {
+  try {
+    const start = new Date(Date.now() - hours * 36e5);
+    const result = await callWS({
+      type: "history/history_during_period",
+      entity_ids: [entity],
+      start_time: start.toISOString(),
+      end_time: (/* @__PURE__ */ new Date()).toISOString(),
+      minimal_response: true,
+      no_attributes: true
+    });
+    const raw = result[entity] || (Array.isArray(result) && result.length > 0 ? result[0] : []);
+    const samples = [];
+    for (const item of raw) {
+      if (!item) continue;
+      let state;
+      let ts;
+      if (Array.isArray(item)) {
+        state = item[0];
+        ts = item[1] ? new Date(item[1]) : null;
+      } else if (typeof item === "object") {
+        state = item.state ?? item.s;
+        const timeVal = item.last_changed ?? item.last_updated ?? item.lu ?? item.lc;
+        if (typeof timeVal === "number") ts = new Date(timeVal * 1e3);
+        else if (timeVal) ts = new Date(timeVal);
+      }
+      if (!ts || state == null) continue;
+      const value = parseFloat(String(state));
+      if (Number.isNaN(value)) continue;
+      const timestamp = ts.getTime();
+      if (!Number.isFinite(timestamp)) continue;
+      samples.push({ timestamp, value });
+    }
+    samples.sort((a, b) => a.timestamp - b.timestamp);
+    return { samples, error: null };
+  } catch (err) {
+    return { samples: [], error: String(err?.message || err || "history_error") };
+  }
+};
+
 // src/room-card.js
 var VERSION = "1.4.0";
 var EDITOR_DOM_REVISION = "6";
@@ -2019,38 +2092,6 @@ var templateNeedsEveryHassUpdate = (ctrl) => {
   const source = TEMPLATE_VALUE_KEYS.map((key) => String(ctrl?.[key] ?? "")).join("\n");
   return source.includes("${") && getTemplateEntityDependencies(ctrl).length === 0;
 };
-var SHARED_SPARKLINE_CACHE = /* @__PURE__ */ new Map();
-var SHARED_SPARKLINE_PENDING = /* @__PURE__ */ new Map();
-var SHARED_SPARKLINE_CACHE_LIMIT = 100;
-var SHARED_SPARKLINE_MAX_AGE_MS = 4 * 60 * 60 * 1e3;
-var normalizeSparklineSamples = (samples) => {
-  const valid = (Array.isArray(samples) ? samples : []).filter((sample) => Number.isFinite(sample?.timestamp) && Number.isFinite(sample?.value)).sort((a, b) => a.timestamp - b.timestamp);
-  if (valid.length === 0) return [];
-  if (valid.length === 1) return [{ x: 0, y: valid[0].value }, { x: 1, y: valid[0].value }];
-  const startTime = valid[0].timestamp;
-  const endTime = Math.max(valid[valid.length - 1].timestamp, startTime + 1);
-  return valid.map((sample) => ({
-    x: (sample.timestamp - startTime) / (endTime - startTime),
-    y: sample.value
-  }));
-};
-var getSparklineStats = (samples) => {
-  const values = (Array.isArray(samples) ? samples : []).map((sample) => sample?.value).filter(Number.isFinite);
-  if (values.length === 0) return null;
-  return {
-    min: Math.min(...values),
-    max: Math.max(...values),
-    average: values.reduce((sum, value) => sum + value, 0) / values.length
-  };
-};
-var pruneSharedSparklineCache = (now = Date.now()) => {
-  for (const [key, entry] of SHARED_SPARKLINE_CACHE.entries()) {
-    if (!entry || now - entry.lastAccess > SHARED_SPARKLINE_MAX_AGE_MS) SHARED_SPARKLINE_CACHE.delete(key);
-  }
-  while (SHARED_SPARKLINE_CACHE.size > SHARED_SPARKLINE_CACHE_LIMIT) {
-    SHARED_SPARKLINE_CACHE.delete(SHARED_SPARKLINE_CACHE.keys().next().value);
-  }
-};
 function formatLastChanged(lastChanged, hass) {
   if (!lastChanged) return "";
   const elapsedSec = Math.floor((Date.now() - new Date(lastChanged)) / 1e3);
@@ -2253,45 +2294,7 @@ var OneLineRoomCard = class extends HTMLElement {
     }
     let promise = SHARED_SPARKLINE_PENDING.get(key);
     if (!promise) {
-      promise = (async () => {
-        try {
-          const start = new Date(Date.now() - hours * 36e5);
-          const result = await this._hass.callWS({
-            type: "history/history_during_period",
-            entity_ids: [entity],
-            start_time: start.toISOString(),
-            end_time: (/* @__PURE__ */ new Date()).toISOString(),
-            minimal_response: true,
-            no_attributes: true
-          });
-          const raw = result[entity] || (Array.isArray(result) && result.length > 0 ? result[0] : []);
-          const samples = [];
-          for (const item of raw) {
-            if (!item) continue;
-            let state;
-            let ts;
-            if (Array.isArray(item)) {
-              state = item[0];
-              ts = item[1] ? new Date(item[1]) : null;
-            } else if (typeof item === "object") {
-              state = item.state ?? item.s;
-              const timeVal = item.last_changed ?? item.last_updated ?? item.lu ?? item.lc;
-              if (typeof timeVal === "number") ts = new Date(timeVal * 1e3);
-              else if (timeVal) ts = new Date(timeVal);
-            }
-            if (!ts || state == null) continue;
-            const value = parseFloat(String(state));
-            if (Number.isNaN(value)) continue;
-            const timestamp = ts.getTime();
-            if (!Number.isFinite(timestamp)) continue;
-            samples.push({ timestamp, value });
-          }
-          samples.sort((a, b) => a.timestamp - b.timestamp);
-          return { samples, error: null };
-        } catch (err) {
-          return { samples: [], error: String(err?.message || err || "history_error") };
-        }
-      })();
+      promise = fetchHistorySamples((message) => this._hass.callWS(message), entity, hours);
       SHARED_SPARKLINE_PENDING.set(key, promise);
     }
     this._sparklinePending.set(key, promise);

--- a/src/lib/history.js
+++ b/src/lib/history.js
@@ -1,0 +1,80 @@
+const SHARED_SPARKLINE_CACHE = new Map();
+const SHARED_SPARKLINE_PENDING = new Map();
+const SHARED_SPARKLINE_CACHE_LIMIT = 100;
+const SHARED_SPARKLINE_MAX_AGE_MS = 4 * 60 * 60 * 1000;
+
+const normalizeSparklineSamples = (samples) => {
+  const valid = (Array.isArray(samples) ? samples : [])
+    .filter((sample) => Number.isFinite(sample?.timestamp) && Number.isFinite(sample?.value))
+    .sort((a, b) => a.timestamp - b.timestamp);
+  if (valid.length === 0) return [];
+  if (valid.length === 1) return [{ x: 0, y: valid[0].value }, { x: 1, y: valid[0].value }];
+  const startTime = valid[0].timestamp;
+  const endTime = Math.max(valid[valid.length - 1].timestamp, startTime + 1);
+  return valid.map((sample) => ({
+    x: (sample.timestamp - startTime) / (endTime - startTime),
+    y: sample.value
+  }));
+};
+
+const getSparklineStats = (samples) => {
+  const values = (Array.isArray(samples) ? samples : [])
+    .map((sample) => sample?.value)
+    .filter(Number.isFinite);
+  if (values.length === 0) return null;
+  return {
+    min: Math.min(...values),
+    max: Math.max(...values),
+    average: values.reduce((sum, value) => sum + value, 0) / values.length
+  };
+};
+
+const pruneSharedSparklineCache = (now = Date.now()) => {
+  for (const [key, entry] of SHARED_SPARKLINE_CACHE.entries()) {
+    if (!entry || now - entry.lastAccess > SHARED_SPARKLINE_MAX_AGE_MS) SHARED_SPARKLINE_CACHE.delete(key);
+  }
+  while (SHARED_SPARKLINE_CACHE.size > SHARED_SPARKLINE_CACHE_LIMIT) {
+    SHARED_SPARKLINE_CACHE.delete(SHARED_SPARKLINE_CACHE.keys().next().value);
+  }
+};
+
+const fetchHistorySamples = async (callWS, entity, hours) => {
+  try {
+    const start = new Date(Date.now() - hours * 3600000);
+    const result = await callWS({
+      type: "history/history_during_period",
+      entity_ids: [entity],
+      start_time: start.toISOString(),
+      end_time: new Date().toISOString(),
+      minimal_response: true,
+      no_attributes: true
+    });
+    const raw = result[entity] || (Array.isArray(result) && result.length > 0 ? result[0] : []);
+    const samples = [];
+    for (const item of raw) {
+      if (!item) continue;
+      let state; let ts;
+      if (Array.isArray(item)) {
+        state = item[0];
+        ts = item[1] ? new Date(item[1]) : null;
+      } else if (typeof item === "object") {
+        state = item.state ?? item.s;
+        const timeVal = item.last_changed ?? item.last_updated ?? item.lu ?? item.lc;
+        if (typeof timeVal === "number") ts = new Date(timeVal * 1000);
+        else if (timeVal) ts = new Date(timeVal);
+      }
+      if (!ts || state == null) continue;
+      const value = parseFloat(String(state));
+      if (Number.isNaN(value)) continue;
+      const timestamp = ts.getTime();
+      if (!Number.isFinite(timestamp)) continue;
+      samples.push({ timestamp, value });
+    }
+    samples.sort((a, b) => a.timestamp - b.timestamp);
+    return { samples, error: null };
+  } catch (err) {
+    return { samples: [], error: String(err?.message || err || "history_error") };
+  }
+};
+
+export { SHARED_SPARKLINE_CACHE, SHARED_SPARKLINE_PENDING, SHARED_SPARKLINE_CACHE_LIMIT, SHARED_SPARKLINE_MAX_AGE_MS, normalizeSparklineSamples, getSparklineStats, pruneSharedSparklineCache, fetchHistorySamples };

--- a/src/room-card.js
+++ b/src/room-card.js
@@ -16,6 +16,8 @@ import { TRANSLATIONS, getTranslation } from "./i18n/translations.js";
 
 import { buildHassActionDetail } from "./lib/actions.js";
 
+import { SHARED_SPARKLINE_CACHE, SHARED_SPARKLINE_PENDING, SHARED_SPARKLINE_CACHE_LIMIT, SHARED_SPARKLINE_MAX_AGE_MS, normalizeSparklineSamples, getSparklineStats, pruneSharedSparklineCache, fetchHistorySamples } from "./lib/history.js";
+
 const VERSION = "1.4.0";
 const EDITOR_DOM_REVISION = "6";
 const LOG_FLAG = `customCards_RoomCard_Logged_${VERSION}`;
@@ -567,45 +569,6 @@ const templateNeedsEveryHassUpdate = (ctrl) => {
 };
 
 
-const SHARED_SPARKLINE_CACHE = new Map();
-const SHARED_SPARKLINE_PENDING = new Map();
-const SHARED_SPARKLINE_CACHE_LIMIT = 100;
-const SHARED_SPARKLINE_MAX_AGE_MS = 4 * 60 * 60 * 1000;
-
-const normalizeSparklineSamples = (samples) => {
-  const valid = (Array.isArray(samples) ? samples : [])
-    .filter((sample) => Number.isFinite(sample?.timestamp) && Number.isFinite(sample?.value))
-    .sort((a, b) => a.timestamp - b.timestamp);
-  if (valid.length === 0) return [];
-  if (valid.length === 1) return [{ x: 0, y: valid[0].value }, { x: 1, y: valid[0].value }];
-  const startTime = valid[0].timestamp;
-  const endTime = Math.max(valid[valid.length - 1].timestamp, startTime + 1);
-  return valid.map((sample) => ({
-    x: (sample.timestamp - startTime) / (endTime - startTime),
-    y: sample.value
-  }));
-};
-
-const getSparklineStats = (samples) => {
-  const values = (Array.isArray(samples) ? samples : [])
-    .map((sample) => sample?.value)
-    .filter(Number.isFinite);
-  if (values.length === 0) return null;
-  return {
-    min: Math.min(...values),
-    max: Math.max(...values),
-    average: values.reduce((sum, value) => sum + value, 0) / values.length
-  };
-};
-
-const pruneSharedSparklineCache = (now = Date.now()) => {
-  for (const [key, entry] of SHARED_SPARKLINE_CACHE.entries()) {
-    if (!entry || now - entry.lastAccess > SHARED_SPARKLINE_MAX_AGE_MS) SHARED_SPARKLINE_CACHE.delete(key);
-  }
-  while (SHARED_SPARKLINE_CACHE.size > SHARED_SPARKLINE_CACHE_LIMIT) {
-    SHARED_SPARKLINE_CACHE.delete(SHARED_SPARKLINE_CACHE.keys().next().value);
-  }
-};
 
 // =============================================================================
 // LAST CHANGED HELPER
@@ -830,44 +793,7 @@ class OneLineRoomCard extends HTMLElement {
     }
     let promise = SHARED_SPARKLINE_PENDING.get(key);
     if (!promise) {
-      promise = (async () => {
-        try {
-          const start = new Date(Date.now() - hours * 3600000);
-          const result = await this._hass.callWS({
-            type: "history/history_during_period",
-            entity_ids: [entity],
-            start_time: start.toISOString(),
-            end_time: new Date().toISOString(),
-            minimal_response: true,
-            no_attributes: true
-          });
-          const raw = result[entity] || (Array.isArray(result) && result.length > 0 ? result[0] : []);
-          const samples = [];
-          for (const item of raw) {
-            if (!item) continue;
-            let state; let ts;
-            if (Array.isArray(item)) {
-              state = item[0];
-              ts = item[1] ? new Date(item[1]) : null;
-            } else if (typeof item === "object") {
-              state = item.state ?? item.s;
-              const timeVal = item.last_changed ?? item.last_updated ?? item.lu ?? item.lc;
-              if (typeof timeVal === "number") ts = new Date(timeVal * 1000);
-              else if (timeVal) ts = new Date(timeVal);
-            }
-            if (!ts || state == null) continue;
-            const value = parseFloat(String(state));
-            if (Number.isNaN(value)) continue;
-            const timestamp = ts.getTime();
-            if (!Number.isFinite(timestamp)) continue;
-            samples.push({ timestamp, value });
-          }
-          samples.sort((a, b) => a.timestamp - b.timestamp);
-          return { samples, error: null };
-        } catch (err) {
-          return { samples: [], error: String(err?.message || err || "history_error") };
-        }
-      })();
+      promise = fetchHistorySamples((message) => this._hass.callWS(message), entity, hours);
       SHARED_SPARKLINE_PENDING.set(key, promise);
     }
     this._sparklinePending.set(key, promise);

--- a/tests/history-helpers.test.mjs
+++ b/tests/history-helpers.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fetchHistorySamples } from "../src/lib/history.js";
+
+test("history service sends the existing HA request and parses legacy/compact sample shapes", async () => {
+  const requests = [];
+  const data = await fetchHistorySamples(async message => {
+    requests.push(message);
+    return { "sensor.temp": [
+      { s: "2.5", lu: 2 },
+      ["1.5", "1970-01-01T00:00:01.000Z"],
+      { state: "3 W", last_changed: "1970-01-01T00:00:03.000Z" },
+      null, { state: "unknown", lc: 4 }, { state: "5", lc: "invalid" }
+    ] };
+  }, "sensor.temp", 6);
+  assert.deepEqual(data, { samples: [
+    { timestamp: 1000, value: 1.5 }, { timestamp: 2000, value: 2.5 }, { timestamp: 3000, value: 3 }
+  ], error: null });
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].type, "history/history_during_period");
+  assert.deepEqual(requests[0].entity_ids, ["sensor.temp"]);
+  assert.equal(requests[0].minimal_response, true);
+  assert.equal(requests[0].no_attributes, true);
+  const range = Date.parse(requests[0].end_time) - Date.parse(requests[0].start_time);
+  assert.ok(range >= 6 * 3600000 && range < 6 * 3600000 + 1000);
+});
+
+test("history service distinguishes empty results, legacy array results and errors", async () => {
+  assert.deepEqual(await fetchHistorySamples(async () => ({}), "sensor.temp", 24), { samples: [], error: null });
+  assert.deepEqual(await fetchHistorySamples(async () => [[{ s: "0", lc: 0 }]], "sensor.temp", 24), { samples: [{ timestamp: 0, value: 0 }], error: null });
+  assert.deepEqual(await fetchHistorySamples(async () => { throw Error("offline"); }, "sensor.temp", 24), { samples: [], error: "offline" });
+});


### PR DESCRIPTION
Part of #100. Moves shared cache maps, sample normalization/statistics/pruning and HA history fetching/parsing into lib/history.js. Fetch receives only an explicit HA callback, entity and range. Per-card coordination, update callbacks, visibility and polling ownership stay unchanged in the card, preserving request deduplication and lifecycle behavior. Full build/check pass (93 tests), including shared/concurrent request and late-response regressions plus direct legacy/compact parsing, payload and error tests. No extra timer, YAML, version or Drawer changes.