### PR TITLE
refactor: extract control capability calculations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@
 - `src/lib/alerts.js` owns legacy alert normalization and activation rules.
 - `src/lib/actions.js` builds HA action payloads; the card still owns availability checks and event dispatch.
 - `src/lib/history.js` owns shared cache primitives and history parsing/requests through an explicit HA callback. Per-card refresh timers, cache coordination and DOM updates stay in the runtime.
+- `src/lib/capabilities.js` owns slider ranges, inline button definitions and media feature masks; availability is supplied by the card.
 - `src/i18n/translations.js` owns the unchanged EN/DE/FR dictionaries and fallback lookup.
 - `dist/room-card.js` is the generated HACS artifact and must not be edited directly.
 - `dist/rooms/` contains the additional assets installed by HACS.

--- a/dist/room-card.js
+++ b/dist/room-card.js
@@ -1550,10 +1550,7 @@ var fetchHistorySamples = async (callWS, entity, hours) => {
   }
 };
 
-// src/room-card.js
-var VERSION = "1.4.0";
-var EDITOR_DOM_REVISION = "6";
-var LOG_FLAG = `customCards_RoomCard_Logged_${VERSION}`;
+// src/lib/capabilities.js
 var MEDIA_PLAYER_FEATURES = Object.freeze({
   PAUSE: 1,
   VOLUME_SET: 4,
@@ -1562,6 +1559,106 @@ var MEDIA_PLAYER_FEATURES = Object.freeze({
   NEXT_TRACK: 32,
   PLAY: 16384
 });
+var getSliderCapabilities = (domain, st, ctrl, unavailable) => {
+  let supported = false, min = 0, max = 100, step = 1, value = 0, pct = 0, action = null;
+  if (!st || unavailable) return { supported };
+  if (domain === "light") {
+    const supp = st.attributes?.supported_color_modes || [];
+    const hasColorTemp = supp.includes("color_temp") || st.attributes?.color_temp !== void 0 || st.attributes?.color_temp_kelvin !== void 0;
+    const isColorTemp = ctrl.slider_mode === "color_temp" && hasColorTemp;
+    supported = true;
+    if (isColorTemp) {
+      if (st.attributes?.min_color_temp_kelvin !== void 0) {
+        min = st.attributes.min_color_temp_kelvin;
+        max = st.attributes.max_color_temp_kelvin;
+        value = st.attributes.color_temp_kelvin ?? min;
+        action = "color_temp_kelvin";
+      } else {
+        min = st.attributes?.min_mireds ?? 153;
+        max = st.attributes?.max_mireds ?? 500;
+        value = st.attributes?.color_temp ?? min;
+        action = "color_temp";
+      }
+    } else {
+      value = st.attributes?.brightness != null ? Math.round(st.attributes.brightness / 255 * 100) : 0;
+      min = 0;
+      max = 100;
+      step = 1;
+      action = "brightness";
+    }
+  } else if (domain === "cover") {
+    supported = true;
+    value = st.attributes?.current_position ?? 0;
+    action = "position";
+  } else if (domain === "climate") {
+    supported = true;
+    min = st.attributes?.min_temp ?? 5;
+    max = st.attributes?.max_temp ?? 35;
+    step = 0.5;
+    value = st.attributes?.temperature ?? min;
+    action = "temperature";
+  } else if (domain === "fan") {
+    supported = true;
+    step = parseInt(st.attributes?.percentage_step ?? 1);
+    value = st.attributes?.percentage ?? 0;
+    action = "percentage";
+  } else if (domain === "media_player") {
+    supported = true;
+    value = st.attributes?.volume_level != null ? Math.round(st.attributes.volume_level * 100) : 0;
+    action = "volume_level";
+  } else if (domain === "number" || domain === "input_number") {
+    supported = true;
+    min = parseFloat(st.attributes?.min ?? 0);
+    max = parseFloat(st.attributes?.max ?? 100);
+    step = parseFloat(st.attributes?.step ?? 1);
+    value = parseFloat(st.state) || min;
+    action = "value";
+  }
+  pct = (Math.max(min, Math.min(max, value)) - min) / (max - min) * 100;
+  return { supported, min, max, step, value, pct, action };
+};
+var getInlineButtons = (domain) => {
+  if (domain === "cover") return [
+    { icon: "mdi:arrow-up-bold", action: "service", service: "cover.open_cover" },
+    { icon: "mdi:stop", action: "service", service: "cover.stop_cover" },
+    { icon: "mdi:arrow-down-bold", action: "service", service: "cover.close_cover" }
+  ];
+  if (domain === "climate") return [
+    { icon: "mdi:minus", action: "custom", custom: "temp_down" },
+    { icon: "mdi:power", action: "custom", custom: "toggle_hvac" },
+    { icon: "mdi:plus", action: "custom", custom: "temp_up" }
+  ];
+  if (domain === "light") return [
+    { icon: "mdi:brightness-5", action: "custom", custom: "dim_down" },
+    { icon: "mdi:power", action: "service", service: "light.toggle" },
+    { icon: "mdi:brightness-7", action: "custom", custom: "dim_up" }
+  ];
+  if (domain === "fan") return [
+    { icon: "mdi:minus", action: "service", service: "fan.decrease_speed" },
+    { icon: "mdi:power", action: "service", service: "fan.toggle" },
+    { icon: "mdi:plus", action: "service", service: "fan.increase_speed" }
+  ];
+  if (domain === "media_player") return [
+    { icon: "mdi:skip-previous", action: "service", service: "media_player.media_previous_track" },
+    { icon: "mdi:play-pause", action: "service", service: "media_player.media_play_pause" },
+    { icon: "mdi:skip-next", action: "service", service: "media_player.media_next_track" }
+  ];
+  if (domain === "select" || domain === "input_select") return [
+    { icon: "mdi:chevron-left", action: "custom", custom: "select_prev" },
+    { icon: "mdi:chevron-right", action: "custom", custom: "select_next" }
+  ];
+  return [];
+};
+var supportsMediaFeature = (stateObj, feature) => {
+  const supported = stateObj?.attributes?.supported_features;
+  if (!Number.isFinite(Number(supported))) return true;
+  return (Number(supported) & feature) !== 0;
+};
+
+// src/room-card.js
+var VERSION = "1.4.0";
+var EDITOR_DOM_REVISION = "6";
+var LOG_FLAG = `customCards_RoomCard_Logged_${VERSION}`;
 var IMAGE_UPLOAD_LIMITS = Object.freeze({
   maxSourceBytes: 20 * 1024 * 1024,
   maxDimension: 2560,
@@ -3621,99 +3718,13 @@ var OneLineRoomCard = class extends HTMLElement {
     return evaluateVisibilityCondition(c, h, (query) => window.matchMedia(query), (condition) => this._checkCondition(condition, h));
   }
   _getSliderCapabilities(domain, st, ctrl) {
-    let supported = false, min = 0, max = 100, step = 1, value = 0, pct = 0, action = null;
-    if (!st || this._isEntityUnavailable(ctrl.entity)) return { supported };
-    if (domain === "light") {
-      const supp = st.attributes?.supported_color_modes || [];
-      const hasColorTemp = supp.includes("color_temp") || st.attributes?.color_temp !== void 0 || st.attributes?.color_temp_kelvin !== void 0;
-      const isColorTemp = ctrl.slider_mode === "color_temp" && hasColorTemp;
-      supported = true;
-      if (isColorTemp) {
-        if (st.attributes?.min_color_temp_kelvin !== void 0) {
-          min = st.attributes.min_color_temp_kelvin;
-          max = st.attributes.max_color_temp_kelvin;
-          value = st.attributes.color_temp_kelvin ?? min;
-          action = "color_temp_kelvin";
-        } else {
-          min = st.attributes?.min_mireds ?? 153;
-          max = st.attributes?.max_mireds ?? 500;
-          value = st.attributes?.color_temp ?? min;
-          action = "color_temp";
-        }
-      } else {
-        value = st.attributes?.brightness != null ? Math.round(st.attributes.brightness / 255 * 100) : 0;
-        min = 0;
-        max = 100;
-        step = 1;
-        action = "brightness";
-      }
-    } else if (domain === "cover") {
-      supported = true;
-      value = st.attributes?.current_position ?? 0;
-      action = "position";
-    } else if (domain === "climate") {
-      supported = true;
-      min = st.attributes?.min_temp ?? 5;
-      max = st.attributes?.max_temp ?? 35;
-      step = 0.5;
-      value = st.attributes?.temperature ?? min;
-      action = "temperature";
-    } else if (domain === "fan") {
-      supported = true;
-      step = parseInt(st.attributes?.percentage_step ?? 1);
-      value = st.attributes?.percentage ?? 0;
-      action = "percentage";
-    } else if (domain === "media_player") {
-      supported = true;
-      value = st.attributes?.volume_level != null ? Math.round(st.attributes.volume_level * 100) : 0;
-      action = "volume_level";
-    } else if (domain === "number" || domain === "input_number") {
-      supported = true;
-      min = parseFloat(st.attributes?.min ?? 0);
-      max = parseFloat(st.attributes?.max ?? 100);
-      step = parseFloat(st.attributes?.step ?? 1);
-      value = parseFloat(st.state) || min;
-      action = "value";
-    }
-    pct = (Math.max(min, Math.min(max, value)) - min) / (max - min) * 100;
-    return { supported, min, max, step, value, pct, action };
+    return getSliderCapabilities(domain, st, ctrl, !st || this._isEntityUnavailable(ctrl.entity));
   }
   _getInlineButtons(domain) {
-    if (domain === "cover") return [
-      { icon: "mdi:arrow-up-bold", action: "service", service: "cover.open_cover" },
-      { icon: "mdi:stop", action: "service", service: "cover.stop_cover" },
-      { icon: "mdi:arrow-down-bold", action: "service", service: "cover.close_cover" }
-    ];
-    if (domain === "climate") return [
-      { icon: "mdi:minus", action: "custom", custom: "temp_down" },
-      { icon: "mdi:power", action: "custom", custom: "toggle_hvac" },
-      { icon: "mdi:plus", action: "custom", custom: "temp_up" }
-    ];
-    if (domain === "light") return [
-      { icon: "mdi:brightness-5", action: "custom", custom: "dim_down" },
-      { icon: "mdi:power", action: "service", service: "light.toggle" },
-      { icon: "mdi:brightness-7", action: "custom", custom: "dim_up" }
-    ];
-    if (domain === "fan") return [
-      { icon: "mdi:minus", action: "service", service: "fan.decrease_speed" },
-      { icon: "mdi:power", action: "service", service: "fan.toggle" },
-      { icon: "mdi:plus", action: "service", service: "fan.increase_speed" }
-    ];
-    if (domain === "media_player") return [
-      { icon: "mdi:skip-previous", action: "service", service: "media_player.media_previous_track" },
-      { icon: "mdi:play-pause", action: "service", service: "media_player.media_play_pause" },
-      { icon: "mdi:skip-next", action: "service", service: "media_player.media_next_track" }
-    ];
-    if (domain === "select" || domain === "input_select") return [
-      { icon: "mdi:chevron-left", action: "custom", custom: "select_prev" },
-      { icon: "mdi:chevron-right", action: "custom", custom: "select_next" }
-    ];
-    return [];
+    return getInlineButtons(domain);
   }
   _supportsMediaFeature(stateObj, feature) {
-    const supported = stateObj?.attributes?.supported_features;
-    if (!Number.isFinite(Number(supported))) return true;
-    return (Number(supported) & feature) !== 0;
+    return supportsMediaFeature(stateObj, feature);
   }
   _updateBtnState(btn, ctrl, h) {
     const systemTempUnit = normalizeTemperatureUnit(h.config.unit_system.temperature) || "°C";

--- a/src/lib/capabilities.js
+++ b/src/lib/capabilities.js
@@ -1,0 +1,107 @@
+const MEDIA_PLAYER_FEATURES = Object.freeze({
+  PAUSE: 1,
+  VOLUME_SET: 4,
+  VOLUME_MUTE: 8,
+  PREVIOUS_TRACK: 16,
+  NEXT_TRACK: 32,
+  PLAY: 16384
+});
+
+const getSliderCapabilities = (domain, st, ctrl, unavailable) => {
+  let supported = false, min = 0, max = 100, step = 1, value = 0, pct = 0, action = null;
+  if (!st || unavailable) return { supported };
+
+  if (domain === "light") {
+    const supp = st.attributes?.supported_color_modes || [];
+    const hasColorTemp = supp.includes("color_temp") || st.attributes?.color_temp !== undefined || st.attributes?.color_temp_kelvin !== undefined;
+    const isColorTemp = ctrl.slider_mode === "color_temp" && hasColorTemp;
+    supported = true;
+    if (isColorTemp) {
+      if (st.attributes?.min_color_temp_kelvin !== undefined) {
+        min = st.attributes.min_color_temp_kelvin;
+        max = st.attributes.max_color_temp_kelvin;
+        value = st.attributes.color_temp_kelvin ?? min;
+        action = "color_temp_kelvin";
+      } else {
+        min = st.attributes?.min_mireds ?? 153;
+        max = st.attributes?.max_mireds ?? 500;
+        value = st.attributes?.color_temp ?? min;
+        action = "color_temp";
+      }
+    } else {
+      value = st.attributes?.brightness != null ? Math.round((st.attributes.brightness / 255) * 100) : 0;
+      min = 0; max = 100; step = 1;
+      action = "brightness";
+    }
+  } else if (domain === "cover") {
+    supported = true;
+    value = st.attributes?.current_position ?? 0;
+    action = "position";
+  } else if (domain === "climate") {
+    supported = true;
+    min = st.attributes?.min_temp ?? 5;
+    max = st.attributes?.max_temp ?? 35;
+    step = 0.5;
+    value = st.attributes?.temperature ?? min;
+    action = "temperature";
+  } else if (domain === "fan") {
+    supported = true;
+    step = parseInt(st.attributes?.percentage_step ?? 1);
+    value = st.attributes?.percentage ?? 0;
+    action = "percentage";
+  } else if (domain === "media_player") {
+    supported = true;
+    value = st.attributes?.volume_level != null ? Math.round(st.attributes.volume_level * 100) : 0;
+    action = "volume_level";
+  } else if (domain === "number" || domain === "input_number") {
+    supported = true;
+    min = parseFloat(st.attributes?.min ?? 0);
+    max = parseFloat(st.attributes?.max ?? 100);
+    step = parseFloat(st.attributes?.step ?? 1);
+    value = parseFloat(st.state) || min;
+    action = "value";
+  }
+  pct = ((Math.max(min, Math.min(max, value)) - min) / (max - min)) * 100;
+  return { supported, min, max, step, value, pct, action };
+};
+
+const getInlineButtons = (domain) => {
+  if (domain === "cover") return [
+    { icon: "mdi:arrow-up-bold", action: "service", service: "cover.open_cover" },
+    { icon: "mdi:stop", action: "service", service: "cover.stop_cover" },
+    { icon: "mdi:arrow-down-bold", action: "service", service: "cover.close_cover" }
+  ];
+  if (domain === "climate") return [
+    { icon: "mdi:minus", action: "custom", custom: "temp_down" },
+    { icon: "mdi:power", action: "custom", custom: "toggle_hvac" },
+    { icon: "mdi:plus", action: "custom", custom: "temp_up" }
+  ];
+  if (domain === "light") return [
+    { icon: "mdi:brightness-5", action: "custom", custom: "dim_down" },
+    { icon: "mdi:power", action: "service", service: "light.toggle" },
+    { icon: "mdi:brightness-7", action: "custom", custom: "dim_up" }
+  ];
+  if (domain === "fan") return [
+    { icon: "mdi:minus", action: "service", service: "fan.decrease_speed" },
+    { icon: "mdi:power", action: "service", service: "fan.toggle" },
+    { icon: "mdi:plus", action: "service", service: "fan.increase_speed" }
+  ];
+  if (domain === "media_player") return [
+    { icon: "mdi:skip-previous", action: "service", service: "media_player.media_previous_track" },
+    { icon: "mdi:play-pause", action: "service", service: "media_player.media_play_pause" },
+    { icon: "mdi:skip-next", action: "service", service: "media_player.media_next_track" }
+  ];
+  if (domain === "select" || domain === "input_select") return [
+    { icon: "mdi:chevron-left", action: "custom", custom: "select_prev" },
+    { icon: "mdi:chevron-right", action: "custom", custom: "select_next" }
+  ];
+  return [];
+};
+
+const supportsMediaFeature = (stateObj, feature) => {
+  const supported = stateObj?.attributes?.supported_features;
+  if (!Number.isFinite(Number(supported))) return true;
+  return (Number(supported) & feature) !== 0;
+};
+
+export { MEDIA_PLAYER_FEATURES, getSliderCapabilities, getInlineButtons, supportsMediaFeature };

--- a/src/room-card.js
+++ b/src/room-card.js
@@ -18,18 +18,12 @@ import { buildHassActionDetail } from "./lib/actions.js";
 
 import { SHARED_SPARKLINE_CACHE, SHARED_SPARKLINE_PENDING, SHARED_SPARKLINE_CACHE_LIMIT, SHARED_SPARKLINE_MAX_AGE_MS, normalizeSparklineSamples, getSparklineStats, pruneSharedSparklineCache, fetchHistorySamples } from "./lib/history.js";
 
+import { MEDIA_PLAYER_FEATURES, getSliderCapabilities, getInlineButtons, supportsMediaFeature } from "./lib/capabilities.js";
+
 const VERSION = "1.4.0";
 const EDITOR_DOM_REVISION = "6";
 const LOG_FLAG = `customCards_RoomCard_Logged_${VERSION}`;
 
-const MEDIA_PLAYER_FEATURES = Object.freeze({
-  PAUSE: 1,
-  VOLUME_SET: 4,
-  VOLUME_MUTE: 8,
-  PREVIOUS_TRACK: 16,
-  NEXT_TRACK: 32,
-  PLAY: 16384
-});
 
 const IMAGE_UPLOAD_LIMITS = Object.freeze({
   maxSourceBytes: 20 * 1024 * 1024,
@@ -2224,100 +2218,15 @@ class OneLineRoomCard extends HTMLElement {
   }
 
   _getSliderCapabilities(domain, st, ctrl) {
-    let supported = false, min = 0, max = 100, step = 1, value = 0, pct = 0, action = null;
-    if (!st || this._isEntityUnavailable(ctrl.entity)) return { supported };
-
-    if (domain === "light") {
-      const supp = st.attributes?.supported_color_modes || [];
-      const hasColorTemp = supp.includes("color_temp") || st.attributes?.color_temp !== undefined || st.attributes?.color_temp_kelvin !== undefined;
-      const isColorTemp = ctrl.slider_mode === "color_temp" && hasColorTemp;
-      supported = true;
-      if (isColorTemp) {
-        if (st.attributes?.min_color_temp_kelvin !== undefined) {
-          min = st.attributes.min_color_temp_kelvin;
-          max = st.attributes.max_color_temp_kelvin;
-          value = st.attributes.color_temp_kelvin ?? min;
-          action = "color_temp_kelvin";
-        } else {
-          min = st.attributes?.min_mireds ?? 153;
-          max = st.attributes?.max_mireds ?? 500;
-          value = st.attributes?.color_temp ?? min;
-          action = "color_temp";
-        }
-      } else {
-        value = st.attributes?.brightness != null ? Math.round((st.attributes.brightness / 255) * 100) : 0;
-        min = 0; max = 100; step = 1;
-        action = "brightness";
-      }
-    } else if (domain === "cover") {
-      supported = true;
-      value = st.attributes?.current_position ?? 0;
-      action = "position";
-    } else if (domain === "climate") {
-      supported = true;
-      min = st.attributes?.min_temp ?? 5;
-      max = st.attributes?.max_temp ?? 35;
-      step = 0.5;
-      value = st.attributes?.temperature ?? min;
-      action = "temperature";
-    } else if (domain === "fan") {
-      supported = true;
-      step = parseInt(st.attributes?.percentage_step ?? 1);
-      value = st.attributes?.percentage ?? 0;
-      action = "percentage";
-    } else if (domain === "media_player") {
-      supported = true;
-      value = st.attributes?.volume_level != null ? Math.round(st.attributes.volume_level * 100) : 0;
-      action = "volume_level";
-    } else if (domain === "number" || domain === "input_number") {
-      supported = true;
-      min = parseFloat(st.attributes?.min ?? 0);
-      max = parseFloat(st.attributes?.max ?? 100);
-      step = parseFloat(st.attributes?.step ?? 1);
-      value = parseFloat(st.state) || min;
-      action = "value";
-    }
-    pct = ((Math.max(min, Math.min(max, value)) - min) / (max - min)) * 100;
-    return { supported, min, max, step, value, pct, action };
+    return getSliderCapabilities(domain, st, ctrl, !st || this._isEntityUnavailable(ctrl.entity));
   }
 
   _getInlineButtons(domain) {
-    if (domain === "cover") return [
-      { icon: "mdi:arrow-up-bold", action: "service", service: "cover.open_cover" },
-      { icon: "mdi:stop", action: "service", service: "cover.stop_cover" },
-      { icon: "mdi:arrow-down-bold", action: "service", service: "cover.close_cover" }
-    ];
-    if (domain === "climate") return [
-      { icon: "mdi:minus", action: "custom", custom: "temp_down" },
-      { icon: "mdi:power", action: "custom", custom: "toggle_hvac" },
-      { icon: "mdi:plus", action: "custom", custom: "temp_up" }
-    ];
-    if (domain === "light") return [
-      { icon: "mdi:brightness-5", action: "custom", custom: "dim_down" },
-      { icon: "mdi:power", action: "service", service: "light.toggle" },
-      { icon: "mdi:brightness-7", action: "custom", custom: "dim_up" }
-    ];
-    if (domain === "fan") return [
-      { icon: "mdi:minus", action: "service", service: "fan.decrease_speed" },
-      { icon: "mdi:power", action: "service", service: "fan.toggle" },
-      { icon: "mdi:plus", action: "service", service: "fan.increase_speed" }
-    ];
-    if (domain === "media_player") return [
-      { icon: "mdi:skip-previous", action: "service", service: "media_player.media_previous_track" },
-      { icon: "mdi:play-pause", action: "service", service: "media_player.media_play_pause" },
-      { icon: "mdi:skip-next", action: "service", service: "media_player.media_next_track" }
-    ];
-    if (domain === "select" || domain === "input_select") return [
-      { icon: "mdi:chevron-left", action: "custom", custom: "select_prev" },
-      { icon: "mdi:chevron-right", action: "custom", custom: "select_next" }
-    ];
-    return [];
+    return getInlineButtons(domain);
   }
 
   _supportsMediaFeature(stateObj, feature) {
-    const supported = stateObj?.attributes?.supported_features;
-    if (!Number.isFinite(Number(supported))) return true;
-    return (Number(supported) & feature) !== 0;
+    return supportsMediaFeature(stateObj, feature);
   }
 
   _updateBtnState(btn, ctrl, h) {

--- a/tests/capability-helpers.test.mjs
+++ b/tests/capability-helpers.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { MEDIA_PLAYER_FEATURES, getSliderCapabilities, getInlineButtons, supportsMediaFeature } from "../src/lib/capabilities.js";
+
+test("slider capabilities use explicit availability and preserve domain conversions", () => {
+  const control = { entity: "light.room" };
+  assert.deepEqual(getSliderCapabilities("light", { state: "on", attributes: {} }, control, true), { supported: false });
+  assert.deepEqual(getSliderCapabilities("light", null, control, false), { supported: false });
+  assert.equal(getSliderCapabilities("light", { attributes: { brightness: 128 } }, control, false).value, 50);
+  const colorTemp = getSliderCapabilities("light", { attributes: { supported_color_modes: ["color_temp"], min_color_temp_kelvin: 2000, max_color_temp_kelvin: 6500, color_temp_kelvin: 4000 } }, { ...control, slider_mode: "color_temp" }, false);
+  assert.equal(colorTemp.action, "color_temp_kelvin");
+  assert.equal(colorTemp.min, 2000);
+  assert.equal(getSliderCapabilities("climate", { attributes: { temperature: 21 } }, control, false).step, 0.5);
+  assert.equal(getSliderCapabilities("fan", { attributes: { percentage_step: "25", percentage: 50 } }, control, false).step, 25);
+  assert.equal(getSliderCapabilities("media_player", { attributes: { volume_level: 0.42 } }, control, false).value, 42);
+  assert.equal(getSliderCapabilities("input_number", { state: "0", attributes: { min: 5, max: 10 } }, control, false).value, 5);
+});
+
+test("inline buttons and media feature masks retain their existing contracts", () => {
+  assert.equal(getInlineButtons("cover")[1].service, "cover.stop_cover");
+  assert.equal(getInlineButtons("media_player")[0].service, "media_player.media_previous_track");
+  assert.deepEqual(getInlineButtons("unsupported"), []);
+  assert.notEqual(getInlineButtons("light"), getInlineButtons("light"));
+  assert.equal(supportsMediaFeature({ attributes: {} }, MEDIA_PLAYER_FEATURES.PLAY), true);
+  assert.equal(supportsMediaFeature({ attributes: { supported_features: 0 } }, MEDIA_PLAYER_FEATURES.PLAY), false);
+  assert.equal(supportsMediaFeature({ attributes: { supported_features: MEDIA_PLAYER_FEATURES.PLAY | MEDIA_PLAYER_FEATURES.PAUSE } }, MEDIA_PLAYER_FEATURES.PAUSE), true);
+});


### PR DESCRIPTION
Part of #100. Extracts slider capabilities, inline-button definitions and media feature masks unchanged into lib/capabilities.js. The runtime supplies availability explicitly and retains event/service ownership. Direct tests cover domain conversions, color temperature, unavailable entities, feature flags and legacy fallbacks. Full build/check pass (95 tests), including control, media and accessibility artifact regressions. No YAML, layout, version or Drawer changes.