### PR TITLE
feat: Room Detail Drawer prototype and HA compatibility gate

### DIFF
--- a/dist/room-card.js
+++ b/dist/room-card.js
@@ -486,6 +486,8 @@ var isAlertSensorActive = (alertCfg, stateObj, normalize = normalizeAlertSensorC
 // src/i18n/translations.js
 var TRANSLATIONS = {
   en: {
+    room_details: "Room details",
+    drawer_prototype_note: "Preview: test opening, focus and nested dialogs. Room controls follow after this prototype is validated.",
     empty: "Empty",
     low: "Low",
     critical: "Critical",
@@ -806,6 +808,8 @@ var TRANSLATIONS = {
     a11y_select_option: "Select {name}"
   },
   de: {
+    room_details: "Raumdetails",
+    drawer_prototype_note: "Vorschau: Öffnen, Fokus und Unterdialoge testen. Die Raumsteuerung folgt nach Prüfung dieses Prototyps.",
     empty: "Leer",
     low: "Niedrig",
     critical: "Kritisch",
@@ -1126,6 +1130,8 @@ var TRANSLATIONS = {
     a11y_select_option: "{name} auswählen"
   },
   fr: {
+    room_details: "Détails de la pièce",
+    drawer_prototype_note: "Aperçu : testez l’ouverture, le focus et les boîtes de dialogue imbriquées. Les commandes suivront après validation de ce prototype.",
     empty: "Vide",
     low: "Faible",
     critical: "Critique",
@@ -1659,6 +1665,233 @@ var supportsMediaFeature = (stateObj, feature) => {
 var VERSION = "1.4.0";
 var EDITOR_DOM_REVISION = "6";
 
+// src/shared/dialog-coordinator.js
+var KEY = /* @__PURE__ */ Symbol.for("room-card.dialog-coordinator");
+var deepActiveElement = (root = document) => {
+  let active = root.activeElement;
+  while (active?.shadowRoot?.activeElement) active = active.shadowRoot.activeElement;
+  return active;
+};
+var focusableElements = (root) => {
+  const result = [];
+  const visit = (parent) => {
+    for (const node of parent.children || []) {
+      if (node.hidden || node.inert || node.getAttribute("aria-hidden") === "true") continue;
+      const style = getComputedStyle(node);
+      if (style.display === "none" || style.visibility === "hidden") continue;
+      if (node.tabIndex >= 0 && !node.disabled) result.push(node);
+      visit(node.shadowRoot || node);
+    }
+  };
+  visit(root);
+  return result;
+};
+var containsFocusTarget = (panel, target) => {
+  for (let node = target; node; node = node.parentNode || node.host) {
+    if (node === panel) return true;
+  }
+  return false;
+};
+var getDialogCoordinator = (doc = document) => {
+  if (doc[KEY]) return doc[KEY];
+  const stack = [];
+  let listening = false;
+  const top = () => stack.at(-1);
+  const focus = (target) => {
+    if (target?.isConnected) target.focus({ preventScroll: true });
+  };
+  const sync = () => {
+    for (const entry of stack) {
+      if (!entry.panel) continue;
+      const paused = entry !== top();
+      entry.panel.inert = paused;
+      entry.panel.setAttribute("aria-modal", String(!paused));
+      if (paused) entry.panel.setAttribute("aria-hidden", "true");
+      else entry.panel.removeAttribute("aria-hidden");
+    }
+    if (stack.length && !listening) {
+      doc.addEventListener("keydown", keydown, true);
+      doc.addEventListener("focusin", focusin, true);
+      listening = true;
+    } else if (!stack.length && listening) {
+      doc.removeEventListener("keydown", keydown, true);
+      doc.removeEventListener("focusin", focusin, true);
+      listening = false;
+    }
+  };
+  const keydown = (event) => {
+    const current = top();
+    if (!current?.panel) return;
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      current.close();
+    } else if (event.key === "Tab") {
+      const nodes = focusableElements(current.panel);
+      const index = nodes.indexOf(deepActiveElement(doc));
+      const next = event.shiftKey ? index <= 0 ? nodes.length - 1 : index - 1 : (index + 1) % nodes.length;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      focus(nodes[next] || current.panel);
+    }
+  };
+  const focusin = (event) => {
+    const current = top();
+    if (!current?.panel || event.composedPath().includes(current.panel)) return;
+    focus(current.initialFocus || current.panel);
+  };
+  const coordinator = {
+    push(entry) {
+      entry.restoreTarget ??= deepActiveElement(doc);
+      stack.push(entry);
+      sync();
+      focus(entry.initialFocus);
+      return entry;
+    },
+    remove(entry, restore = true) {
+      const index = stack.indexOf(entry);
+      if (index < 0) return;
+      const wasTop = entry === top();
+      stack.splice(index, 1);
+      sync();
+      if (restore && wasTop) {
+        const current = top();
+        const target = entry.restoreTarget;
+        if (!current || current.panel && target?.isConnected && containsFocusTarget(current.panel, target)) focus(target);
+        else if (current?.panel) focus(current.initialFocus || current.panel);
+      }
+    },
+    isTop: (entry) => top() === entry,
+    get size() {
+      return stack.length;
+    },
+    replaceDrawer() {
+      for (const entry of [...stack].reverse()) {
+        if (entry.kind !== "ha") entry.close(false);
+      }
+    }
+  };
+  doc[KEY] = coordinator;
+  return coordinator;
+};
+
+// src/shared/ha-dialog-adapter.js
+var observeHassDialogs = (coordinator, doc = document) => {
+  const entries = /* @__PURE__ */ new Map();
+  const opened = (event) => {
+    const path = event.composedPath();
+    if (!path.some((node) => ["HA-DIALOG", "HA-BOTTOM-SHEET", "HA-ADAPTIVE-DIALOG"].includes(node.tagName))) return;
+    const owner = path.find((node) => node.tagName?.startsWith("HA-") && typeof node.closeDialog === "function");
+    if (!owner || entries.has(owner)) return;
+    const entry = { kind: "ha", restoreTarget: deepActiveElement(doc) };
+    entries.set(owner, entry);
+    coordinator.push(entry);
+  };
+  const closed = (event) => {
+    for (const [owner, entry] of entries) {
+      if (event.detail?.dialog !== owner.localName || !event.composedPath().includes(owner)) continue;
+      entries.delete(owner);
+      queueMicrotask(() => coordinator.remove(entry));
+    }
+  };
+  doc.addEventListener("opened", opened, true);
+  doc.addEventListener("dialog-closed", closed, true);
+  return () => {
+    doc.removeEventListener("opened", opened, true);
+    doc.removeEventListener("dialog-closed", closed, true);
+    for (const entry of entries.values()) coordinator.remove(entry, false);
+    entries.clear();
+  };
+};
+
+// src/card/detail-drawer.js
+var createDetailDrawer = ({ title, closeLabel, trigger, onClose }) => {
+  const coordinator = getDialogCoordinator();
+  coordinator.replaceDrawer();
+  const host = document.createElement("div");
+  host.dataset.roomCardDrawer = "";
+  const root = host.attachShadow({ mode: "open" });
+  root.innerHTML = `
+    <style>
+      :host { position:fixed; inset:0; z-index:5; color:var(--primary-text-color,#212121); font-family:var(--paper-font-body1_-_font-family, sans-serif); }
+      * { box-sizing:border-box; }
+      .backdrop { position:absolute; inset:0; background:rgba(0,0,0,.48); }
+      .panel { position:absolute; inset:0 0 0 auto; display:flex; flex-direction:column; width:480px; max-width:100%; background:var(--ha-card-background,var(--card-background-color,#fff)); box-shadow:-6px 0 30px rgba(0,0,0,.25); animation:enter .18s ease-out; }
+      header { flex:none; display:flex; align-items:center; gap:16px; padding:calc(16px + env(safe-area-inset-top,0px)) calc(16px + env(safe-area-inset-right,0px)) 16px calc(16px + env(safe-area-inset-left,0px)); border-bottom:1px solid var(--divider-color,#ddd); }
+      h2 { flex:1; margin:0; font-size:20px; overflow-wrap:anywhere; }
+      button { min-width:44px; min-height:44px; padding:10px; border:1px solid var(--divider-color,#ddd); border-radius:12px; background:transparent; color:inherit; font:inherit; cursor:pointer; }
+      button:disabled { opacity:.5; cursor:default; }
+      button:focus-visible { outline:2px solid var(--primary-color,#03a9f4); outline-offset:2px; }
+      .content { flex:1; min-height:0; overflow:auto; overscroll-behavior:contain; padding:16px calc(16px + env(safe-area-inset-right,0px)) calc(16px + env(safe-area-inset-bottom,0px)) calc(16px + env(safe-area-inset-left,0px)); }
+      .prototype-actions { display:flex; flex-wrap:wrap; gap:10px; }
+      .prototype-note { color:var(--secondary-text-color,#666); }
+      @keyframes enter { from { opacity:0; transform:translateX(24px); } to { opacity:1; transform:none; } }
+      @media (max-width:767px) {
+        .panel { inset:auto 0 0; width:100%; max-height:90vh; max-height:90dvh; border-radius:20px 20px 0 0; animation-name:enter-bottom; }
+        @keyframes enter-bottom { from { opacity:0; transform:translateY(24px); } to { opacity:1; transform:none; } }
+      }
+      @media (prefers-reduced-motion:reduce) { .panel { animation:none; } }
+    </style>
+    <div class="backdrop" aria-hidden="true"></div>
+    <section class="panel" role="dialog" aria-modal="true" aria-labelledby="drawer-title" tabindex="-1">
+      <header><h2 id="drawer-title"></h2><button type="button" class="close">✕</button></header>
+      <div class="content"></div>
+    </section>`;
+  const panel = root.querySelector(".panel");
+  const heading = root.querySelector("h2");
+  const closeButton = root.querySelector(".close");
+  const content = root.querySelector(".content");
+  heading.textContent = title;
+  closeButton.setAttribute("aria-label", closeLabel);
+  let closed = false;
+  const close = (restore = true) => {
+    if (closed) return;
+    closed = true;
+    stopHass();
+    window.removeEventListener("location-changed", navigation);
+    window.removeEventListener("popstate", navigation);
+    window.removeEventListener("hashchange", navigation);
+    onClose?.();
+    host.remove();
+    coordinator.remove(entry, restore);
+  };
+  const route = window.location.pathname + window.location.hash;
+  const navigation = () => {
+    if (window.location.pathname + window.location.hash !== route) close(false);
+  };
+  closeButton.addEventListener("click", () => {
+    if (coordinator.isTop(entry)) close();
+  });
+  root.querySelector(".backdrop").addEventListener("click", () => {
+    if (coordinator.isTop(entry)) close();
+  });
+  for (const name of ["click", "pointerdown", "pointerup", "keydown", "keyup"]) host.addEventListener(name, (event) => event.stopPropagation());
+  document.body.append(host);
+  const entry = { kind: "drawer", panel, initialFocus: closeButton, restoreTarget: trigger, close };
+  const stopHass = observeHassDialogs(coordinator);
+  coordinator.push(entry);
+  window.addEventListener("location-changed", navigation);
+  window.addEventListener("popstate", navigation);
+  window.addEventListener("hashchange", navigation);
+  return {
+    host,
+    root,
+    panel,
+    content,
+    close,
+    update({ title: nextTitle, closeLabel: nextCloseLabel, themeSource }) {
+      heading.textContent = nextTitle;
+      closeButton.setAttribute("aria-label", nextCloseLabel);
+      const style = getComputedStyle(themeSource);
+      host.style.cssText = "";
+      for (let i = 0; i < style.length; i++) {
+        const name = style.item(i);
+        if (name.startsWith("--")) host.style.setProperty(name, style.getPropertyValue(name));
+      }
+    }
+  };
+};
+
 // src/shared/presentation.js
 var IMAGE_UPLOAD_LIMITS = Object.freeze({
   maxSourceBytes: 20 * 1024 * 1024,
@@ -1979,6 +2212,7 @@ var OneLineRoomCard = class extends HTMLElement {
     }
   }
   disconnectedCallback() {
+    this._detailDrawer?.close(false);
     this._closeDialog?.();
     this._closeDialog = null;
     this._sparklineDialogRequest += 1;
@@ -2022,7 +2256,10 @@ var OneLineRoomCard = class extends HTMLElement {
   set hass(hass) {
     this._hass = hass;
     if (!this.content) this.render();
-    if (!this._shouldUpdateFromHass(hass)) return;
+    if (!this._shouldUpdateFromHass(hass)) {
+      if (this._detailDrawer) this._syncDetailDrawer();
+      return;
+    }
     this._updateContentState();
     this._captureStateSnapshot(hass);
   }
@@ -2035,6 +2272,7 @@ var OneLineRoomCard = class extends HTMLElement {
   setConfig(config) {
     const prevKey = this._collapseKey;
     this.config = config;
+    if (config.detail_drawer?.enabled !== true) this._detailDrawer?.close();
     this._sparklineRefreshSec = clampNum(config.sparkline_refresh, 60, 3600, 300);
     this._collapseKey = `oneline-room-card-collapsed:${this._getCollapseUniqueId(config)}`;
     if (this._collapseKey !== prevKey) {
@@ -2538,6 +2776,9 @@ var OneLineRoomCard = class extends HTMLElement {
         .collapse-btn { position: absolute; bottom: 8px; right: 8px; z-index: 3; width: 28px; height: 28px; padding: 0; border: 0; border-radius: 50%; background: rgba(0,0,0,0.38); display: none; align-items: center; justify-content: center; cursor: pointer; }
         .collapse-btn ha-icon { --mdc-icon-size: 18px; color: white; transition: transform 0.35s ease; }
         .collapse-btn.open ha-icon { transform: rotate(180deg); }
+        .details-btn { position:absolute; top:8px; right:8px; z-index:3; min-width:44px; min-height:44px; padding:8px 12px; border:0; border-radius:12px; background:rgba(0,0,0,.55); color:white; font:inherit; cursor:pointer; }
+        .details-btn[hidden] { display:none; }
+        .details-btn:focus-visible { outline:2px solid var(--primary-color,#03a9f4); outline-offset:2px; }
         .btn-chips { display: flex; flex-direction: row; flex-wrap: wrap; gap: 2px; align-items: center; max-width: 100%; margin-top: 2px; }
         .btn-chips.chips-top { margin-top: 0; margin-bottom: 2px; }
         .btn.has-inline-ctrl .btn-chips { margin-top: 4px; padding-bottom: 2px; }
@@ -2574,6 +2815,7 @@ var OneLineRoomCard = class extends HTMLElement {
             </div>
             <div id="chips" class="chips"></div>
             <button id="collapse-btn" class="collapse-btn" type="button"><ha-icon icon="mdi:chevron-down"></ha-icon></button>
+            <button id="details-btn" class="details-btn" type="button" hidden></button>
           </div>
           <div id="info-bar" class="info-bar"></div>
           <div id="room-modes" class="room-modes" role="group" aria-label="${getTranslation(this._hass, "room_modes")}"></div>
@@ -2584,6 +2826,12 @@ var OneLineRoomCard = class extends HTMLElement {
     this.controls = this.shadowRoot.getElementById("ctrls");
     const imageBox = this.shadowRoot.querySelector(".img-box");
     if (imageBox) this._attachHeaderActions(imageBox);
+    const detailsButton = this.shadowRoot.getElementById("details-btn");
+    for (const eventName of ["pointerdown", "pointerup", "pointercancel", "keydown", "keyup"]) detailsButton.addEventListener(eventName, (event) => event.stopPropagation());
+    detailsButton.addEventListener("click", (event) => {
+      event.stopPropagation();
+      this._showDetailDrawer(detailsButton);
+    });
     const collapseButton = this.shadowRoot.getElementById("collapse-btn");
     if (collapseButton) {
       ["pointerdown", "pointerup", "pointercancel"].forEach((eventName) => {
@@ -2735,46 +2983,29 @@ var OneLineRoomCard = class extends HTMLElement {
   }
   _openDialog(container, panel, closeButton, previouslyFocused, onClose) {
     this._closeDialog?.(false);
-    this.shadowRoot.appendChild(container);
+    const coordinator = getDialogCoordinator();
+    (this._detailDrawer?.root || this.shadowRoot).appendChild(container);
     let closing = false;
     const closeDialog = (restoreFocus = true) => {
       if (closing) return;
       closing = true;
-      document.removeEventListener("keydown", handleKeydown);
       container.remove();
       onClose?.();
       if (this._closeDialog === closeDialog) this._closeDialog = null;
-      if (restoreFocus && previouslyFocused?.isConnected && typeof previouslyFocused.focus === "function") {
-        const focusTimer = setTimeout(() => {
-          this._activeTimers.delete(focusTimer);
-          previouslyFocused.focus();
-        }, 0);
-        this._activeTimers.add(focusTimer);
-      }
+      coordinator.remove(entry, restoreFocus);
     };
-    const handleKeydown = (event) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        closeDialog();
-        return;
-      }
-      if (event.key !== "Tab") return;
-      const focusable = Array.from(panel.querySelectorAll("button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])"));
-      if (focusable.length === 0) return;
-      const currentIndex = focusable.indexOf(this.shadowRoot.activeElement);
-      const nextIndex = event.shiftKey ? currentIndex <= 0 ? focusable.length - 1 : currentIndex - 1 : currentIndex < 0 || currentIndex === focusable.length - 1 ? 0 : currentIndex + 1;
-      event.preventDefault();
-      focusable[nextIndex].focus();
-    };
+    const entry = { panel, initialFocus: closeButton, restoreTarget: previouslyFocused, close: closeDialog };
     this._closeDialog = closeDialog;
-    closeButton.addEventListener("click", closeDialog);
-    container.querySelector("[data-dialog-backdrop]")?.addEventListener("click", closeDialog);
-    document.addEventListener("keydown", handleKeydown);
-    closeButton.focus();
+    const dismiss = () => {
+      if (coordinator.isTop(entry)) closeDialog();
+    };
+    closeButton.addEventListener("click", dismiss);
+    container.querySelector("[data-dialog-backdrop]")?.addEventListener("click", dismiss);
+    coordinator.push(entry);
     return closeDialog;
   }
   _showAlertDialog(alerts, dialogTitle = getTranslation(this._hass, "active_alerts"), accentColor = "#FF5252") {
-    const previouslyFocused = this.shadowRoot.activeElement || document.activeElement;
+    const previouslyFocused = deepActiveElement();
     const container = document.createElement("div");
     container.className = "alert-dialog-container";
     const backdrop = document.createElement("div");
@@ -2846,9 +3077,10 @@ var OneLineRoomCard = class extends HTMLElement {
       row.addEventListener("click", () => {
         const entityId = row.dataset.entity;
         if (entityId && this._hass) {
+          if (this._detailDrawer) row.focus({ preventScroll: true });
           this._fireAction("tap", { entity: entityId, tap_action: { action: "more-info" } });
         }
-        closeDialog();
+        if (!this._detailDrawer) closeDialog();
       });
     });
   }
@@ -2995,6 +3227,7 @@ var OneLineRoomCard = class extends HTMLElement {
   }
   _updateContentState() {
     if (!this.config || !this._hass || !this.content) return;
+    this._syncDetailDrawer();
     const h = this._hass, c = this.config;
     const effectiveEntity = c.entity;
     const effectiveTempSensor = c.temp_sensor;
@@ -4503,6 +4736,10 @@ var OneLineRoomCard = class extends HTMLElement {
     node.addEventListener("blur", cancel);
   }
   _fireAction(type, config) {
+    if (config?.[`${type}_action`]?.action === "room-details") {
+      this._showDetailDrawer(deepActiveElement());
+      return;
+    }
     if (config.entity && this._isEntityUnavailable(config.entity)) return;
     const eventDetail = buildHassActionDetail(type, config, this._hass);
     this.dispatchEvent(new CustomEvent("hass-action", { bubbles: true, composed: true, detail: eventDetail }));
@@ -4525,6 +4762,73 @@ var OneLineRoomCard = class extends HTMLElement {
   }
   static getConfigElement() {
     return document.createElement("oneline-room-card-editor");
+  }
+  _showDetailDrawer(trigger) {
+    if (!this.isConnected || this.config?.detail_drawer?.enabled !== true || this._detailDrawer) return;
+    this._closeDialog?.(false);
+    const t = (key) => getTranslation(this._hass, key);
+    this._detailDrawer = createDetailDrawer({
+      title: this.config.detail_drawer.title || this.config.name || t("room_details"),
+      closeLabel: t("a11y_close"),
+      trigger,
+      onClose: () => {
+        this._closeDialog?.(false);
+        this._detailDrawer = null;
+        this.shadowRoot.getElementById("details-btn")?.setAttribute("aria-expanded", "false");
+      }
+    });
+    const note = document.createElement("p");
+    note.className = "prototype-note";
+    const actions = document.createElement("div");
+    actions.className = "prototype-actions";
+    for (const [name, action] of [
+      ["more", (event) => {
+        event.currentTarget.focus({ preventScroll: true });
+        this._fireAction("tap", { entity: this.config.entity, tap_action: { action: "more-info" } });
+      }],
+      ["history", (event) => this._showSparklineDialog(this._drawerHistoryEntity(), 24, event.currentTarget)],
+      ["status", () => this._showAlertDialog(this._drawerStatusRows(), t("status_groups"))]
+    ]) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.dataset.drawerAction = name;
+      button.addEventListener("click", action);
+      actions.append(button);
+    }
+    this._detailDrawer.content.append(note, actions);
+    this._syncDetailDrawer();
+  }
+  _drawerHistoryEntity() {
+    return (this.config?.controls || []).find((ctrl) => ctrl.entity?.startsWith("sensor.") && ctrl.show_sparkline === true)?.entity || (this.config?.temp_sensor?.startsWith("sensor.") ? this.config.temp_sensor : "");
+  }
+  _drawerStatusRows() {
+    return (this.config?.status_groups || []).flatMap((group) => {
+      const result = getStatusGroupResult(group, this._hass);
+      return result.visible ? result.contributors : [];
+    });
+  }
+  _syncDetailDrawer() {
+    const t = (key) => getTranslation(this._hass, key);
+    const enabled = this.config?.detail_drawer?.enabled === true;
+    const button = this.shadowRoot.getElementById("details-btn");
+    if (button) {
+      button.hidden = !enabled;
+      button.textContent = t("room_details");
+      button.setAttribute("aria-haspopup", "dialog");
+      button.setAttribute("aria-expanded", String(!!this._detailDrawer));
+    }
+    if (!this._detailDrawer) return;
+    this._detailDrawer.update({ title: this.config.detail_drawer.title || this.config.name || t("room_details"), closeLabel: t("a11y_close"), themeSource: this });
+    this._detailDrawer.content.querySelector(".prototype-note").textContent = t("drawer_prototype_note");
+    const more = this._detailDrawer.content.querySelector('[data-drawer-action="more"]');
+    more.textContent = t("act_more");
+    more.disabled = !this.config.entity || !this._hass?.states?.[this.config.entity] || this._isEntityUnavailable(this.config.entity);
+    const history2 = this._detailDrawer.content.querySelector('[data-drawer-action="history"]');
+    history2.textContent = t("sparkline_detail_title");
+    history2.disabled = !this._drawerHistoryEntity() || !this._hass?.states?.[this._drawerHistoryEntity()];
+    const status = this._detailDrawer.content.querySelector('[data-drawer-action="status"]');
+    status.textContent = t("status_groups");
+    status.disabled = this._drawerStatusRows().length === 0;
   }
 };
 

--- a/docs/room-detail-drawer.md
+++ b/docs/room-detail-drawer.md
@@ -1,0 +1,108 @@
+# Room Detail Drawer — prototype decision
+
+Target: v1.5.0, issue #127. The source modularization passed its manual gate on
+2026-09-05 against commit `5756362111f9ce8952eab4871cd087c51302bc21`.
+The user confirmed editor/save, existing controls, mobile and light/dark checks.
+The browser confirmed the pinned bundle URL and loaded header images.
+The modularized baseline has 98 passing automated tests and green PR CI.
+No quantitative cold-load timing was recorded; no performance gain is claimed.
+
+## Primitive and ownership
+
+The prototype uses a body-mounted, fixed-position host with its own shadow root.
+It is outside every card layout container, so card transforms and overflow
+cannot clip it. It is a 480px right sidebar at 768px and wider; smaller viewports
+use a full-width bottom sheet capped at 90dvh. The title/close header remains
+fixed while the content scrolls. CSS covers safe areas and reduced motion.
+Theme custom properties are copied from the owner when it updates.
+
+The card owns configuration, HA state and the drawer handle. The host only
+owns its DOM and route listeners. The shared dialog coordinator owns modal
+ordering and focus; it stores no HA state. It pauses lower panels and handles
+only the top modal's Tab, Escape and backdrop. All listeners disappear after
+the last modal closes. A document-scoped symbol also coordinates duplicate
+bundle evaluations. Only one RoomCard drawer can be open at once.
+
+The prototype does not clone or move active controls. Full integration will
+create independent DOM nodes through shared renderers, with the original
+`controls` list as the only configuration source. `display_in` handling and
+the visual editor section belong to the integration PR after this gate.
+
+## Child dialogs and cleanup
+
+The existing history and status dialogs share the coordinator and render in
+the drawer's shadow root when the drawer owns them. Closing a child restores
+the triggering button without resetting the drawer scroll position. Opening
+the drawer itself does not fetch history or create polling timers.
+
+`ha-dialog-adapter.js` observes confirmed HA `opened` events from dialog
+primitives and matching owner `dialog-closed` events. A dispatched request
+alone never suspends the drawer. HA owns focus and Escape while its dialog is
+open. Events from unrelated owners cannot complete the handoff. Cleanup removes
+the adapter, including pending handoffs, when the drawer is removed.
+
+Official HA contracts inspected for this adapter:
+
+- [ha-dialog](https://github.com/home-assistant/frontend/blob/dev/src/components/ha-dialog.ts)
+- [ha-adaptive-dialog](https://github.com/home-assistant/frontend/blob/dev/src/components/ha-adaptive-dialog.ts)
+- [more-info owner](https://github.com/home-assistant/frontend/blob/dev/src/dialogs/more-info/ha-more-info-dialog.ts)
+- [dialog manager](https://github.com/home-assistant/frontend/blob/dev/src/dialogs/make-dialog-manager.ts)
+
+Route changes, owner disconnection, disabling the option, or opening another
+card's drawer close the previous drawer. HA history entries on the same route
+do not close it. Live configuration updates keep the current nodes and scroll
+position; the editor's existing deferred save remains the configuration boundary.
+
+## Decisions and alternatives
+
+- An in-card overlay would inherit clipping and containing blocks: rejected.
+- A recursive RoomCard would duplicate lifecycle and polling: rejected.
+- Native HA layout primitives vary by frontend version and do not provide the
+  specified 768px/480px layout contract: a custom host was selected.
+- A second control list would duplicate settings and ordering: rejected.
+- Monkey-patching HA methods or polling for dialog visibility was rejected in
+  favor of an isolated event adapter that can be verified on the actual HA build.
+
+## Test the prototype (release remains blocked)
+
+Local browser fixture checks on 2026-09-05 passed: the desktop sidebar rendered
+outside a transformed, clipped card container; at 390×844 CSS pixels the bottom
+sheet measured 390px wide and ended at the viewport bottom. Light/dark rendering,
+history opening and Escape focus restoration were checked, with no browser error
+logs. This fixture uses simulated data, not the actual HA dialog implementation.
+It can be served from the repository root and opened at
+`tests/fixtures/drawer-prototype.html`. The automated suite passes 106 tests.
+
+Add this to one existing card's YAML after loading the pinned prototype bundle:
+
+```yaml
+detail_drawer:
+  enabled: true
+  title: Wohnzimmer
+```
+
+The new **Room details / Raumdetails** header button opens the prototype.
+Existing controls stay on the card during this phase. Optional explicit
+`tap_action`, `hold_action` and `double_tap_action` can use `action: room-details`.
+The preview contains three diagnostic entry points:
+
+- HA details use the card's `entity` and disable when missing/unavailable.
+- History uses a configured sensor sparkline or `temp_sensor`.
+- Status uses contributors from configured `status_groups`.
+
+Before full control integration, manually verify on the actual HA installation:
+
+1. Desktop sidebar (480px), mobile bottom sheet (90dvh), light/dark, safe-area
+   edges, fixed close header and content scroll.
+2. Repeated opening, closing, Tab/Shift+Tab, Escape, backdrop and opener focus.
+3. HA more-info on top; Escape closes only HA; focus and scroll return. Repeat
+   with status → HA details and history. Verify HA's lazy cold first opening.
+4. Open a second card's drawer; navigate away; disable; remove the owner preview.
+   No orphan host, stale focus trap or background requests should remain.
+5. Open from an editor preview and verify its interaction with HA's own editor
+   dialog and layering. This is a manual compatibility gate, not yet certified.
+
+Automated DOM tests verify event contracts and cleanup but cannot certify HA's
+native top-layer implementation, physical mobile interactions or theme visuals.
+Do not merge this prototype as a finished feature, close #127 or publish v1.5.0
+before the manual prototype gate and full integration have passed.

--- a/docs/room-detail-drawer.md
+++ b/docs/room-detail-drawer.md
@@ -65,6 +65,12 @@ position; the editor's existing deferred save remains the configuration boundary
 
 ## Test the prototype (release remains blocked)
 
+The owner confirmed the actual HA prototype gate on 2026-09-05 against
+`3bdbd2c780a39afed845970be0e68d61f8d4fe65`: HA details/history/status with
+Escape returning to the drawer, mobile use and opening from the editor preview
+worked. This permits control integration; it does not certify the not-yet-built
+full feature or authorize skipping its final manual release gate.
+
 Local browser fixture checks on 2026-09-05 passed: the desktop sidebar rendered
 outside a transformed, clipped card container; at 390×844 CSS pixels the bottom
 sheet measured 390px wide and ended at the viewport bottom. Light/dark rendering,

--- a/src/card/detail-drawer.js
+++ b/src/card/detail-drawer.js
@@ -1,0 +1,83 @@
+import { getDialogCoordinator } from "../shared/dialog-coordinator.js";
+import { observeHassDialogs } from "../shared/ha-dialog-adapter.js";
+
+export const createDetailDrawer = ({ title, closeLabel, trigger, onClose }) => {
+  const coordinator = getDialogCoordinator();
+  coordinator.replaceDrawer();
+  const host = document.createElement("div");
+  host.dataset.roomCardDrawer = "";
+  const root = host.attachShadow({ mode: "open" });
+  root.innerHTML = `
+    <style>
+      :host { position:fixed; inset:0; z-index:5; color:var(--primary-text-color,#212121); font-family:var(--paper-font-body1_-_font-family, sans-serif); }
+      * { box-sizing:border-box; }
+      .backdrop { position:absolute; inset:0; background:rgba(0,0,0,.48); }
+      .panel { position:absolute; inset:0 0 0 auto; display:flex; flex-direction:column; width:480px; max-width:100%; background:var(--ha-card-background,var(--card-background-color,#fff)); box-shadow:-6px 0 30px rgba(0,0,0,.25); animation:enter .18s ease-out; }
+      header { flex:none; display:flex; align-items:center; gap:16px; padding:calc(16px + env(safe-area-inset-top,0px)) calc(16px + env(safe-area-inset-right,0px)) 16px calc(16px + env(safe-area-inset-left,0px)); border-bottom:1px solid var(--divider-color,#ddd); }
+      h2 { flex:1; margin:0; font-size:20px; overflow-wrap:anywhere; }
+      button { min-width:44px; min-height:44px; padding:10px; border:1px solid var(--divider-color,#ddd); border-radius:12px; background:transparent; color:inherit; font:inherit; cursor:pointer; }
+      button:disabled { opacity:.5; cursor:default; }
+      button:focus-visible { outline:2px solid var(--primary-color,#03a9f4); outline-offset:2px; }
+      .content { flex:1; min-height:0; overflow:auto; overscroll-behavior:contain; padding:16px calc(16px + env(safe-area-inset-right,0px)) calc(16px + env(safe-area-inset-bottom,0px)) calc(16px + env(safe-area-inset-left,0px)); }
+      .prototype-actions { display:flex; flex-wrap:wrap; gap:10px; }
+      .prototype-note { color:var(--secondary-text-color,#666); }
+      @keyframes enter { from { opacity:0; transform:translateX(24px); } to { opacity:1; transform:none; } }
+      @media (max-width:767px) {
+        .panel { inset:auto 0 0; width:100%; max-height:90vh; max-height:90dvh; border-radius:20px 20px 0 0; animation-name:enter-bottom; }
+        @keyframes enter-bottom { from { opacity:0; transform:translateY(24px); } to { opacity:1; transform:none; } }
+      }
+      @media (prefers-reduced-motion:reduce) { .panel { animation:none; } }
+    </style>
+    <div class="backdrop" aria-hidden="true"></div>
+    <section class="panel" role="dialog" aria-modal="true" aria-labelledby="drawer-title" tabindex="-1">
+      <header><h2 id="drawer-title"></h2><button type="button" class="close">✕</button></header>
+      <div class="content"></div>
+    </section>`;
+  const panel = root.querySelector(".panel");
+  const heading = root.querySelector("h2");
+  const closeButton = root.querySelector(".close");
+  const content = root.querySelector(".content");
+  heading.textContent = title;
+  closeButton.setAttribute("aria-label", closeLabel);
+  let closed = false;
+  const close = (restore = true) => {
+    if (closed) return;
+    closed = true;
+    stopHass();
+    window.removeEventListener("location-changed", navigation);
+    window.removeEventListener("popstate", navigation);
+    window.removeEventListener("hashchange", navigation);
+    onClose?.();
+    host.remove();
+    coordinator.remove(entry, restore);
+  };
+  // HA more-info adds history entries too. Only a changed dashboard route
+  // closes the owner drawer; dismissing an HA child must return to the drawer.
+  const route = window.location.pathname + window.location.hash;
+  const navigation = () => {
+    if (window.location.pathname + window.location.hash !== route) close(false);
+  };
+  closeButton.addEventListener("click", () => { if (coordinator.isTop(entry)) close(); });
+  root.querySelector(".backdrop").addEventListener("click", () => { if (coordinator.isTop(entry)) close(); });
+  for (const name of ["click", "pointerdown", "pointerup", "keydown", "keyup"]) host.addEventListener(name, event => event.stopPropagation());
+  document.body.append(host);
+  const entry = { kind: "drawer", panel, initialFocus: closeButton, restoreTarget: trigger, close };
+  const stopHass = observeHassDialogs(coordinator);
+  coordinator.push(entry);
+  window.addEventListener("location-changed", navigation);
+  window.addEventListener("popstate", navigation);
+  window.addEventListener("hashchange", navigation);
+  return {
+    host, root, panel, content, close,
+    update({ title: nextTitle, closeLabel: nextCloseLabel, themeSource }) {
+      heading.textContent = nextTitle;
+      closeButton.setAttribute("aria-label", nextCloseLabel);
+      const style = getComputedStyle(themeSource);
+      host.style.cssText = "";
+      for (let i = 0; i < style.length; i++) {
+        const name = style.item(i);
+        if (name.startsWith("--")) host.style.setProperty(name, style.getPropertyValue(name));
+      }
+    }
+  };
+};

--- a/src/card/room-card.js
+++ b/src/card/room-card.js
@@ -10,6 +10,8 @@ import { buildHassActionDetail } from "../lib/actions.js";
 import { SHARED_SPARKLINE_CACHE, SHARED_SPARKLINE_PENDING, normalizeSparklineSamples, getSparklineStats, pruneSharedSparklineCache, fetchHistorySamples } from "../lib/history.js";
 import { MEDIA_PLAYER_FEATURES, getSliderCapabilities, getInlineButtons, supportsMediaFeature } from "../lib/capabilities.js";
 import { VERSION, EDITOR_DOM_REVISION } from "../version.js";
+import { createDetailDrawer } from "./detail-drawer.js";
+import { deepActiveElement, getDialogCoordinator } from "../shared/dialog-coordinator.js";
 import { IMAGE_UPLOAD_LIMITS, parseImagePosition, validateImageUpload, ROOM_IMAGE_PRESETS, ROOM_IMAGE_PRESET_MAP, getRoomImagePresetUrl, resolveRoomImageUrl, evaluateAdaptiveImageConditions, resolveAdaptiveRoomImage, getStatusGroupResult, isHeaderManualColorEnabled, resolveLabelPosition, setAlignmentClass, applyLabelPosition, evalTemplateString, resolveTemplateCtrl, resolveSubChipPresentations, TEMPLATE_VALUE_KEYS, getTemplateEntityDependencies, templateNeedsEveryHassUpdate, formatLastChanged } from "../shared/presentation.js";
 
 
@@ -51,6 +53,7 @@ class OneLineRoomCard extends HTMLElement {
   }
 
   disconnectedCallback() {
+    this._detailDrawer?.close(false);
     this._closeDialog?.();
     this._closeDialog = null;
     this._sparklineDialogRequest += 1;
@@ -97,7 +100,10 @@ class OneLineRoomCard extends HTMLElement {
   set hass(hass) {
     this._hass = hass;
     if (!this.content) this.render();
-    if (!this._shouldUpdateFromHass(hass)) return;
+    if (!this._shouldUpdateFromHass(hass)) {
+      if (this._detailDrawer) this._syncDetailDrawer();
+      return;
+    }
     this._updateContentState();
     this._captureStateSnapshot(hass);
   }
@@ -112,6 +118,7 @@ class OneLineRoomCard extends HTMLElement {
   setConfig(config) {
     const prevKey = this._collapseKey;
     this.config = config;
+    if (config.detail_drawer?.enabled !== true) this._detailDrawer?.close();
     this._sparklineRefreshSec = clampNum(config.sparkline_refresh, 60, 3600, 300);
     this._collapseKey = `oneline-room-card-collapsed:${this._getCollapseUniqueId(config)}`;
     if (this._collapseKey !== prevKey) {
@@ -634,6 +641,9 @@ class OneLineRoomCard extends HTMLElement {
         .collapse-btn { position: absolute; bottom: 8px; right: 8px; z-index: 3; width: 28px; height: 28px; padding: 0; border: 0; border-radius: 50%; background: rgba(0,0,0,0.38); display: none; align-items: center; justify-content: center; cursor: pointer; }
         .collapse-btn ha-icon { --mdc-icon-size: 18px; color: white; transition: transform 0.35s ease; }
         .collapse-btn.open ha-icon { transform: rotate(180deg); }
+        .details-btn { position:absolute; top:8px; right:8px; z-index:3; min-width:44px; min-height:44px; padding:8px 12px; border:0; border-radius:12px; background:rgba(0,0,0,.55); color:white; font:inherit; cursor:pointer; }
+        .details-btn[hidden] { display:none; }
+        .details-btn:focus-visible { outline:2px solid var(--primary-color,#03a9f4); outline-offset:2px; }
         .btn-chips { display: flex; flex-direction: row; flex-wrap: wrap; gap: 2px; align-items: center; max-width: 100%; margin-top: 2px; }
         .btn-chips.chips-top { margin-top: 0; margin-bottom: 2px; }
         .btn.has-inline-ctrl .btn-chips { margin-top: 4px; padding-bottom: 2px; }
@@ -670,6 +680,7 @@ class OneLineRoomCard extends HTMLElement {
             </div>
             <div id="chips" class="chips"></div>
             <button id="collapse-btn" class="collapse-btn" type="button"><ha-icon icon="mdi:chevron-down"></ha-icon></button>
+            <button id="details-btn" class="details-btn" type="button" hidden></button>
           </div>
           <div id="info-bar" class="info-bar"></div>
           <div id="room-modes" class="room-modes" role="group" aria-label="${getTranslation(this._hass, "room_modes")}"></div>
@@ -681,6 +692,12 @@ class OneLineRoomCard extends HTMLElement {
     this.controls = this.shadowRoot.getElementById("ctrls");
     const imageBox = this.shadowRoot.querySelector(".img-box");
     if (imageBox) this._attachHeaderActions(imageBox);
+    const detailsButton = this.shadowRoot.getElementById("details-btn");
+    for (const eventName of ["pointerdown", "pointerup", "pointercancel", "keydown", "keyup"]) detailsButton.addEventListener(eventName, event => event.stopPropagation());
+    detailsButton.addEventListener("click", event => {
+      event.stopPropagation();
+      this._showDetailDrawer(detailsButton);
+    });
     const collapseButton = this.shadowRoot.getElementById("collapse-btn");
     if (collapseButton) {
       ["pointerdown", "pointerup", "pointercancel"].forEach((eventName) => {
@@ -844,49 +861,28 @@ class OneLineRoomCard extends HTMLElement {
 
   _openDialog(container, panel, closeButton, previouslyFocused, onClose) {
     this._closeDialog?.(false);
-    this.shadowRoot.appendChild(container);
+    const coordinator = getDialogCoordinator();
+    (this._detailDrawer?.root || this.shadowRoot).appendChild(container);
     let closing = false;
     const closeDialog = (restoreFocus = true) => {
       if (closing) return;
       closing = true;
-      document.removeEventListener("keydown", handleKeydown);
       container.remove();
       onClose?.();
       if (this._closeDialog === closeDialog) this._closeDialog = null;
-      if (restoreFocus && previouslyFocused?.isConnected && typeof previouslyFocused.focus === "function") {
-        const focusTimer = setTimeout(() => {
-          this._activeTimers.delete(focusTimer);
-          previouslyFocused.focus();
-        }, 0);
-        this._activeTimers.add(focusTimer);
-      }
+      coordinator.remove(entry, restoreFocus);
     };
-    const handleKeydown = (event) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        closeDialog();
-        return;
-      }
-      if (event.key !== "Tab") return;
-      const focusable = Array.from(panel.querySelectorAll("button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])"));
-      if (focusable.length === 0) return;
-      const currentIndex = focusable.indexOf(this.shadowRoot.activeElement);
-      const nextIndex = event.shiftKey
-        ? (currentIndex <= 0 ? focusable.length - 1 : currentIndex - 1)
-        : (currentIndex < 0 || currentIndex === focusable.length - 1 ? 0 : currentIndex + 1);
-      event.preventDefault();
-      focusable[nextIndex].focus();
-    };
+    const entry = { panel, initialFocus: closeButton, restoreTarget: previouslyFocused, close: closeDialog };
     this._closeDialog = closeDialog;
-    closeButton.addEventListener("click", closeDialog);
-    container.querySelector("[data-dialog-backdrop]")?.addEventListener("click", closeDialog);
-    document.addEventListener("keydown", handleKeydown);
-    closeButton.focus();
+    const dismiss = () => { if (coordinator.isTop(entry)) closeDialog(); };
+    closeButton.addEventListener("click", dismiss);
+    container.querySelector("[data-dialog-backdrop]")?.addEventListener("click", dismiss);
+    coordinator.push(entry);
     return closeDialog;
   }
 
   _showAlertDialog(alerts, dialogTitle = getTranslation(this._hass, "active_alerts"), accentColor = "#FF5252") {
-    const previouslyFocused = this.shadowRoot.activeElement || document.activeElement;
+    const previouslyFocused = deepActiveElement();
     const container = document.createElement("div");
     container.className = "alert-dialog-container";
 
@@ -963,9 +959,11 @@ class OneLineRoomCard extends HTMLElement {
       row.addEventListener("click", () => {
         const entityId = row.dataset.entity;
         if (entityId && this._hass) {
+          if (this._detailDrawer) row.focus({ preventScroll: true });
           this._fireAction("tap", { entity: entityId, tap_action: { action: "more-info" } });
         }
-        closeDialog();
+        // Preserve status details underneath HA more-info when inside a drawer.
+        if (!this._detailDrawer) closeDialog();
       });
     });
   }
@@ -1128,6 +1126,7 @@ class OneLineRoomCard extends HTMLElement {
 
   _updateContentState() {
     if (!this.config || !this._hass || !this.content) return;
+    this._syncDetailDrawer();
     const h = this._hass, c = this.config;
     const effectiveEntity = c.entity;
     const effectiveTempSensor = c.temp_sensor;
@@ -2703,6 +2702,10 @@ class OneLineRoomCard extends HTMLElement {
   }
 
   _fireAction(type, config) {
+    if (config?.[`${type}_action`]?.action === "room-details") {
+      this._showDetailDrawer(deepActiveElement());
+      return;
+    }
     if (config.entity && this._isEntityUnavailable(config.entity)) return;
     const eventDetail = buildHassActionDetail(type, config, this._hass);
     this.dispatchEvent(new CustomEvent("hass-action", { bubbles: true, composed: true, detail: eventDetail }));
@@ -2728,6 +2731,77 @@ class OneLineRoomCard extends HTMLElement {
   }
 
   static getConfigElement() { return document.createElement("oneline-room-card-editor"); }
+
+  _showDetailDrawer(trigger) {
+    if (!this.isConnected || this.config?.detail_drawer?.enabled !== true || this._detailDrawer) return;
+    this._closeDialog?.(false);
+    const t = key => getTranslation(this._hass, key);
+    this._detailDrawer = createDetailDrawer({
+      title: this.config.detail_drawer.title || this.config.name || t("room_details"),
+      closeLabel: t("a11y_close"), trigger,
+      onClose: () => {
+        this._closeDialog?.(false);
+        this._detailDrawer = null;
+        this.shadowRoot.getElementById("details-btn")?.setAttribute("aria-expanded", "false");
+      }
+    });
+    const note = document.createElement("p");
+    note.className = "prototype-note";
+    const actions = document.createElement("div");
+    actions.className = "prototype-actions";
+    for (const [name, action] of [
+      ["more", event => {
+        event.currentTarget.focus({ preventScroll: true });
+        this._fireAction("tap", { entity: this.config.entity, tap_action: { action: "more-info" } });
+      }],
+      ["history", event => this._showSparklineDialog(this._drawerHistoryEntity(), 24, event.currentTarget)],
+      ["status", () => this._showAlertDialog(this._drawerStatusRows(), t("status_groups"))]
+    ]) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.dataset.drawerAction = name;
+      button.addEventListener("click", action);
+      actions.append(button);
+    }
+    this._detailDrawer.content.append(note, actions);
+    this._syncDetailDrawer();
+  }
+
+  _drawerHistoryEntity() {
+    return (this.config?.controls || []).find(ctrl => ctrl.entity?.startsWith("sensor.") && ctrl.show_sparkline === true)?.entity
+      || (this.config?.temp_sensor?.startsWith("sensor.") ? this.config.temp_sensor : "");
+  }
+
+  _drawerStatusRows() {
+    return (this.config?.status_groups || []).flatMap(group => {
+      const result = getStatusGroupResult(group, this._hass);
+      return result.visible ? result.contributors : [];
+    });
+  }
+
+  _syncDetailDrawer() {
+    const t = key => getTranslation(this._hass, key);
+    const enabled = this.config?.detail_drawer?.enabled === true;
+    const button = this.shadowRoot.getElementById("details-btn");
+    if (button) {
+      button.hidden = !enabled;
+      button.textContent = t("room_details");
+      button.setAttribute("aria-haspopup", "dialog");
+      button.setAttribute("aria-expanded", String(!!this._detailDrawer));
+    }
+    if (!this._detailDrawer) return;
+    this._detailDrawer.update({ title: this.config.detail_drawer.title || this.config.name || t("room_details"), closeLabel: t("a11y_close"), themeSource: this });
+    this._detailDrawer.content.querySelector(".prototype-note").textContent = t("drawer_prototype_note");
+    const more = this._detailDrawer.content.querySelector('[data-drawer-action="more"]');
+    more.textContent = t("act_more");
+    more.disabled = !this.config.entity || !this._hass?.states?.[this.config.entity] || this._isEntityUnavailable(this.config.entity);
+    const history = this._detailDrawer.content.querySelector('[data-drawer-action="history"]');
+    history.textContent = t("sparkline_detail_title");
+    history.disabled = !this._drawerHistoryEntity() || !this._hass?.states?.[this._drawerHistoryEntity()];
+    const status = this._detailDrawer.content.querySelector('[data-drawer-action="status"]');
+    status.textContent = t("status_groups");
+    status.disabled = this._drawerStatusRows().length === 0;
+  }
 }
 
 export { OneLineRoomCard };

--- a/src/i18n/translations.js
+++ b/src/i18n/translations.js
@@ -1,5 +1,6 @@
 const TRANSLATIONS = {
   en: {
+    room_details: "Room details", drawer_prototype_note: "Preview: test opening, focus and nested dialogs. Room controls follow after this prototype is validated.",
     empty: "Empty", low: "Low", critical: "Critical", window: "Window", general: "General",
     sensors_manual: "Sensors (Manual)", buttons: "Buttons", button: "Button", add_button: "Add Button",
     main_climate: "Main Climate Device (Optional)", climate_info: "Fills Temp/Humidity automatically if empty below.",
@@ -99,6 +100,7 @@ const TRANSLATIONS = {
     a11y_activate: "Activate {name}", a11y_set_value: "Set {name}", a11y_select_option: "Select {name}"
   },
   de: {
+    room_details: "Raumdetails", drawer_prototype_note: "Vorschau: Öffnen, Fokus und Unterdialoge testen. Die Raumsteuerung folgt nach Prüfung dieses Prototyps.",
     empty: "Leer", low: "Niedrig", critical: "Kritisch", window: "Fenster", general: "Allgemein",
     sensors_manual: "Sensoren (Manuell)", buttons: "Buttons", button: "Button", add_button: "Button hinzufügen",
     main_climate: "Haupt-Klima-Gerät", climate_info: "Füllt Temp/Feuchtigkeit automatisch, wenn unten leer.",
@@ -202,6 +204,7 @@ const TRANSLATIONS = {
     a11y_activate: "{name} bedienen", a11y_set_value: "{name} einstellen", a11y_select_option: "{name} auswählen"
   },
   fr: {
+    room_details: "Détails de la pièce", drawer_prototype_note: "Aperçu : testez l’ouverture, le focus et les boîtes de dialogue imbriquées. Les commandes suivront après validation de ce prototype.",
     empty: "Vide", low: "Faible", critical: "Critique", window: "Fenêtre", general: "Général",
     sensors_manual: "Capteurs (Manuel)", buttons: "Boutons", button: "Bouton", add_button: "Ajouter un bouton",
     main_climate: "Appareil climatique principal (Optionnel)", climate_info: "Remplit automatiquement Temp/Humidité si vide ci-dessous.",

--- a/src/shared/dialog-coordinator.js
+++ b/src/shared/dialog-coordinator.js
@@ -1,0 +1,112 @@
+// Only modal ordering and focus live here; configuration and HA data stay with
+// the owning card. Share the coordinator even when a second bundle is loaded.
+const KEY = Symbol.for("room-card.dialog-coordinator");
+
+export const deepActiveElement = (root = document) => {
+  let active = root.activeElement;
+  while (active?.shadowRoot?.activeElement) active = active.shadowRoot.activeElement;
+  return active;
+};
+
+const focusableElements = (root) => {
+  const result = [];
+  const visit = (parent) => {
+    for (const node of parent.children || []) {
+      if (node.hidden || node.inert || node.getAttribute("aria-hidden") === "true") continue;
+      const style = getComputedStyle(node);
+      if (style.display === "none" || style.visibility === "hidden") continue;
+      if (node.tabIndex >= 0 && !node.disabled) result.push(node);
+      visit(node.shadowRoot || node);
+    }
+  };
+  visit(root);
+  return result;
+};
+
+const containsFocusTarget = (panel, target) => {
+  for (let node = target; node; node = node.parentNode || node.host) {
+    if (node === panel) return true;
+  }
+  return false;
+};
+
+export const getDialogCoordinator = (doc = document) => {
+  if (doc[KEY]) return doc[KEY];
+  const stack = [];
+  let listening = false;
+  const top = () => stack.at(-1);
+  const focus = (target) => {
+    if (target?.isConnected) target.focus({ preventScroll: true });
+  };
+  const sync = () => {
+    for (const entry of stack) {
+      if (!entry.panel) continue;
+      const paused = entry !== top();
+      entry.panel.inert = paused;
+      entry.panel.setAttribute("aria-modal", String(!paused));
+      if (paused) entry.panel.setAttribute("aria-hidden", "true");
+      else entry.panel.removeAttribute("aria-hidden");
+    }
+    if (stack.length && !listening) {
+      doc.addEventListener("keydown", keydown, true);
+      doc.addEventListener("focusin", focusin, true);
+      listening = true;
+    } else if (!stack.length && listening) {
+      doc.removeEventListener("keydown", keydown, true);
+      doc.removeEventListener("focusin", focusin, true);
+      listening = false;
+    }
+  };
+  const keydown = (event) => {
+    const current = top();
+    if (!current?.panel) return; // HA owns the active external dialog.
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      current.close();
+    } else if (event.key === "Tab") {
+      const nodes = focusableElements(current.panel);
+      const index = nodes.indexOf(deepActiveElement(doc));
+      const next = event.shiftKey ? (index <= 0 ? nodes.length - 1 : index - 1) : (index + 1) % nodes.length;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      focus(nodes[next] || current.panel);
+    }
+  };
+  const focusin = (event) => {
+    const current = top();
+    if (!current?.panel || event.composedPath().includes(current.panel)) return;
+    focus(current.initialFocus || current.panel);
+  };
+  const coordinator = {
+    push(entry) {
+      entry.restoreTarget ??= deepActiveElement(doc);
+      stack.push(entry);
+      sync();
+      focus(entry.initialFocus);
+      return entry;
+    },
+    remove(entry, restore = true) {
+      const index = stack.indexOf(entry);
+      if (index < 0) return;
+      const wasTop = entry === top();
+      stack.splice(index, 1);
+      sync();
+      if (restore && wasTop) {
+        const current = top();
+        const target = entry.restoreTarget;
+        if (!current || (current.panel && target?.isConnected && containsFocusTarget(current.panel, target))) focus(target);
+        else if (current?.panel) focus(current.initialFocus || current.panel);
+      }
+    },
+    isTop: (entry) => top() === entry,
+    get size() { return stack.length; },
+    replaceDrawer() {
+      for (const entry of [...stack].reverse()) {
+        if (entry.kind !== "ha") entry.close(false);
+      }
+    }
+  };
+  doc[KEY] = coordinator;
+  return coordinator;
+};

--- a/src/shared/ha-dialog-adapter.js
+++ b/src/shared/ha-dialog-adapter.js
@@ -1,0 +1,34 @@
+import { deepActiveElement } from "./dialog-coordinator.js";
+
+// HA ha-dialog/ha-bottom-sheet emit `opened`; their owners emit
+// `dialog-closed` with { dialog: localName }. A request alone is not proof that
+// a lazy-loaded HA dialog actually opened. No monkey-patching or polling.
+export const observeHassDialogs = (coordinator, doc = document) => {
+  const entries = new Map();
+  const opened = (event) => {
+    const path = event.composedPath();
+    if (!path.some(node => ["HA-DIALOG", "HA-BOTTOM-SHEET", "HA-ADAPTIVE-DIALOG"].includes(node.tagName))) return;
+    const owner = path.find(node => node.tagName?.startsWith("HA-") && typeof node.closeDialog === "function");
+    if (!owner || entries.has(owner)) return;
+    const entry = { kind: "ha", restoreTarget: deepActiveElement(doc) };
+    entries.set(owner, entry);
+    coordinator.push(entry);
+  };
+  const closed = (event) => {
+    for (const [owner, entry] of entries) {
+      if (event.detail?.dialog !== owner.localName || !event.composedPath().includes(owner)) continue;
+      entries.delete(owner);
+      // HA also restores focus. Run after its synchronous handlers, but never
+      // resurrect a drawer that was closed or replaced during the handoff.
+      queueMicrotask(() => coordinator.remove(entry));
+    }
+  };
+  doc.addEventListener("opened", opened, true);
+  doc.addEventListener("dialog-closed", closed, true);
+  return () => {
+    doc.removeEventListener("opened", opened, true);
+    doc.removeEventListener("dialog-closed", closed, true);
+    for (const entry of entries.values()) coordinator.remove(entry, false);
+    entries.clear();
+  };
+};

--- a/tests/detail-drawer.test.mjs
+++ b/tests/detail-drawer.test.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createHass, importRoomCard, installDomEnvironment, wait } from "./support/dom-env.mjs";
+import { getDialogCoordinator, deepActiveElement } from "../src/shared/dialog-coordinator.js";
+
+installDomEnvironment();
+await importRoomCard();
+const createCard = (config = {}, hass = createHass()) => {
+  const card = document.createElement("oneline-room-card");
+  card.setConfig({ name: "Living room", controls: [], ...config });
+  card.hass = hass;
+  document.body.append(card);
+  return card;
+};
+const open = card => card.shadowRoot.querySelector("#details-btn").click();
+const host = () => document.querySelector("[data-room-card-drawer]");
+const escape = () => document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+
+test("drawer is strictly opt-in, outside clipped ancestors, isolated from header actions, and restores focus", () => {
+  const card = createCard({ collapsible: true, tap_action: { action: "toggle" } });
+  assert.equal(card.shadowRoot.querySelector("#details-btn").hidden, true);
+  card._fireAction("tap", { tap_action: { action: "room-details" } });
+  assert.equal(host(), null);
+  card.setConfig({ ...card.config, detail_drawer: { enabled: true }, remember_state: false });
+  const actions = [];
+  card.addEventListener("hass-action", event => actions.push(event.detail));
+  card.style.transform = "translateX(0)";
+  card.style.overflow = "hidden";
+  const trigger = card.shadowRoot.querySelector("#details-btn");
+  trigger.focus();
+  const collapsed = card._collapsed;
+  open(card);
+  assert.equal(host().parentElement, document.body);
+  assert.equal(host().shadowRoot.querySelector("h2").textContent, "Living room");
+  assert.equal(host().shadowRoot.activeElement, host().shadowRoot.querySelector(".close"));
+  assert.equal(card._collapsed, collapsed);
+  assert.equal(actions.length, 0);
+  escape();
+  assert.equal(host(), null);
+  assert.equal(deepActiveElement(), trigger);
+  assert.equal(getDialogCoordinator().size, 0);
+  card.remove();
+});
+
+test("drawer traps forward/reverse Tab, skips disabled entries, and restores focus after backdrop", () => {
+  const card = createCard({ detail_drawer: { enabled: true }, entity: "light.test" }, createHass({ states: { "light.test": { state: "off", attributes: {} } } }));
+  open(card);
+  const root = host().shadowRoot;
+  const close = root.querySelector(".close");
+  const more = root.querySelector('[data-drawer-action="more"]');
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", shiftKey: true, bubbles: true }));
+  assert.equal(root.activeElement, more);
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+  assert.equal(root.activeElement, close);
+  const outside = document.createElement("button");
+  document.body.append(outside);
+  outside.focus();
+  assert.equal(root.activeElement, close);
+  root.querySelector(".backdrop").click();
+  assert.equal(host(), null);
+  outside.remove(); card.remove();
+});
+
+test("opening and updating a drawer never requests history; nested history returns focus and preserves scroll", async () => {
+  let requests = 0;
+  const entity = "sensor.drawer_temperature";
+  const card = createCard({ detail_drawer: { enabled: true }, temp_sensor: entity }, createHass({
+    states: { [entity]: { state: "21", attributes: { unit_of_measurement: "°C" } } },
+    callWS: async () => { requests++; return {}; }
+  }));
+  open(card);
+  const root = host().shadowRoot;
+  const content = root.querySelector(".content");
+  content.scrollTop = 65;
+  assert.equal(requests, 0);
+  card.setConfig({ ...card.config, detail_drawer: { enabled: true, title: "Changed" } });
+  assert.equal(root.querySelector("h2").textContent, "Changed");
+  assert.equal(content.scrollTop, 65);
+  const button = root.querySelector('[data-drawer-action="history"]');
+  button.focus(); button.click();
+  await wait();
+  assert.equal(requests, 1);
+  assert.ok(root.querySelector(".sparkline-dialog"));
+  assert.equal(root.querySelector(".panel").inert, true);
+  root.querySelector(".backdrop").click();
+  assert.ok(host(), "lower backdrop cannot close a child");
+  escape();
+  assert.equal(root.querySelector(".sparkline-dialog"), null);
+  assert.equal(root.activeElement, button);
+  assert.equal(root.querySelector(".panel").inert, false);
+  assert.equal(content.scrollTop, 65);
+  escape();
+  assert.equal(host(), null);
+  card.remove();
+});
+
+test("HA handoff requires a confirmed opening; only its matching closed event resumes RoomCard focus", async () => {
+  const card = createCard({ detail_drawer: { enabled: true }, entity: "light.test" }, createHass({ states: { "light.test": { state: "off", attributes: {} } } }));
+  const actions = [];
+  card.addEventListener("hass-action", event => actions.push(event.detail));
+  open(card);
+  const root = host().shadowRoot;
+  const more = root.querySelector('[data-drawer-action="more"]');
+  more.focus(); more.click();
+  assert.equal(actions.length, 1);
+  assert.equal(root.querySelector(".panel").inert, false, "request alone must not pause the drawer");
+  const ha = document.createElement("ha-more-info-dialog");
+  ha.closeDialog = () => {};
+  const haRoot = ha.attachShadow({ mode: "open" });
+  const primitive = document.createElement("ha-dialog");
+  const input = document.createElement("button");
+  primitive.append(input); haRoot.append(primitive); document.body.append(ha);
+  primitive.dispatchEvent(new CustomEvent("opened", { bubbles: true, composed: true }));
+  input.focus();
+  assert.equal(deepActiveElement(), input);
+  assert.equal(root.querySelector(".panel").inert, true);
+  escape();
+  assert.ok(host(), "RoomCard must not handle HA's Escape");
+  document.dispatchEvent(new CustomEvent("dialog-closed", { detail: { dialog: "ha-more-info-dialog" } }));
+  await wait();
+  assert.equal(root.querySelector(".panel").inert, true, "unrelated target cannot dismiss the handoff");
+  ha.dispatchEvent(new CustomEvent("dialog-closed", { bubbles: true, composed: true, detail: { dialog: "ha-more-info-dialog" } }));
+  await wait();
+  assert.equal(root.querySelector(".panel").inert, false);
+  assert.equal(deepActiveElement(), more);
+  ha.remove(); card.remove();
+  assert.equal(getDialogCoordinator().size, 0);
+});
+
+test("one drawer across cards; disable, removal and real navigation clean up while HA history leaves it open", () => {
+  const one = createCard({ detail_drawer: { enabled: true } });
+  const two = createCard({ detail_drawer: { enabled: true } });
+  open(one);
+  const old = host();
+  open(two);
+  assert.equal(old.isConnected, false);
+  assert.equal(one._detailDrawer, null);
+  assert.equal(document.querySelectorAll("[data-room-card-drawer]").length, 1);
+  window.dispatchEvent(new Event("popstate"));
+  assert.ok(host());
+  history.pushState(null, "", "/lovelace/1");
+  window.dispatchEvent(new Event("location-changed"));
+  assert.equal(host(), null);
+  history.replaceState(null, "", "/lovelace/0");
+  open(one);
+  one.setConfig({ ...one.config, detail_drawer: { enabled: false } });
+  assert.equal(host(), null);
+  open(two); two.remove(); one.remove();
+  assert.equal(host(), null);
+  assert.equal(getDialogCoordinator().size, 0);
+});
+
+test("repeated opening adds no timers or retained modal listeners", () => {
+  const originalAdd = document.addEventListener.bind(document);
+  const originalRemove = document.removeEventListener.bind(document);
+  const tracked = new Map();
+  const names = ["keydown", "focusin", "opened", "dialog-closed"];
+  document.addEventListener = (type, fn, options) => { if (names.includes(type)) tracked.set(fn, type); originalAdd(type, fn, options); };
+  document.removeEventListener = (type, fn, options) => { if (tracked.get(fn) === type) tracked.delete(fn); originalRemove(type, fn, options); };
+  const card = createCard({ detail_drawer: { enabled: true } });
+  try {
+    for (let i = 0; i < 20; i++) {
+      open(card); escape();
+      assert.equal(host(), null);
+      assert.equal(getDialogCoordinator().size, 0);
+      assert.equal(tracked.size, 0);
+      assert.equal(card._activeTimers.size, 0);
+    }
+  } finally {
+    card.remove(); document.addEventListener = originalAdd; document.removeEventListener = originalRemove;
+  }
+});
+
+test("removing a drawer during a pending history request cannot restore it", async () => {
+  let resolveHistory;
+  const entity = "sensor.pending_drawer";
+  const card = createCard({ detail_drawer: { enabled: true }, temp_sensor: entity }, createHass({
+    states: { [entity]: { state: "12", attributes: {} } },
+    callWS: () => new Promise(resolve => { resolveHistory = resolve; })
+  }));
+  open(card);
+  const old = host();
+  old.shadowRoot.querySelector('[data-drawer-action="history"]').click();
+  card.remove();
+  resolveHistory({});
+  await wait();
+  assert.equal(host(), null);
+  assert.equal(old.shadowRoot.querySelector(".sparkline-dialog"), null);
+  assert.equal(getDialogCoordinator().size, 0);
+});
+
+test("tap, hold and double-tap room-details actions stay local and theme updates preserve drawer nodes", () => {
+  const card = createCard({ detail_drawer: { enabled: true } });
+  const actions = [];
+  card.addEventListener("hass-action", event => actions.push(event.detail));
+  for (const type of ["tap", "hold", "double_tap"]) {
+    card._fireAction(type, { [`${type}_action`]: { action: "room-details" } });
+    assert.ok(host());
+    escape();
+  }
+  assert.equal(actions.length, 0);
+  open(card);
+  const old = host();
+  card.style.setProperty("--primary-text-color", "rgb(240, 240, 240)");
+  card.hass = card._hass;
+  assert.equal(host(), old);
+  assert.equal(old.style.getPropertyValue("--primary-text-color"), "rgb(240, 240, 240)");
+  card.remove();
+});

--- a/tests/fixtures/drawer-prototype.html
+++ b/tests/fixtures/drawer-prototype.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>RoomCard drawer prototype — local fixture</title>
+<style>
+  body { margin:24px; font:16px system-ui; background:#f3f5f7; --primary-text-color:#20252c; --secondary-text-color:#616875; --ha-card-background:#fff; --divider-color:#d7dce2; --primary-color:#007fa8; }
+  body.dark { background:#13171c; color:#e7edf6; --primary-text-color:#e7edf6; --secondary-text-color:#acb6c5; --ha-card-background:#222932; --divider-color:#414a58; --primary-color:#66cbed; }
+  .layout { max-width:420px; transform:translateZ(0); overflow:hidden; }
+  button { padding:12px; margin-bottom:16px; }
+</style>
+<h1>Drawer prototype</h1>
+<p>Local rendering fixture only. Real HA dialog compatibility is tested separately.</p>
+<button id="theme">Switch light/dark</button>
+<div class="layout"><oneline-room-card></oneline-room-card></div>
+<script type="module">
+  import "../../dist/room-card.js";
+  const card = document.querySelector("oneline-room-card");
+  const hass = {
+    language:"en", locale:{language:"en"}, config:{unit_system:{temperature:"°C"}},
+    states:{
+      "sensor.temperature":{entity_id:"sensor.temperature",state:"22.1",attributes:{friendly_name:"Room temperature",unit_of_measurement:"°C"}},
+      "light.test":{entity_id:"light.test",state:"on",attributes:{friendly_name:"Reading light"}}
+    },
+    callWS:async () => ({"sensor.temperature":[{s:"21.2",lu:Date.now()/1000-7200},{s:"22.1",lu:Date.now()/1000}]}),
+    formatEntityState: state => `${state.state} ${state.attributes.unit_of_measurement || ""}`,
+    entities:{},user:{id:"local-fixture"}
+  };
+  card.setConfig({name:"Living room",image_preset:"living-room",detail_drawer:{enabled:true},temp_sensor:"sensor.temperature",controls:[],status_groups:[{name:"Lights on",entities:["light.test"],type:"count",active_states:["on"],details:true}]});
+  card.hass = hass;
+  document.querySelector("#theme").addEventListener("click", () => { document.body.classList.toggle("dark"); card.hass=hass; });
+</script>


### PR DESCRIPTION
## Scope

Refs #127. This is the required **prototype gate**, not the completed Room Detail Drawer and not a release PR.

- Body-mounted Shadow DOM host, 480px desktop sidebar / mobile bottom sheet, safe areas, reduced motion and theme propagation.
- Opt-in `detail_drawer.enabled: true`, optional title, isolated header button and explicit `action: room-details`.
- Shared modal coordinator for focus, Escape, backdrop and nested history/status dialogs; isolated adapter using confirmed HA opening/closing events.
- Singleton ownership, navigation/disconnect/disable cleanup, no extra history polling.
- EN/DE/FR prototype strings, test fixture and architecture/manual-gate documentation.

Existing controls deliberately remain on the card. Shared control rendering, `display_in` and the editor section follow only after the real HA prototype gate passes. Version remains 1.4.0 until the final v1.5.0 release stage.

## Verification

- `npm run check`: **106 tests pass**, syntax and fresh deterministic artifact checks pass.
- `git diff --check`: clean.
- Local browser fixture: desktop sidebar outside transformed/clipped card layout; 390×844 mobile bottom sheet; light/dark; history child and Escape focus return; no browser error logs.
- The fixture uses simulated state. It does **not** certify HA native top-layer behavior.

## Blocking manual gate

- [ ] Actual HA desktop/mobile and light/dark layout.
- [ ] HA more-info cold opening, only topmost Escape/backdrop, focus/scroll restoration.
- [ ] Status → HA details and history nesting.
- [ ] Repeated open/close, second card, navigation and owner removal.
- [ ] Drawer opened from the HA editor preview: layering and focus.

Do not close #127 or publish v1.5.0 from this PR. See `docs/room-detail-drawer.md` for the full checklist and the prior modularization gate evidence.
