### PR TITLE
feat: integrate Room Detail Drawer controls and editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to OneLine Room Card are documented here.
 
 ## [Unreleased]
 
-* Build: Introduce pinned esbuild 0.28.2 as the first isolated step toward #100. Keep runtime/editor behavior and the single-file HACS delivery unchanged; verify a fresh reproducible build, registration order, explicit helper test imports, and adjacent room-image assets. Source extraction and the Room Detail Drawer remain gated follow-up work for v1.5.0.
+* Build & architecture: Bundle with pinned esbuild 0.28.2 and separate helpers, translations, runtime, input compatibility and editor into test-gated modules. Keep the unminified single-file HACS artifact, registration order and relative room-image assets; check dependency direction, reproducibility and the shipped bundle. Ref #100.
+* Runtime & editor (v1.5 candidate): Add opt-in `detail_drawer.enabled` and per-control `display_in: card | drawer | both`. Share renderers, state and history cache while giving each location independent DOM and listeners. Preserve visibility conditions, existing actions, card collapse and disabled-drawer fallback. Add title, preview, placement and control duplication in EN/DE/FR; retain live-preview/deferred-save behavior. Ref #127; final HA integration test and release remain pending.
+* Accessibility & lifecycle: Coordinate nested room/history/status/HA dialogs, restore focus into native controls after updates, close on navigation/disconnect/disable, and avoid history requests for closed drawer-only controls or a second polling timer.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,47 @@ covers all settings — no YAML required.
 | `sparkline_refresh` | `300` | Auto-refresh cadence for all sparkline buttons in seconds (60–3600); configurable in the visual editor under **Buttons** |
 | `room_modes` | — | Ordered scene/script shortcuts shown between the header/info bar and controls |
 | `status_groups` | — | Informational header chips that count matching states or sum compatible numeric sensor values |
+| `detail_drawer.enabled` | `false` | Enable the opt-in Room Detail Drawer (v1.5 candidate) |
+| `detail_drawer.title` | Card name | Optional title of the drawer |
+
+#### Room Detail Drawer (v1.5 candidate)
+
+Keep compact controls on the card and put additional controls in a responsive
+room-details panel. It opens as a 480px right sidebar on desktop (from 768px),
+or a full-width bottom sheet on smaller displays. The room image, header
+information, status and Room Modes use the same configuration in both places.
+
+```yaml
+detail_drawer:
+  enabled: true
+  title: Living room
+controls:
+  - entity: light.ceiling
+    display_in: both
+  - entity: light.reading
+    display_in: drawer
+  - entity: media_player.living_room
+    display_in: card
+```
+
+`display_in` accepts `card`, `drawer` and `both`; omitted or unknown values mean
+`card`. If room details are disabled, all controls return to the card regardless
+of placement. Existing `hide` and visibility conditions still apply. Order comes
+from the single `controls` list; there is no second list to maintain.
+
+Use the new **Room details** header button, or explicitly assign
+`action: room-details` to a tap, hold or double-tap action. Existing card actions
+and collapse behavior are not replaced; drawer controls remain expanded even
+when the card is collapsed. History and HA detail dialogs open above the drawer.
+
+In the visual editor, **Configuration → Room details** enables the drawer and
+sets its title. Under **Buttons**, each control has **Display in → Card / Room
+details / Both**. Reordering, duplication and area setup retain existing placement.
+The preview button opens HA's existing card preview; it requires live preview.
+With live preview off, changes apply through the existing Save workflow.
+
+This feature is a v1.5 candidate, not part of the published v1.4.0 release.
+See the [architecture and test gates](docs/room-detail-drawer.md).
 
 #### Room Modes
 

--- a/dist/room-card.js
+++ b/dist/room-card.js
@@ -486,8 +486,16 @@ var isAlertSensorActive = (alertCfg, stateObj, normalize = normalizeAlertSensorC
 // src/i18n/translations.js
 var TRANSLATIONS = {
   en: {
+    control_duplicate: "Duplicate control",
     room_details: "Room details",
-    drawer_prototype_note: "Preview: test opening, focus and nested dialogs. Room controls follow after this prototype is validated.",
+    drawer_enable: "Enable room details",
+    drawer_title: "Title (optional)",
+    drawer_preview: "Preview room details",
+    drawer_placement: "Display in",
+    drawer_card: "Card",
+    drawer_both: "Both",
+    drawer_help: "Choose Card, Room details or Both for each control. With room details disabled, all controls return to the card. Preview requires live preview; otherwise changes apply on Save.",
+    drawer_preview_unavailable: "The HA card preview is not ready yet. Wait for the preview, or save and open Room details on the dashboard.",
     empty: "Empty",
     low: "Low",
     critical: "Critical",
@@ -808,8 +816,16 @@ var TRANSLATIONS = {
     a11y_select_option: "Select {name}"
   },
   de: {
+    control_duplicate: "Control duplizieren",
     room_details: "Raumdetails",
-    drawer_prototype_note: "Vorschau: Öffnen, Fokus und Unterdialoge testen. Die Raumsteuerung folgt nach Prüfung dieses Prototyps.",
+    drawer_enable: "Raumdetails aktivieren",
+    drawer_title: "Titel (optional)",
+    drawer_preview: "Raumdetails ansehen",
+    drawer_placement: "Anzeigen in",
+    drawer_card: "Karte",
+    drawer_both: "Beide",
+    drawer_help: "Pro Control Karte, Raumdetails oder Beide wählen. Bei deaktivierten Raumdetails erscheinen alle Controls wieder auf der Karte. Die Vorschau benötigt Live-Vorschau; sonst gelten Änderungen erst nach dem Speichern.",
+    drawer_preview_unavailable: "Die HA-Kartenvorschau ist noch nicht bereit. Bitte kurz warten oder speichern und die Raumdetails im Dashboard öffnen.",
     empty: "Leer",
     low: "Niedrig",
     critical: "Kritisch",
@@ -1130,8 +1146,16 @@ var TRANSLATIONS = {
     a11y_select_option: "{name} auswählen"
   },
   fr: {
+    control_duplicate: "Dupliquer la commande",
     room_details: "Détails de la pièce",
-    drawer_prototype_note: "Aperçu : testez l’ouverture, le focus et les boîtes de dialogue imbriquées. Les commandes suivront après validation de ce prototype.",
+    drawer_enable: "Activer les détails de la pièce",
+    drawer_title: "Titre (facultatif)",
+    drawer_preview: "Aperçu des détails",
+    drawer_placement: "Afficher dans",
+    drawer_card: "Carte",
+    drawer_both: "Les deux",
+    drawer_help: "Pour chaque commande, choisissez Carte, Détails de la pièce ou Les deux. Si les détails sont désactivés, toutes les commandes reviennent sur la carte. L’aperçu nécessite l’aperçu en direct ; sinon les modifications s’appliquent à l’enregistrement.",
+    drawer_preview_unavailable: "L’aperçu de la carte HA n’est pas encore prêt. Patientez, ou enregistrez puis ouvrez les détails depuis le tableau de bord.",
     empty: "Vide",
     low: "Faible",
     critical: "Critique",
@@ -1663,7 +1687,7 @@ var supportsMediaFeature = (stateObj, feature) => {
 
 // src/version.js
 var VERSION = "1.4.0";
-var EDITOR_DOM_REVISION = "6";
+var EDITOR_DOM_REVISION = "7";
 
 // src/shared/dialog-coordinator.js
 var KEY = /* @__PURE__ */ Symbol.for("room-card.dialog-coordinator");
@@ -1823,8 +1847,7 @@ var createDetailDrawer = ({ title, closeLabel, trigger, onClose }) => {
       button:disabled { opacity:.5; cursor:default; }
       button:focus-visible { outline:2px solid var(--primary-color,#03a9f4); outline-offset:2px; }
       .content { flex:1; min-height:0; overflow:auto; overscroll-behavior:contain; padding:16px calc(16px + env(safe-area-inset-right,0px)) calc(16px + env(safe-area-inset-bottom,0px)) calc(16px + env(safe-area-inset-left,0px)); }
-      .prototype-actions { display:flex; flex-wrap:wrap; gap:10px; }
-      .prototype-note { color:var(--secondary-text-color,#666); }
+      .drawer-actions { display:flex; flex-wrap:wrap; gap:10px; margin-bottom:16px; }
       @keyframes enter { from { opacity:0; transform:translateX(24px); } to { opacity:1; transform:none; } }
       @media (max-width:767px) {
         .panel { inset:auto 0 0; width:100%; max-height:90vh; max-height:90dvh; border-radius:20px 20px 0 0; animation-name:enter-bottom; }
@@ -1890,6 +1913,208 @@ var createDetailDrawer = ({ title, closeLabel, trigger, onClose }) => {
       }
     }
   };
+};
+
+// src/card/surface.js
+var getRoomSurfaceMarkup = (hass) => `
+      <style>
+        ha-card { position: relative; overflow: hidden; border-radius: 16px; background: none; border: none; cursor: default; }
+        ha-card.warning-battery { outline: 2px solid var(--error-color, #d32f2f); outline-offset: -2px; }
+        ha-card.warning-humidity { outline: 2px solid var(--info-color, #2196F3); outline-offset: -2px; box-shadow: 0 0 0 2px rgba(33,150,243,0.35), 0 0 12px rgba(33,150,243,0.35), 0 0 22px rgba(33,150,243,0.25); }
+        ha-card.alert-sensor { outline: 2px solid var(--rc-alert-border-color, var(--error-color, #d32f2d)); outline-offset: -2px; box-shadow: 0 0 0 2px rgba(211,47,47,0.15); }
+        .container { display: flex; flex-direction: column; background: var(--ha-card-background, rgba(255,255,255,0.1)); border-radius: 16px; }
+        .img-box { position: relative; width: 100%; height: 120px; overflow: hidden; border-radius: 16px 16px 0 0; background: #444; cursor: pointer; }
+        .img-box.no-image { background: transparent; }
+        .img-box.no-image .img { display: none; }
+        .img-box.no-image .overlay { background: none; position: relative; }
+        .img { width: 100%; height: 100%; object-fit: cover; display: block; transition: filter 0.8s ease; }
+        .img.grayscale { filter: grayscale(100%) brightness(0.6); }
+        .overlay { position: absolute; top: 0; left: 0; width: 100%; padding: 12px; box-sizing: border-box; background: linear-gradient(to bottom, rgba(0,0,0,0.8) 0%, rgba(0,0,0,0) 100%); display: flex; align-items: center; gap: 12px; }
+        .text { display: flex; flex: 1; min-width: 0; flex-direction: column; align-items: flex-start; color: white; text-shadow: 0 1px 2px rgba(0,0,0,0.5); }
+        ha-card.no-header-text-shadow .text { text-shadow: none; }
+        ha-icon { color: var(--icon-color, white); }
+        .primary { display: block; max-width: 100%; font-weight: var(--rc-header-name-weight, bold); font-size: var(--rc-header-name-size, 14px); font-style: var(--rc-header-name-style, normal); color: var(--rc-header-name-color, white); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        .secondary { max-width: 100%; min-width: 0; font-weight: var(--rc-header-info-weight, normal); font-size: var(--rc-header-info-size, 12px); font-style: var(--rc-header-info-style, normal); color: var(--rc-header-info-color, white); opacity: 0.9; display: flex; flex-wrap: nowrap; gap: 6px; align-items: center; overflow: hidden; }
+        .info-item { display: inline-flex; align-items: center; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        .info-item.badge { padding: 2px 6px; border-radius: 999px; }
+        .chips { position: absolute; bottom: 8px; left: 8px; display: flex; gap: 6px; flex-wrap: wrap; z-index: 2; }
+        .chip { display: flex; align-items: center; gap: 4px; padding: 4px 8px; border: 0; border-radius: 8px; font-family: inherit; font-size: 11px; font-weight: bold; background: #FFF8E1; color: #FFA000; box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
+        .chip.status-group-chip { background:rgba(var(--rgb-primary-color, 3,169,244),.14); color:var(--primary-color, #03a9f4); }
+        button.chip.status-group-chip { cursor:pointer; }
+        button.chip.status-group-chip:focus-visible { outline:2px solid var(--primary-color, #03a9f4); outline-offset:2px; }
+        .chip ha-icon { color: currentColor; }
+        ha-card.no-chip-shadow .chip { box-shadow: none; }
+        .chip.alert { background: #FFEBEE; color: #D32F2F; }
+        .chip.humidity { background: #E3F2FD; color: #1976D2; }
+        .chip.info { background: #E3F2FD; color: #1976D2; }
+        .chip.custom { background: var(--chip-bg); color: var(--chip-color); }
+        .controls { display: flex; flex-wrap: wrap; gap: 6px; padding: 10px; }
+        .btn.has-sparkline { height: auto; align-items: stretch; overflow: visible; flex-wrap: wrap; padding-bottom: 6px; }
+        .btn-sparkline { width: 100%; flex: 0 0 100%; order: 99; align-self: stretch; min-height: 28px; margin-top: 6px; display: flex; align-items: center; padding: 4px 6px; border: 0; border-radius: 12px; color: inherit; font: inherit; background: rgba(255,255,255,0.06); box-sizing: border-box; }
+        button.btn-sparkline { cursor: pointer; }
+        button.btn-sparkline:focus-visible { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: 2px; }
+        .btn-sparkline svg { width: 100%; height: 22px; display: block; overflow: visible; }
+        .btn-sparkline polyline { fill: none; vector-effect: non-scaling-stroke; }
+        .btn { position: relative; display: flex; align-items: center; gap: 10px; padding: 0 10px; border-radius: 12px; cursor: pointer; background: var(--rc-btn-bg, var(--btn-bg, var(--card-background-color, rgba(128,128,128,0.05)))); border: 1px solid transparent; flex-grow: 1; flex-shrink: 1; min-width: 0; overflow: hidden; box-sizing: border-box; transition: background 0.2s; user-select: none; -webkit-user-select: none; touch-action: manipulation; -webkit-tap-highlight-color: transparent; flex-basis: var(--btn-flex-basis, auto); height: var(--btn-height, 60px); justify-content: var(--btn-justify, center); }
+        .btn.label-right { flex-direction: row; align-items: center; justify-content: var(--btn-justify, center); gap: 10px; padding: 0 10px; }
+        .btn.label-left { flex-direction: row-reverse; align-items: center; justify-content: var(--btn-justify, center); gap: 10px; padding: 0 10px; }
+        .btn.label-bottom { flex-direction: column; justify-content: flex-start; align-items: center; gap: 1px; padding: 2px 4px; overflow: hidden; }
+        .btn.label-top { flex-direction: column-reverse; justify-content: center; gap: 4px; padding: 6px 8px; overflow: hidden; }
+        .btn.has-inline-ctrl.label-bottom,
+        .btn.has-inline-ctrl.label-top { align-items: center; }
+        .btn.has-inline-ctrl.label-bottom .btn-top,
+        .btn.has-inline-ctrl.label-top .btn-top { align-items: center; width: 100%; }
+        .btn.label-left .btn-txt { text-align: right; align-items: flex-end; }
+        .btn.label-bottom .icon-box,
+        .btn.label-top .icon-box { flex-shrink: 0; }
+        .btn.label-bottom .icon-box { width: 28px; height: 28px; margin-top: 1px; }
+        .btn.label-bottom ha-icon { --mdc-icon-size: 18px; }
+        .btn.label-bottom .btn-txt,
+        .btn.label-top .btn-txt { text-align: center; align-items: center; flex: 1; min-height: 0; max-width: 100%; overflow: hidden; }
+        .btn.label-bottom .btn-txt { flex: 0 0 auto; min-height: 22px; max-height: 22px; gap: 1px; }
+        .btn.label-bottom .btn-name,
+        .btn.label-bottom .btn-state,
+        .btn.label-top .btn-name,
+        .btn.label-top .btn-state { font-size: 11px; line-height: 1.1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+        .btn.label-bottom .btn-name { font-size: 11px; line-height: 11px; }
+        .btn.label-bottom .btn-state { font-size: 10px; line-height: 10px; margin-top: 0; }
+        .btn:hover { background: var(--rc-btn-bg-hover, rgba(128,128,128,0.1)); border-color: rgba(128,128,128,0.2); }
+        .btn:active { background: var(--rc-btn-bg-active, rgba(128,128,128,0.15)); }
+        .btn:focus-visible, button:focus-visible, select:focus-visible, input:focus-visible, .img-box:focus-visible { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: 2px; }
+        .btn.state-unavailable { opacity: 0.56; }
+        .btn.state-unavailable:hover,
+        .btn.state-unavailable:active { background: var(--rc-btn-bg, var(--btn-bg, var(--card-background-color, rgba(128,128,128,0.05)))); border-color: transparent; }
+        .btn.state-unavailable .btn-name,
+        .btn.state-unavailable .btn-state,
+        .btn.state-unavailable ha-icon { color: var(--disabled-text-color, var(--secondary-text-color)); }
+        .icon-box { display: flex; align-items: center; justify-content: center; width: 32px; height: 32px; border-radius: 50%; flex-shrink: 0; background: var(--icon-bg, transparent); }
+        .btn-txt { display: flex; flex-direction: column; text-align: left; overflow: hidden; min-width: 0; flex: initial; max-width: 100%; }
+        .btn ha-icon { color: var(--rc-icon-color, var(--icon-color, grey)); --mdc-icon-size: 20px; }
+        .btn-name { font-size: 13px; font-weight: 600; color: var(--primary-text-color); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+        .btn-state { font-size: 11px; color: var(--secondary-text-color); margin-top: 1px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+        .warn { position: absolute; top: 4px; right: 4px; color: #d32f2f; --mdc-icon-size: 16px; background: rgba(255,255,255,0.8); border-radius: 50%; padding: 1px; }
+        .warn.warn-offline { color: var(--warning-color, var(--secondary-text-color)); background: var(--card-background-color, rgba(255,255,255,0.85)); }
+        .btn.has-inline-ctrl { flex-direction: column; align-items: stretch; padding: 6px 10px; gap: 4px; height: auto; min-height: var(--btn-height, 60px); }
+        .btn.has-inline-ctrl .btn-top { display: flex; align-items: center; gap: 10px; width: 100%; flex: 0 0 auto; }
+        .btn.has-inline-ctrl .btn-txt { flex: 1; min-width: 0; }
+        .btn-slider-wrap { width: 100%; flex: 0 0 auto; padding: 0 2px 4px; }
+        .btn-slider { -webkit-appearance: none; appearance: none; width: 100%; height: 4px; border-radius: 2px; outline: none; cursor: pointer; background: linear-gradient(to right, var(--icon-color, #ff9800) 0%, var(--icon-color, #ff9800) var(--slider-pct, 0%), rgba(128,128,128,0.3) var(--slider-pct, 0%), rgba(128,128,128,0.3) 100%); }
+        .btn-slider::-webkit-slider-thumb { -webkit-appearance: none; width: 14px; height: 14px; border-radius: 50%; background: var(--icon-color, #ff9800); cursor: pointer; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
+        .btn-slider::-moz-range-thumb { width: 14px; height: 14px; border-radius: 50%; background: var(--icon-color, #ff9800); cursor: pointer; border: none; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
+        .btn-cover-actions { display: flex; gap: 4px; width: 100%; flex: 0 0 auto; padding-bottom: 4px; }
+        .cover-action-btn { flex: 0 0 auto; display: flex; align-items: center; justify-content: center; background: rgba(128,128,128,0.1); border: 0; color: inherit; font: inherit; border-radius: 6px; padding: 4px 6px; cursor: pointer; transition: background 0.15s; touch-action: manipulation; }
+        .cover-action-btn:hover { background: rgba(128,128,128,0.22); }
+        .cover-action-btn ha-icon { --mdc-icon-size: 16px; color: var(--primary-text-color); }
+        .media-transport-row, .media-volume-row { display: flex; align-items: center; gap: 6px; width: 100%; flex: 0 0 auto; }
+        .media-transport-row { justify-content: center; padding-top: 2px; }
+        .media-volume-row { padding: 2px 0 4px; }
+        .media-ctrl-btn { flex: 0 0 auto; display: flex; align-items: center; justify-content: center; width: 32px; height: 32px; padding: 0; border: 0; border-radius: 50%; background: transparent; color: inherit; cursor: pointer; transition: background 0.15s; touch-action: manipulation; }
+        .media-ctrl-btn:hover { background: rgba(128,128,128,0.18); }
+        .media-ctrl-btn ha-icon { --mdc-icon-size: 19px; color: var(--primary-text-color); }
+        .media-ctrl-btn.muted ha-icon { color: var(--secondary-text-color); }
+        .media-volume-row .btn-slider-wrap { flex: 1; min-width: 0; padding: 0; }
+        .media-volume-row .btn-slider { height: 4px; }
+        .media-volume-row .vol-label { font-size: 10px; font-weight: 600; color: var(--secondary-text-color); min-width: 32px; text-align: center; flex: 0 0 auto; }
+        .media-thumb { width: 40px; height: 40px; border-radius: 4px; object-fit: cover; flex-shrink: 0; }
+        .media-full-layout { display: flex; gap: 10px; width: 100%; align-items: stretch; }
+        .media-full-layout .media-thumb { width: 72px; height: 72px; aspect-ratio: 1; border-radius: 6px; align-self: center; object-fit: cover; }
+        .media-full-layout .media-right { display: flex; flex-direction: column; flex: 1; min-width: 0; justify-content: center; gap: 2px; }
+        .btn-cover-presets { display: flex; gap: 4px; width: 100%; flex: 0 0 auto; padding-bottom: 4px; }
+        .preset-btn { flex: 1; display: flex; align-items: center; justify-content: center; background: rgba(128,128,128,0.1); border: 0; border-radius: 6px; padding: 3px 4px; cursor: pointer; transition: background 0.15s, color 0.15s; font: inherit; font-size: 11px; font-weight: 600; color: var(--secondary-text-color); white-space: nowrap; touch-action: manipulation; }
+        .preset-btn:hover { background: rgba(128,128,128,0.22); color: var(--primary-text-color); }
+        .preset-btn.active { background: var(--icon-color, var(--primary-color, #ff9800)); color: #fff; }
+        .btn-select-dropdown { width: 100%; padding-bottom: 4px; }
+        .btn-select-dropdown select { width: 100%; padding: 4px 8px; border-radius: 6px; border: none; background: rgba(128,128,128,0.12); color: var(--primary-text-color); font-size: 12px; font-weight: 500; cursor: pointer; appearance: auto; outline: none; touch-action: manipulation; }
+        .btn-select-dropdown select:focus { box-shadow: 0 0 0 1px var(--icon-color, var(--primary-color, #ff9800)); }
+        .btn-select-options { flex-wrap: wrap; }
+        .btn-select-options .preset-btn { flex: 0 1 auto; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+        .btn-color-favorites { display: flex; gap: 6px; width: 100%; flex: 0 0 auto; padding-bottom: 4px; flex-wrap: wrap; }
+        .color-swatch { width: 20px; height: 20px; padding: 0; border-radius: 50%; cursor: pointer; flex-shrink: 0; border: 2px solid transparent; transition: transform 0.15s, border-color 0.15s; box-shadow: 0 1px 3px rgba(0,0,0,0.25); touch-action: manipulation; }
+        .color-swatch:hover { transform: scale(1.2); }
+        .color-swatch.active { border-color: var(--primary-text-color); transform: scale(1.15); }
+        .controls { transition: max-height 0.35s ease, padding 0.35s ease; overflow: hidden; max-height: 2000px; }
+        .controls.collapsed { max-height: 0 !important; padding-top: 0 !important; padding-bottom: 0 !important; }
+        .collapse-btn { position: absolute; bottom: 8px; right: 8px; z-index: 3; width: 28px; height: 28px; padding: 0; border: 0; border-radius: 50%; background: rgba(0,0,0,0.38); display: none; align-items: center; justify-content: center; cursor: pointer; }
+        .collapse-btn ha-icon { --mdc-icon-size: 18px; color: white; transition: transform 0.35s ease; }
+        .collapse-btn.open ha-icon { transform: rotate(180deg); }
+        .details-btn { position:absolute; top:8px; right:8px; z-index:3; min-width:44px; min-height:44px; padding:8px 12px; border:0; border-radius:12px; background:rgba(0,0,0,.55); color:white; font:inherit; cursor:pointer; }
+        .details-btn[hidden] { display:none; }
+        .details-btn:focus-visible { outline:2px solid var(--primary-color,#03a9f4); outline-offset:2px; }
+        .btn-chips { display: flex; flex-direction: row; flex-wrap: wrap; gap: 2px; align-items: center; max-width: 100%; margin-top: 2px; }
+        .btn-chips.chips-top { margin-top: 0; margin-bottom: 2px; }
+        .btn.has-inline-ctrl .btn-chips { margin-top: 4px; padding-bottom: 2px; }
+        .btn.has-inline-ctrl .btn-chips.chips-top { margin-top: 0; margin-bottom: 4px; padding-bottom: 0; padding-top: 2px; }
+        .btn-chip { display: inline-flex; align-items: center; gap: 2px; padding: 2px 5px; background: rgba(var(--rgb-primary-text-color, 0, 0, 0), 0.12); color: var(--secondary-text-color, rgba(0,0,0,0.6)); border-radius: 6px; max-width: 100%; box-sizing: border-box; }
+        .btn-chip span { font-size: 9px; line-height: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .btn-chip ha-icon { --mdc-icon-size: 11px; }
+        .info-bar { display: none; flex-wrap: nowrap; gap: 6px; padding: 4px 12px 6px; align-items: center; overflow: hidden; font-size: var(--rc-header-info-size, 12px); font-weight: var(--rc-header-info-weight, normal); font-style: var(--rc-header-info-style, normal); color: var(--rc-header-info-color, var(--secondary-text-color)); }
+        .info-bar.active { display: flex; }
+        .room-modes { display: flex; gap: 7px; padding: 8px 10px; overflow-x: auto; overflow-y: hidden; scrollbar-width: thin; overscroll-behavior-inline: contain; border-top: 1px solid var(--divider-color, rgba(128,128,128,.18)); }
+        .room-modes:empty { display: none; }
+        .room-mode { flex: 0 0 auto; min-height: 34px; display: inline-flex; align-items: center; gap: 6px; padding: 6px 11px; border: 1px solid var(--divider-color, rgba(128,128,128,.25)); border-radius: 999px; color: var(--primary-text-color); background: rgba(128,128,128,.08); font: inherit; font-size: 12px; font-weight: 600; white-space: nowrap; cursor: pointer; touch-action: manipulation; }
+        .room-mode ha-icon { --mdc-icon-size: 18px; color: var(--room-mode-color, var(--primary-color)); }
+        .room-mode.active { color: var(--text-primary-color, #fff); background: var(--room-mode-color, var(--primary-color)); border-color: var(--room-mode-color, var(--primary-color)); }
+        .room-mode.active ha-icon { color: currentColor; }
+        .room-mode:disabled { opacity: .45; cursor: not-allowed; }
+        .room-mode:focus-visible { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: 2px; }
+        @media (max-width: 480px) {
+          .media-full-layout { gap: 8px; }
+          .media-full-layout .media-thumb { width: 60px; height: 60px; }
+          .media-ctrl-btn { width: 30px; height: 30px; }
+        }
+      </style>
+      <ha-card>
+        <div class="container">
+          <div class="img-box">
+            <img id="bg" class="img">
+            <div class="overlay">
+              <ha-icon id="icon"></ha-icon>
+              <div class="text">
+                <span id="name" class="primary"></span>
+                <span id="info" class="secondary"></span>
+              </div>
+            </div>
+            <div id="chips" class="chips"></div>
+            <button id="collapse-btn" class="collapse-btn" type="button"><ha-icon icon="mdi:chevron-down"></ha-icon></button>
+            <button id="details-btn" class="details-btn" type="button" hidden></button>
+          </div>
+          <div id="info-bar" class="info-bar"></div>
+          <div id="room-modes" class="room-modes" role="group" aria-label="${getTranslation(hass, "room_modes")}"></div>
+          <div id="ctrls" class="controls"></div>
+        </div>
+      </ha-card>`;
+
+// src/lib/control-placement.js
+var getControlPlacement = (control) => ["card", "drawer", "both"].includes(control?.display_in) ? control.display_in : "card";
+var isControlInContext = (control, config, context) => {
+  if (config?.detail_drawer?.enabled !== true) return context === "card";
+  const placement = getControlPlacement(control);
+  return placement === "both" || placement === context;
+};
+
+// src/shared/drawer-preview.js
+var KEY2 = /* @__PURE__ */ Symbol.for("room-card.drawer-preview");
+var scopeOf = (node) => {
+  for (let current = node; current; current = current.parentNode || current.host) {
+    if (current.localName === "hui-dialog-edit-card") return current;
+  }
+  return null;
+};
+var registerDrawerPreview = (node, open) => {
+  const scope = scopeOf(node);
+  if (!scope) return () => {
+  };
+  const entries = scope[KEY2] ||= /* @__PURE__ */ new Set();
+  entries.add(open);
+  return () => {
+    entries.delete(open);
+    if (!entries.size) delete scope[KEY2];
+  };
+};
+var requestDrawerPreview = (editor, trigger) => {
+  const entries = scopeOf(editor)?.[KEY2];
+  if (!entries || entries.size !== 1) return false;
+  return [...entries][0](trigger);
 };
 
 // src/shared/presentation.js
@@ -2199,9 +2424,15 @@ var OneLineRoomCard = class extends HTMLElement {
     this._closeDialog = null;
     this._sparklineDialogRequest = 0;
     this._headerImageRequest = 0;
+    this._headerImageRequests = /* @__PURE__ */ new WeakMap();
     this._adaptiveMediaQueries = [];
   }
   connectedCallback() {
+    this._stopDrawerPreview?.();
+    this._stopDrawerPreview = registerDrawerPreview(this, (trigger) => {
+      this._showDetailDrawer(trigger);
+      return !!this._detailDrawer;
+    });
     document.addEventListener("visibilitychange", this._boundPageVisibilityChange);
     this._setupSparklineVisibilityObserver();
     if (this.config) {
@@ -2212,6 +2443,8 @@ var OneLineRoomCard = class extends HTMLElement {
     }
   }
   disconnectedCallback() {
+    this._stopDrawerPreview?.();
+    this._stopDrawerPreview = null;
     this._detailDrawer?.close(false);
     this._closeDialog?.();
     this._closeDialog = null;
@@ -2251,7 +2484,11 @@ var OneLineRoomCard = class extends HTMLElement {
     this._sparklineObserver.observe(this);
   }
   _isSparklinePollingActive() {
-    return this.isConnected && this._sparklineVisible && document.hidden !== true;
+    return this.isConnected && (this._sparklineVisible || !!this._detailDrawer) && document.hidden !== true;
+  }
+  _isControlRendered(ctrl) {
+    if (ctrl.hide || !this._checkConditions(ctrl.visibility, this._hass)) return false;
+    return this._sparklineVisible && isControlInContext(ctrl, this.config, "card") || !!this._detailDrawer && isControlInContext(ctrl, this.config, "drawer");
   }
   set hass(hass) {
     this._hass = hass;
@@ -2340,7 +2577,7 @@ var OneLineRoomCard = class extends HTMLElement {
   _hasSparklineControls() {
     return (this.config?.controls || []).some((ctrl) => {
       const domain = ctrl?.entity?.split?.(".")?.[0];
-      return domain === "sensor" && ctrl.show_sparkline === true;
+      return domain === "sensor" && ctrl.show_sparkline === true && this._isControlRendered(ctrl);
     });
   }
   _setupSparklineInterval() {
@@ -2395,6 +2632,7 @@ var OneLineRoomCard = class extends HTMLElement {
     if (!this._hasSparklineControls() || !this._hass || !this._isSparklinePollingActive()) return;
     const requests = [];
     for (const ctrl of this.config.controls || []) {
+      if (!this._isControlRendered(ctrl)) continue;
       if (ctrl?.show_sparkline !== true) continue;
       const domain = ctrl?.entity?.split?.(".")?.[0];
       if (domain !== "sensor") continue;
@@ -2406,7 +2644,7 @@ var OneLineRoomCard = class extends HTMLElement {
     await Promise.all(requests);
   }
   _updateSparklineElements(key, data) {
-    const wrappers = this.shadowRoot?.querySelectorAll?.(`.btn-sparkline[data-sparkline-key="${key}"]`) || [];
+    const wrappers = [this._cardSurface, this._detailDrawer?.surface].filter(Boolean).flatMap((surface) => Array.from(surface.root.querySelectorAll(`.btn-sparkline[data-sparkline-key="${key}"]`)));
     wrappers.forEach((wrapper) => {
       const btn = wrapper.closest(".btn");
       if (!btn) return;
@@ -2502,7 +2740,7 @@ var OneLineRoomCard = class extends HTMLElement {
       wrapper.style.display = "block";
       this._drawSparkline(wrapper, points, color || "currentColor");
     }
-    if (this._isSparklinePollingActive() && !this._sparklinePending.has(key) && !this._sparklineCache.has(key)) {
+    if (this._isSparklinePollingActive() && this._isControlRendered(ctrl) && !this._sparklinePending.has(key) && !this._sparklineCache.has(key)) {
       this._fetchSparklineData(entityId, hours);
     }
   }
@@ -2647,181 +2885,15 @@ var OneLineRoomCard = class extends HTMLElement {
   static getStubConfig(hass) {
     return { name: "", entity: "", collapsible: true, controls: [] };
   }
+  _createSurface(root, kind) {
+    root.innerHTML = getRoomSurfaceMarkup(this._hass);
+    const surface = { root, kind, controls: root.getElementById("ctrls"), signature: null };
+    surface.controls.dataset.renderContext = kind;
+    return surface;
+  }
   render() {
     if (!this.config) return;
-    const actOpts = [
-      { value: "more-info", label: getTranslation(this._hass, "act_more") || "Details (Default)" },
-      { value: "toggle", label: getTranslation(this._hass, "act_toggle") || "Toggle" },
-      { value: "navigate", label: getTranslation(this._hass, "act_navigate") || "Navigate" },
-      { value: "none", label: getTranslation(this._hass, "act_none") || "None" }
-    ];
-    this.shadowRoot.innerHTML = `
-      <style>
-        ha-card { position: relative; overflow: hidden; border-radius: 16px; background: none; border: none; cursor: default; }
-        ha-card.warning-battery { outline: 2px solid var(--error-color, #d32f2f); outline-offset: -2px; }
-        ha-card.warning-humidity { outline: 2px solid var(--info-color, #2196F3); outline-offset: -2px; box-shadow: 0 0 0 2px rgba(33,150,243,0.35), 0 0 12px rgba(33,150,243,0.35), 0 0 22px rgba(33,150,243,0.25); }
-        ha-card.alert-sensor { outline: 2px solid var(--rc-alert-border-color, var(--error-color, #d32f2d)); outline-offset: -2px; box-shadow: 0 0 0 2px rgba(211,47,47,0.15); }
-        .container { display: flex; flex-direction: column; background: var(--ha-card-background, rgba(255,255,255,0.1)); border-radius: 16px; }
-        .img-box { position: relative; width: 100%; height: 120px; overflow: hidden; border-radius: 16px 16px 0 0; background: #444; cursor: pointer; }
-        .img-box.no-image { background: transparent; }
-        .img-box.no-image .img { display: none; }
-        .img-box.no-image .overlay { background: none; position: relative; }
-        .img { width: 100%; height: 100%; object-fit: cover; display: block; transition: filter 0.8s ease; }
-        .img.grayscale { filter: grayscale(100%) brightness(0.6); }
-        .overlay { position: absolute; top: 0; left: 0; width: 100%; padding: 12px; box-sizing: border-box; background: linear-gradient(to bottom, rgba(0,0,0,0.8) 0%, rgba(0,0,0,0) 100%); display: flex; align-items: center; gap: 12px; }
-        .text { display: flex; flex: 1; min-width: 0; flex-direction: column; align-items: flex-start; color: white; text-shadow: 0 1px 2px rgba(0,0,0,0.5); }
-        ha-card.no-header-text-shadow .text { text-shadow: none; }
-        ha-icon { color: var(--icon-color, white); }
-        .primary { display: block; max-width: 100%; font-weight: var(--rc-header-name-weight, bold); font-size: var(--rc-header-name-size, 14px); font-style: var(--rc-header-name-style, normal); color: var(--rc-header-name-color, white); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-        .secondary { max-width: 100%; min-width: 0; font-weight: var(--rc-header-info-weight, normal); font-size: var(--rc-header-info-size, 12px); font-style: var(--rc-header-info-style, normal); color: var(--rc-header-info-color, white); opacity: 0.9; display: flex; flex-wrap: nowrap; gap: 6px; align-items: center; overflow: hidden; }
-        .info-item { display: inline-flex; align-items: center; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-        .info-item.badge { padding: 2px 6px; border-radius: 999px; }
-        .chips { position: absolute; bottom: 8px; left: 8px; display: flex; gap: 6px; flex-wrap: wrap; z-index: 2; }
-        .chip { display: flex; align-items: center; gap: 4px; padding: 4px 8px; border: 0; border-radius: 8px; font-family: inherit; font-size: 11px; font-weight: bold; background: #FFF8E1; color: #FFA000; box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
-        .chip.status-group-chip { background:rgba(var(--rgb-primary-color, 3,169,244),.14); color:var(--primary-color, #03a9f4); }
-        button.chip.status-group-chip { cursor:pointer; }
-        button.chip.status-group-chip:focus-visible { outline:2px solid var(--primary-color, #03a9f4); outline-offset:2px; }
-        .chip ha-icon { color: currentColor; }
-        ha-card.no-chip-shadow .chip { box-shadow: none; }
-        .chip.alert { background: #FFEBEE; color: #D32F2F; }
-        .chip.humidity { background: #E3F2FD; color: #1976D2; }
-        .chip.info { background: #E3F2FD; color: #1976D2; }
-        .chip.custom { background: var(--chip-bg); color: var(--chip-color); }
-        .controls { display: flex; flex-wrap: wrap; gap: 6px; padding: 10px; }
-        .btn.has-sparkline { height: auto; align-items: stretch; overflow: visible; flex-wrap: wrap; padding-bottom: 6px; }
-        .btn-sparkline { width: 100%; flex: 0 0 100%; order: 99; align-self: stretch; min-height: 28px; margin-top: 6px; display: flex; align-items: center; padding: 4px 6px; border: 0; border-radius: 12px; color: inherit; font: inherit; background: rgba(255,255,255,0.06); box-sizing: border-box; }
-        button.btn-sparkline { cursor: pointer; }
-        button.btn-sparkline:focus-visible { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: 2px; }
-        .btn-sparkline svg { width: 100%; height: 22px; display: block; overflow: visible; }
-        .btn-sparkline polyline { fill: none; vector-effect: non-scaling-stroke; }
-        .btn { position: relative; display: flex; align-items: center; gap: 10px; padding: 0 10px; border-radius: 12px; cursor: pointer; background: var(--rc-btn-bg, var(--btn-bg, var(--card-background-color, rgba(128,128,128,0.05)))); border: 1px solid transparent; flex-grow: 1; flex-shrink: 1; min-width: 0; overflow: hidden; box-sizing: border-box; transition: background 0.2s; user-select: none; -webkit-user-select: none; touch-action: manipulation; -webkit-tap-highlight-color: transparent; flex-basis: var(--btn-flex-basis, auto); height: var(--btn-height, 60px); justify-content: var(--btn-justify, center); }
-        .btn.label-right { flex-direction: row; align-items: center; justify-content: var(--btn-justify, center); gap: 10px; padding: 0 10px; }
-        .btn.label-left { flex-direction: row-reverse; align-items: center; justify-content: var(--btn-justify, center); gap: 10px; padding: 0 10px; }
-        .btn.label-bottom { flex-direction: column; justify-content: flex-start; align-items: center; gap: 1px; padding: 2px 4px; overflow: hidden; }
-        .btn.label-top { flex-direction: column-reverse; justify-content: center; gap: 4px; padding: 6px 8px; overflow: hidden; }
-        .btn.has-inline-ctrl.label-bottom,
-        .btn.has-inline-ctrl.label-top { align-items: center; }
-        .btn.has-inline-ctrl.label-bottom .btn-top,
-        .btn.has-inline-ctrl.label-top .btn-top { align-items: center; width: 100%; }
-        .btn.label-left .btn-txt { text-align: right; align-items: flex-end; }
-        .btn.label-bottom .icon-box,
-        .btn.label-top .icon-box { flex-shrink: 0; }
-        .btn.label-bottom .icon-box { width: 28px; height: 28px; margin-top: 1px; }
-        .btn.label-bottom ha-icon { --mdc-icon-size: 18px; }
-        .btn.label-bottom .btn-txt,
-        .btn.label-top .btn-txt { text-align: center; align-items: center; flex: 1; min-height: 0; max-width: 100%; overflow: hidden; }
-        .btn.label-bottom .btn-txt { flex: 0 0 auto; min-height: 22px; max-height: 22px; gap: 1px; }
-        .btn.label-bottom .btn-name,
-        .btn.label-bottom .btn-state,
-        .btn.label-top .btn-name,
-        .btn.label-top .btn-state { font-size: 11px; line-height: 1.1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
-        .btn.label-bottom .btn-name { font-size: 11px; line-height: 11px; }
-        .btn.label-bottom .btn-state { font-size: 10px; line-height: 10px; margin-top: 0; }
-        .btn:hover { background: var(--rc-btn-bg-hover, rgba(128,128,128,0.1)); border-color: rgba(128,128,128,0.2); }
-        .btn:active { background: var(--rc-btn-bg-active, rgba(128,128,128,0.15)); }
-        .btn:focus-visible, button:focus-visible, select:focus-visible, input:focus-visible, .img-box:focus-visible { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: 2px; }
-        .btn.state-unavailable { opacity: 0.56; }
-        .btn.state-unavailable:hover,
-        .btn.state-unavailable:active { background: var(--rc-btn-bg, var(--btn-bg, var(--card-background-color, rgba(128,128,128,0.05)))); border-color: transparent; }
-        .btn.state-unavailable .btn-name,
-        .btn.state-unavailable .btn-state,
-        .btn.state-unavailable ha-icon { color: var(--disabled-text-color, var(--secondary-text-color)); }
-        .icon-box { display: flex; align-items: center; justify-content: center; width: 32px; height: 32px; border-radius: 50%; flex-shrink: 0; background: var(--icon-bg, transparent); }
-        .btn-txt { display: flex; flex-direction: column; text-align: left; overflow: hidden; min-width: 0; flex: initial; max-width: 100%; }
-        .btn ha-icon { color: var(--rc-icon-color, var(--icon-color, grey)); --mdc-icon-size: 20px; }
-        .btn-name { font-size: 13px; font-weight: 600; color: var(--primary-text-color); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
-        .btn-state { font-size: 11px; color: var(--secondary-text-color); margin-top: 1px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
-        .warn { position: absolute; top: 4px; right: 4px; color: #d32f2f; --mdc-icon-size: 16px; background: rgba(255,255,255,0.8); border-radius: 50%; padding: 1px; }
-        .warn.warn-offline { color: var(--warning-color, var(--secondary-text-color)); background: var(--card-background-color, rgba(255,255,255,0.85)); }
-        .btn.has-inline-ctrl { flex-direction: column; align-items: stretch; padding: 6px 10px; gap: 4px; height: auto; min-height: var(--btn-height, 60px); }
-        .btn.has-inline-ctrl .btn-top { display: flex; align-items: center; gap: 10px; width: 100%; flex: 0 0 auto; }
-        .btn.has-inline-ctrl .btn-txt { flex: 1; min-width: 0; }
-        .btn-slider-wrap { width: 100%; flex: 0 0 auto; padding: 0 2px 4px; }
-        .btn-slider { -webkit-appearance: none; appearance: none; width: 100%; height: 4px; border-radius: 2px; outline: none; cursor: pointer; background: linear-gradient(to right, var(--icon-color, #ff9800) 0%, var(--icon-color, #ff9800) var(--slider-pct, 0%), rgba(128,128,128,0.3) var(--slider-pct, 0%), rgba(128,128,128,0.3) 100%); }
-        .btn-slider::-webkit-slider-thumb { -webkit-appearance: none; width: 14px; height: 14px; border-radius: 50%; background: var(--icon-color, #ff9800); cursor: pointer; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
-        .btn-slider::-moz-range-thumb { width: 14px; height: 14px; border-radius: 50%; background: var(--icon-color, #ff9800); cursor: pointer; border: none; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
-        .btn-cover-actions { display: flex; gap: 4px; width: 100%; flex: 0 0 auto; padding-bottom: 4px; }
-        .cover-action-btn { flex: 0 0 auto; display: flex; align-items: center; justify-content: center; background: rgba(128,128,128,0.1); border: 0; color: inherit; font: inherit; border-radius: 6px; padding: 4px 6px; cursor: pointer; transition: background 0.15s; touch-action: manipulation; }
-        .cover-action-btn:hover { background: rgba(128,128,128,0.22); }
-        .cover-action-btn ha-icon { --mdc-icon-size: 16px; color: var(--primary-text-color); }
-        .media-transport-row, .media-volume-row { display: flex; align-items: center; gap: 6px; width: 100%; flex: 0 0 auto; }
-        .media-transport-row { justify-content: center; padding-top: 2px; }
-        .media-volume-row { padding: 2px 0 4px; }
-        .media-ctrl-btn { flex: 0 0 auto; display: flex; align-items: center; justify-content: center; width: 32px; height: 32px; padding: 0; border: 0; border-radius: 50%; background: transparent; color: inherit; cursor: pointer; transition: background 0.15s; touch-action: manipulation; }
-        .media-ctrl-btn:hover { background: rgba(128,128,128,0.18); }
-        .media-ctrl-btn ha-icon { --mdc-icon-size: 19px; color: var(--primary-text-color); }
-        .media-ctrl-btn.muted ha-icon { color: var(--secondary-text-color); }
-        .media-volume-row .btn-slider-wrap { flex: 1; min-width: 0; padding: 0; }
-        .media-volume-row .btn-slider { height: 4px; }
-        .media-volume-row .vol-label { font-size: 10px; font-weight: 600; color: var(--secondary-text-color); min-width: 32px; text-align: center; flex: 0 0 auto; }
-        .media-thumb { width: 40px; height: 40px; border-radius: 4px; object-fit: cover; flex-shrink: 0; }
-        .media-full-layout { display: flex; gap: 10px; width: 100%; align-items: stretch; }
-        .media-full-layout .media-thumb { width: 72px; height: 72px; aspect-ratio: 1; border-radius: 6px; align-self: center; object-fit: cover; }
-        .media-full-layout .media-right { display: flex; flex-direction: column; flex: 1; min-width: 0; justify-content: center; gap: 2px; }
-        .btn-cover-presets { display: flex; gap: 4px; width: 100%; flex: 0 0 auto; padding-bottom: 4px; }
-        .preset-btn { flex: 1; display: flex; align-items: center; justify-content: center; background: rgba(128,128,128,0.1); border: 0; border-radius: 6px; padding: 3px 4px; cursor: pointer; transition: background 0.15s, color 0.15s; font: inherit; font-size: 11px; font-weight: 600; color: var(--secondary-text-color); white-space: nowrap; touch-action: manipulation; }
-        .preset-btn:hover { background: rgba(128,128,128,0.22); color: var(--primary-text-color); }
-        .preset-btn.active { background: var(--icon-color, var(--primary-color, #ff9800)); color: #fff; }
-        .btn-select-dropdown { width: 100%; padding-bottom: 4px; }
-        .btn-select-dropdown select { width: 100%; padding: 4px 8px; border-radius: 6px; border: none; background: rgba(128,128,128,0.12); color: var(--primary-text-color); font-size: 12px; font-weight: 500; cursor: pointer; appearance: auto; outline: none; touch-action: manipulation; }
-        .btn-select-dropdown select:focus { box-shadow: 0 0 0 1px var(--icon-color, var(--primary-color, #ff9800)); }
-        .btn-select-options { flex-wrap: wrap; }
-        .btn-select-options .preset-btn { flex: 0 1 auto; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
-        .btn-color-favorites { display: flex; gap: 6px; width: 100%; flex: 0 0 auto; padding-bottom: 4px; flex-wrap: wrap; }
-        .color-swatch { width: 20px; height: 20px; padding: 0; border-radius: 50%; cursor: pointer; flex-shrink: 0; border: 2px solid transparent; transition: transform 0.15s, border-color 0.15s; box-shadow: 0 1px 3px rgba(0,0,0,0.25); touch-action: manipulation; }
-        .color-swatch:hover { transform: scale(1.2); }
-        .color-swatch.active { border-color: var(--primary-text-color); transform: scale(1.15); }
-        .controls { transition: max-height 0.35s ease, padding 0.35s ease; overflow: hidden; max-height: 2000px; }
-        .controls.collapsed { max-height: 0 !important; padding-top: 0 !important; padding-bottom: 0 !important; }
-        .collapse-btn { position: absolute; bottom: 8px; right: 8px; z-index: 3; width: 28px; height: 28px; padding: 0; border: 0; border-radius: 50%; background: rgba(0,0,0,0.38); display: none; align-items: center; justify-content: center; cursor: pointer; }
-        .collapse-btn ha-icon { --mdc-icon-size: 18px; color: white; transition: transform 0.35s ease; }
-        .collapse-btn.open ha-icon { transform: rotate(180deg); }
-        .details-btn { position:absolute; top:8px; right:8px; z-index:3; min-width:44px; min-height:44px; padding:8px 12px; border:0; border-radius:12px; background:rgba(0,0,0,.55); color:white; font:inherit; cursor:pointer; }
-        .details-btn[hidden] { display:none; }
-        .details-btn:focus-visible { outline:2px solid var(--primary-color,#03a9f4); outline-offset:2px; }
-        .btn-chips { display: flex; flex-direction: row; flex-wrap: wrap; gap: 2px; align-items: center; max-width: 100%; margin-top: 2px; }
-        .btn-chips.chips-top { margin-top: 0; margin-bottom: 2px; }
-        .btn.has-inline-ctrl .btn-chips { margin-top: 4px; padding-bottom: 2px; }
-        .btn.has-inline-ctrl .btn-chips.chips-top { margin-top: 0; margin-bottom: 4px; padding-bottom: 0; padding-top: 2px; }
-        .btn-chip { display: inline-flex; align-items: center; gap: 2px; padding: 2px 5px; background: rgba(var(--rgb-primary-text-color, 0, 0, 0), 0.12); color: var(--secondary-text-color, rgba(0,0,0,0.6)); border-radius: 6px; max-width: 100%; box-sizing: border-box; }
-        .btn-chip span { font-size: 9px; line-height: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-        .btn-chip ha-icon { --mdc-icon-size: 11px; }
-        .info-bar { display: none; flex-wrap: nowrap; gap: 6px; padding: 4px 12px 6px; align-items: center; overflow: hidden; font-size: var(--rc-header-info-size, 12px); font-weight: var(--rc-header-info-weight, normal); font-style: var(--rc-header-info-style, normal); color: var(--rc-header-info-color, var(--secondary-text-color)); }
-        .info-bar.active { display: flex; }
-        .room-modes { display: flex; gap: 7px; padding: 8px 10px; overflow-x: auto; overflow-y: hidden; scrollbar-width: thin; overscroll-behavior-inline: contain; border-top: 1px solid var(--divider-color, rgba(128,128,128,.18)); }
-        .room-modes:empty { display: none; }
-        .room-mode { flex: 0 0 auto; min-height: 34px; display: inline-flex; align-items: center; gap: 6px; padding: 6px 11px; border: 1px solid var(--divider-color, rgba(128,128,128,.25)); border-radius: 999px; color: var(--primary-text-color); background: rgba(128,128,128,.08); font: inherit; font-size: 12px; font-weight: 600; white-space: nowrap; cursor: pointer; touch-action: manipulation; }
-        .room-mode ha-icon { --mdc-icon-size: 18px; color: var(--room-mode-color, var(--primary-color)); }
-        .room-mode.active { color: var(--text-primary-color, #fff); background: var(--room-mode-color, var(--primary-color)); border-color: var(--room-mode-color, var(--primary-color)); }
-        .room-mode.active ha-icon { color: currentColor; }
-        .room-mode:disabled { opacity: .45; cursor: not-allowed; }
-        .room-mode:focus-visible { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: 2px; }
-        @media (max-width: 480px) {
-          .media-full-layout { gap: 8px; }
-          .media-full-layout .media-thumb { width: 60px; height: 60px; }
-          .media-ctrl-btn { width: 30px; height: 30px; }
-        }
-      </style>
-      <ha-card>
-        <div class="container">
-          <div class="img-box">
-            <img id="bg" class="img">
-            <div class="overlay">
-              <ha-icon id="icon"></ha-icon>
-              <div class="text">
-                <span id="name" class="primary"></span>
-                <span id="info" class="secondary"></span>
-              </div>
-            </div>
-            <div id="chips" class="chips"></div>
-            <button id="collapse-btn" class="collapse-btn" type="button"><ha-icon icon="mdi:chevron-down"></ha-icon></button>
-            <button id="details-btn" class="details-btn" type="button" hidden></button>
-          </div>
-          <div id="info-bar" class="info-bar"></div>
-          <div id="room-modes" class="room-modes" role="group" aria-label="${getTranslation(this._hass, "room_modes")}"></div>
-          <div id="ctrls" class="controls"></div>
-        </div>
-      </ha-card>`;
+    this._cardSurface = this._createSurface(this.shadowRoot, "card");
     this.content = this.shadowRoot.querySelector(".container");
     this.controls = this.shadowRoot.getElementById("ctrls");
     const imageBox = this.shadowRoot.querySelector(".img-box");
@@ -3206,12 +3278,13 @@ var OneLineRoomCard = class extends HTMLElement {
     const targetUrl = selection?.url || "/static/images/card_media/cover.png";
     image.style.objectPosition = selection?.position || "50% 50%";
     if (image.dataset.roomImageUrl === targetUrl) {
-      this._headerImageRequest += 1;
+      this._headerImageRequests.set(image, null);
       return;
     }
-    const request = ++this._headerImageRequest;
+    const request = {};
+    this._headerImageRequests.set(image, request);
     const commit = () => {
-      if (request !== this._headerImageRequest || !image.isConnected) return;
+      if (request !== this._headerImageRequests.get(image) || !image.isConnected) return;
       image.src = targetUrl;
       image.dataset.roomImageUrl = targetUrl;
     };
@@ -3228,6 +3301,14 @@ var OneLineRoomCard = class extends HTMLElement {
   _updateContentState() {
     if (!this.config || !this._hass || !this.content) return;
     this._syncDetailDrawer();
+    this._updateSurfaceState(this._cardSurface);
+    if (this._detailDrawer?.surface) this._updateSurfaceState(this._detailDrawer.surface);
+    this._configChanged = false;
+    const shouldPoll = this._hasSparklineControls() && this._isSparklinePollingActive();
+    if (shouldPoll !== !!this._sparklineInterval) this._setupSparklineInterval();
+  }
+  _updateSurfaceState(surface) {
+    if (!this.config || !this._hass || !this.content) return;
     const h = this._hass, c = this.config;
     const effectiveEntity = c.entity;
     const effectiveTempSensor = c.temp_sensor;
@@ -3236,7 +3317,7 @@ var OneLineRoomCard = class extends HTMLElement {
     const effectiveBatterySensors = c.battery_sensors || [];
     const systemTempUnit = normalizeTemperatureUnit(h.config.unit_system.temperature) || "°C";
     const configuredTempUnit = normalizeTemperatureUnit(c.temp_unit);
-    const bgEl = this.shadowRoot.getElementById("bg");
+    const bgEl = surface.root.getElementById("bg");
     this._applyHeaderImage(bgEl, resolveAdaptiveRoomImage(c, h));
     if (c.image_entity && h.states[c.image_entity]) {
       const isOff = !isEntityActive(h.states[c.image_entity], c.image_entity);
@@ -3244,7 +3325,7 @@ var OneLineRoomCard = class extends HTMLElement {
     } else {
       bgEl.classList.remove("grayscale");
     }
-    const imgBox = this.shadowRoot.querySelector(".img-box");
+    const imgBox = surface.root.querySelector(".img-box");
     if (imgBox) {
       const hh = c.header_height !== void 0 ? Number(c.header_height) : NaN;
       const hideImg = c.show_image === false;
@@ -3253,10 +3334,10 @@ var OneLineRoomCard = class extends HTMLElement {
       else imgBox.style.height = "120px";
       imgBox.classList.toggle("no-image", hideImg);
     }
-    const nameEl = this.shadowRoot.getElementById("name");
+    const nameEl = surface.root.getElementById("name");
     nameEl.innerText = c.name || "Room";
     nameEl.style.display = c.show_name === false ? "none" : "";
-    const ico = this.shadowRoot.getElementById("icon");
+    const ico = surface.root.getElementById("icon");
     ico.icon = c.icon || "mdi:home";
     const headerManualColor = isHeaderManualColorEnabled(c);
     const headerColors = this._resolveEntityIconColors(effectiveEntity, h, {
@@ -3287,8 +3368,8 @@ var OneLineRoomCard = class extends HTMLElement {
       hm = climateState.attributes.current_humidity;
     }
     const infoPos = c.info_line_position || "header";
-    const infoEl = this.shadowRoot.getElementById("info");
-    const infoBarEl = this.shadowRoot.getElementById("info-bar");
+    const infoEl = surface.root.getElementById("info");
+    const infoBarEl = surface.root.getElementById("info-bar");
     const infoParts = [];
     const standardHeaderBadgeBackground = trimStr(c.header_info_background);
     if (t != null && t !== "-" && !isNaN(parseFloat(t))) {
@@ -3360,13 +3441,13 @@ var OneLineRoomCard = class extends HTMLElement {
       }
     });
     if (infoBarEl) infoBarEl.classList.toggle("active", infoPos === "below_header" && infoParts.length > 0);
-    const textEl = this.shadowRoot.querySelector(".text");
+    const textEl = surface.root.querySelector(".text");
     const nameOffset = Number(c.header_name_offset ?? 0);
     const infoOffset = infoPos === "header" ? Number(c.header_info_offset ?? 0) : 0;
     if (textEl) textEl.style.flex = nameOffset > 0 || infoOffset > 0 ? "1" : "";
     this._applyHeaderOffset(nameEl, nameOffset, textEl);
     if (infoPos === "header") this._applyHeaderOffset(infoEl, infoOffset, textEl);
-    const ch = this.shadowRoot.getElementById("chips");
+    const ch = surface.root.getElementById("chips");
     ch.replaceChildren();
     const createHeaderChip = (className, iconName, text, tagName = "div") => {
       const chip = document.createElement(tagName);
@@ -3483,7 +3564,7 @@ var OneLineRoomCard = class extends HTMLElement {
       ch.appendChild(chip);
     });
     this._renderStatusGroups(ch, c, h);
-    const cardEl = this.shadowRoot.querySelector("ha-card");
+    const cardEl = surface.root.querySelector("ha-card");
     if (cardEl) {
       const showStatusBorder = c.show_status_border !== false;
       cardEl.classList.toggle("no-header-text-shadow", c.show_header_text_shadow === false);
@@ -3511,35 +3592,36 @@ var OneLineRoomCard = class extends HTMLElement {
       setStrProp("--rc-header-info-style", c.header_info_style, "normal");
       setStrProp("--rc-header-info-color", c.header_info_color, "white");
     }
-    this._renderRoomModes(c, h);
-    this._syncCollapseUI();
+    this._renderRoomModes(c, h, surface.root);
+    if (surface.kind === "card") this._syncCollapseUI();
     let visibleCtrls = (c.controls || []).filter((ctrl) => {
+      if (!isControlInContext(ctrl, c, surface.kind)) return false;
       if (ctrl.hide) return false;
       if (Array.isArray(ctrl.visibility) && ctrl.visibility.length > 0) {
         if (!this._checkConditions(ctrl.visibility, h)) return false;
       }
       return ctrl.entity || ctrl.type === "template";
     });
-    if (c.auto_climate_button && c.entity && getEntityDomain(c.entity) === "climate") {
+    if (surface.kind === "card" && c.auto_climate_button && c.entity && getEntityDomain(c.entity) === "climate") {
       const alreadyPresent = visibleCtrls.some((ctrl) => ctrl.entity === c.entity);
       if (!alreadyPresent) {
         const climateState2 = h.states[c.entity];
         visibleCtrls = [{ entity: c.entity, name: climateState2?.attributes?.friendly_name || "", width: 60, height: 60 }, ...visibleCtrls];
       }
     }
-    const controlsSig = JSON.stringify(visibleCtrls.map((ct) => ct.entity + (ct.type || "")));
-    if (this._configChanged || this._lastControlsSig !== controlsSig) {
-      this._lastControlsSig = controlsSig;
-      this.controls.replaceChildren();
+    const controlsSig = JSON.stringify(visibleCtrls);
+    if (this._configChanged || surface.signature !== controlsSig) {
+      surface.signature = controlsSig;
+      for (const node of surface.controls.children) node._disposeActions?.();
+      surface.controls.replaceChildren();
       visibleCtrls.forEach((ctrl) => {
         const btn = this._createBtn(ctrl);
-        this.controls.appendChild(btn);
+        surface.controls.appendChild(btn);
         this._updateBtnState(btn, ctrl, h);
       });
-      this._configChanged = false;
     } else {
       visibleCtrls.forEach((ctrl, i) => {
-        const btn = this.controls.children[i];
+        const btn = surface.controls.children[i];
         if (btn) this._updateBtnState(btn, ctrl, h);
       });
     }
@@ -3628,8 +3710,8 @@ var OneLineRoomCard = class extends HTMLElement {
     apply();
     requestAnimationFrame(() => requestAnimationFrame(apply));
   }
-  _renderRoomModes(config, hass) {
-    const container = this.shadowRoot.getElementById("room-modes");
+  _renderRoomModes(config, hass, root = this.shadowRoot) {
+    const container = root.getElementById("room-modes");
     if (!container) return;
     const modes = (Array.isArray(config?.room_modes) ? config.room_modes : []).filter((mode) => ["scene", "script"].includes(getEntityDomain(mode?.entity)));
     const signature = JSON.stringify(modes.map((mode) => ({
@@ -3640,7 +3722,8 @@ var OneLineRoomCard = class extends HTMLElement {
       active_when: mode.active_when || null
     })));
     if (container.dataset.configSignature !== signature) {
-      const focusedEntity = this.shadowRoot.activeElement?.closest?.(".room-mode")?.dataset?.entity;
+      const active = deepActiveElement();
+      const focusedEntity = container.contains(active) ? active?.closest?.(".room-mode")?.dataset?.entity : null;
       const buttons = modes.map((mode) => {
         const domain = getEntityDomain(mode.entity);
         const button = document.createElement("button");
@@ -3711,7 +3794,7 @@ var OneLineRoomCard = class extends HTMLElement {
     const domain = ctrl.entity ? ctrl.entity.split(".")[0] : "";
     const isTemplate = ctrl.type === "template";
     const subChipPresentations = resolveSubChipPresentations(ctrl, h);
-    const activeElement = this.shadowRoot.activeElement;
+    const activeElement = deepActiveElement();
     const focusedControlKey = activeElement && btn.contains(activeElement) ? activeElement.dataset?.rcFocusKey || "" : "";
     let typ = "default";
     if (domain === "cover") typ = "shutter";
@@ -4464,7 +4547,10 @@ var OneLineRoomCard = class extends HTMLElement {
     } else {
       btn.classList.remove("has-inline-ctrl");
     }
-    if (focusedControlKey && !this.controls?.hasAttribute("inert")) {
+    Array.from(btn.querySelectorAll("button,input,select,textarea,a[href],[tabindex]")).forEach((element, index) => {
+      element.dataset.rcFocusKey ||= `${element.localName}:${index}`;
+    });
+    if (focusedControlKey && !btn.closest(".controls")?.hasAttribute("inert")) {
       const replacement = Array.from(btn.querySelectorAll("[data-rc-focus-key]")).find((element) => element.dataset.rcFocusKey === focusedControlKey);
       replacement?.focus();
     }
@@ -4488,7 +4574,7 @@ var OneLineRoomCard = class extends HTMLElement {
     const trackTimeout = (fn, ms) => {
       const id = setTimeout(() => {
         this._activeTimers.delete(id);
-        fn();
+        if (node.isConnected) fn();
       }, ms);
       this._activeTimers.add(id);
       return id;
@@ -4496,6 +4582,12 @@ var OneLineRoomCard = class extends HTMLElement {
     const cancelTimeout = (id) => {
       clearTimeout(id);
       this._activeTimers.delete(id);
+    };
+    node._disposeActions = () => {
+      cancelTimeout(timer);
+      cancelTimeout(holdTimer);
+      timer = null;
+      holdTimer = null;
     };
     const triggerTap = () => {
       if (this._isEntityUnavailable(ctrl.entity) || held) return;
@@ -4618,7 +4710,7 @@ var OneLineRoomCard = class extends HTMLElement {
     });
     node.addEventListener("blur", cancel);
   }
-  _attachHeaderActions(node) {
+  _attachHeaderActions(node, context = "card") {
     const getActionContext = () => {
       const config = this.config || {};
       return {
@@ -4637,7 +4729,7 @@ var OneLineRoomCard = class extends HTMLElement {
     const trackTimeout = (fn, ms) => {
       const id = setTimeout(() => {
         this._activeTimers.delete(id);
-        fn();
+        if (node.isConnected) fn();
       }, ms);
       this._activeTimers.add(id);
       return id;
@@ -4648,6 +4740,7 @@ var OneLineRoomCard = class extends HTMLElement {
     };
     const handleTap = () => {
       const { cardConfig, actionConfig, hasExplicitTap } = getActionContext();
+      if (context === "drawer" && !hasExplicitTap) return;
       if (!hasExplicitTap && cardConfig.collapsible === true) {
         this._toggleCollapse();
         return;
@@ -4659,6 +4752,12 @@ var OneLineRoomCard = class extends HTMLElement {
         cancelTimeout(holdTimer);
         holdTimer = null;
       }
+    };
+    node._disposeActions = () => {
+      cancelTimeout(timer);
+      cancelTimeout(holdTimer);
+      timer = null;
+      holdTimer = null;
     };
     node.addEventListener("pointerdown", () => {
       held = false;
@@ -4773,14 +4872,15 @@ var OneLineRoomCard = class extends HTMLElement {
       trigger,
       onClose: () => {
         this._closeDialog?.(false);
+        for (const node of this._detailDrawer?.surface?.controls.children || []) node._disposeActions?.();
+        this._detailDrawer?.surface?.root.querySelector(".img-box")?._disposeActions?.();
         this._detailDrawer = null;
         this.shadowRoot.getElementById("details-btn")?.setAttribute("aria-expanded", "false");
+        this._setupSparklineInterval();
       }
     });
-    const note = document.createElement("p");
-    note.className = "prototype-note";
     const actions = document.createElement("div");
-    actions.className = "prototype-actions";
+    actions.className = "drawer-actions";
     for (const [name, action] of [
       ["more", (event) => {
         event.currentTarget.focus({ preventScroll: true });
@@ -4795,8 +4895,14 @@ var OneLineRoomCard = class extends HTMLElement {
       button.addEventListener("click", action);
       actions.append(button);
     }
-    this._detailDrawer.content.append(note, actions);
+    const surfaceHost = document.createElement("div");
+    surfaceHost.dataset.roomSurface = "drawer";
+    this._detailDrawer.content.append(actions, surfaceHost);
+    this._detailDrawer.surface = this._createSurface(surfaceHost.attachShadow({ mode: "open" }), "drawer");
+    this._attachHeaderActions(this._detailDrawer.surface.root.querySelector(".img-box"), "drawer");
     this._syncDetailDrawer();
+    this._updateSurfaceState(this._detailDrawer.surface);
+    this._setupSparklineInterval();
   }
   _drawerHistoryEntity() {
     return (this.config?.controls || []).find((ctrl) => ctrl.entity?.startsWith("sensor.") && ctrl.show_sparkline === true)?.entity || (this.config?.temp_sensor?.startsWith("sensor.") ? this.config.temp_sensor : "");
@@ -4819,7 +4925,14 @@ var OneLineRoomCard = class extends HTMLElement {
     }
     if (!this._detailDrawer) return;
     this._detailDrawer.update({ title: this.config.detail_drawer.title || this.config.name || t("room_details"), closeLabel: t("a11y_close"), themeSource: this });
-    this._detailDrawer.content.querySelector(".prototype-note").textContent = t("drawer_prototype_note");
+    const header = this._detailDrawer.surface?.root.querySelector(".img-box");
+    const hasAction = [this.config.tap_action, this.config.hold_action, this.config.double_tap_action].some((action) => action?.action && action.action !== "none");
+    if (header) {
+      header.tabIndex = hasAction ? 0 : -1;
+      if (hasAction) header.setAttribute("role", "button");
+      else header.removeAttribute("role");
+      header.setAttribute("aria-label", this.config.name || t("room_details"));
+    }
     const more = this._detailDrawer.content.querySelector('[data-drawer-action="more"]');
     more.textContent = t("act_more");
     more.disabled = !this.config.entity || !this._hass?.states?.[this.config.entity] || this._isEntityUnavailable(this.config.entity);
@@ -5718,6 +5831,14 @@ var OneLineRoomCardEditor = class extends HTMLElement {
       </div>
       </div>
       <div class="sec">
+        <h3>${getTranslation(h, "room_details")}</h3>
+        <ha-formfield label="${getTranslation(h, "drawer_enable")}"><ha-switch id="drawer-enabled"></ha-switch></ha-formfield>
+        <oneline-room-card-textfield id="drawer-title" label="${getTranslation(h, "drawer_title")}" style="display:block;margin-top:12px"></oneline-room-card-textfield>
+        <p>${getTranslation(h, "drawer_help")}</p>
+        <button type="button" id="drawer-preview">${getTranslation(h, "drawer_preview")}</button>
+        <p id="drawer-preview-status" role="status"></p>
+      </div>
+      <div class="sec">
         <div id="room-modes-head" class="sec-head" style="cursor:pointer;user-select:none;padding:4px 0">
           <h3>${getTranslation(h, "room_modes")}</h3>
           <ha-icon id="room-modes-chev" icon="mdi:chevron-right" style="--mdc-icon-size:18px;opacity:0.7;transition:transform 0.15s ease"></ha-icon>
@@ -6201,6 +6322,27 @@ var OneLineRoomCardEditor = class extends HTMLElement {
       });
     }
     const roomModesHead = this.shadowRoot.getElementById("room-modes-head");
+    const setDrawerOption = (key, value) => {
+      const drawer = { ...this._config.detail_drawer, [key]: value };
+      if (value === "") delete drawer[key];
+      this._fire({ ...this._config, detail_drawer: drawer });
+      this._updateDrawerUI();
+    };
+    this.shadowRoot.getElementById("drawer-enabled").addEventListener("change", (event) => {
+      event.stopPropagation();
+      setDrawerOption("enabled", event.target.checked === true);
+    });
+    this.shadowRoot.getElementById("drawer-title").addEventListener("input", (event) => {
+      event.stopPropagation();
+      setDrawerOption("title", event.target.value);
+    });
+    this.shadowRoot.getElementById("drawer-preview").addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!this._livePreview || this._config.detail_drawer?.enabled !== true) return;
+      const opened = requestDrawerPreview(this, event.currentTarget);
+      this.shadowRoot.getElementById("drawer-preview-status").textContent = opened ? "" : getTranslation(this._hass, "drawer_preview_unavailable");
+    });
     if (roomModesHead) {
       roomModesHead.addEventListener("click", () => {
         this._roomModesSectionOpen = !this._roomModesSectionOpen;
@@ -6902,6 +7044,7 @@ var OneLineRoomCardEditor = class extends HTMLElement {
     }
     const actOpts = [
       { value: "more-info", label: getTranslation(h, "act_more") || "Details (Default)" },
+      { value: "room-details", label: getTranslation(h, "room_details") },
       { value: "toggle", label: getTranslation(h, "act_toggle") || "Toggle" },
       { value: "navigate", label: getTranslation(h, "act_navigate") || "Navigate" },
       { value: "none", label: getTranslation(h, "act_none") || "None" }
@@ -7197,6 +7340,7 @@ var OneLineRoomCardEditor = class extends HTMLElement {
         const enabled = ev.target.checked !== false;
         const wasEnabled = this._livePreview !== false;
         this._livePreview = enabled;
+        this._updateDrawerUI();
         if (enabled && !wasEnabled) this._flushPendingConfig();
       });
     }
@@ -7536,6 +7680,19 @@ var OneLineRoomCardEditor = class extends HTMLElement {
     if (content) content.hidden = !this._actionsSectionOpen;
     if (section) section.classList.toggle("open", this._actionsSectionOpen);
     if (chev) chev.style.transform = this._actionsSectionOpen ? "rotate(90deg)" : "";
+  }
+  _updateDrawerUI() {
+    const enabled = this._config?.detail_drawer?.enabled === true;
+    const toggle = this.shadowRoot?.getElementById("drawer-enabled");
+    const title = this.shadowRoot?.getElementById("drawer-title");
+    const preview = this.shadowRoot?.getElementById("drawer-preview");
+    if (toggle) toggle.checked = enabled;
+    if (title) {
+      title.value = this._config?.detail_drawer?.title || "";
+      title.placeholder = this._config?.name || getTranslation(this._hass, "room_details");
+      title.disabled = !enabled;
+    }
+    if (preview) preview.disabled = !enabled || !this._livePreview;
   }
   _updateRoomModesUI() {
     const content = this.shadowRoot?.getElementById("room-modes-content");
@@ -8623,6 +8780,7 @@ var OneLineRoomCardEditor = class extends HTMLElement {
     if (!h) return;
     this._syncControlIds();
     const actOpts = [
+      { value: "room-details", label: getTranslation(h, "room_details") },
       { value: "more-info", label: getTranslation(h, "act_more") || "Details (Default)" },
       { value: "toggle", label: getTranslation(h, "act_toggle") || "Toggle" },
       { value: "navigate", label: getTranslation(h, "act_navigate") || "Navigate" },
@@ -8830,6 +8988,37 @@ var OneLineRoomCardEditor = class extends HTMLElement {
         }
         this._fire({ ...this._config, controls: c });
       };
+      const placement = document.createElement("ha-selector");
+      placement.className = "display-in";
+      placement.label = getTranslation(h, "drawer_placement");
+      placement.hass = h;
+      placement.selector = { select: { mode: "dropdown", options: [
+        { value: "card", label: getTranslation(h, "drawer_card") },
+        { value: "drawer", label: getTranslation(h, "room_details") },
+        { value: "both", label: getTranslation(h, "drawer_both") }
+      ] } };
+      placement.value = getControlPlacement(ctrl);
+      placement.addEventListener("value-changed", (event) => {
+        event.stopPropagation();
+        const value = getControlPlacement({ display_in: event.detail?.value });
+        placement.value = value;
+        upd("display_in", value, true);
+      });
+      box.querySelector(".body").prepend(placement);
+      const duplicate = document.createElement("button");
+      duplicate.type = "button";
+      duplicate.className = "dup";
+      duplicate.textContent = getTranslation(h, "control_duplicate");
+      duplicate.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const controls = [...this._config.controls];
+        controls.splice(i + 1, 0, structuredClone(controls[i]));
+        this._controlIds.splice(i + 1, 0, this._makeControlId());
+        this._fire({ ...this._config, controls });
+        this.renBtn();
+      });
+      box.querySelector(".body").append(duplicate);
       const updAct = (type, val) => {
         keepOpen();
         const c = [...this._config.controls];
@@ -9860,6 +10049,7 @@ var OneLineRoomCardEditor = class extends HTMLElement {
   }
   updVal() {
     if (!this._config) return;
+    this._updateDrawerUI();
     this.shadowRoot.querySelectorAll(".i").forEach((e) => {
       const k = e.getAttribute("cfg");
       let v = k === "nav_path" ? this._config.tap_action?.navigation_path || "" : this._config[k] ?? "";

--- a/dist/room-card.js
+++ b/dist/room-card.js
@@ -4908,7 +4908,7 @@ var OneLineRoomCard = class extends HTMLElement {
     return (this.config?.controls || []).find((ctrl) => ctrl.entity?.startsWith("sensor.") && ctrl.show_sparkline === true)?.entity || (this.config?.temp_sensor?.startsWith("sensor.") ? this.config.temp_sensor : "");
   }
   _drawerStatusRows() {
-    return (this.config?.status_groups || []).flatMap((group) => {
+    return (Array.isArray(this.config?.status_groups) ? this.config.status_groups : []).flatMap((group) => {
       const result = getStatusGroupResult(group, this._hass);
       return result.visible ? result.contributors : [];
     });

--- a/docs/manual-smoke-test.md
+++ b/docs/manual-smoke-test.md
@@ -19,6 +19,9 @@ the Home Assistant version, browser, viewport, theme, commit SHA, and result.
 | Sparklines | Use two cards with the same sensor, scroll them off/on screen, and hide/show the tab | History is shared, polling pauses, and stale data refreshes on return |
 | Images | Select a preset, move focal point, and upload a valid/invalid image | Preview, validation, upload, and persisted configuration remain correct |
 | Navigation cleanup | Repeatedly enter/leave the dashboard and recreate editor previews | No orphan timers, observers, dialogs, or increasing history traffic remain |
+| Room details placement | Assign Card / Room details / Both, reorder/duplicate, collapse card, disable drawer | Correct independent controls and shared state; drawer remains expanded; disabled fallback returns controls to card |
+| Room details editor | Enable, change title/placement, use preview, save with live preview on/off | Existing HA preview opens; deferred changes apply only on Save; no duplicate card instance |
+| Room details nesting | Open history/status/HA more-info from drawer controls; use Escape/Tab/backdrop; navigate away | Only top dialog handles dismissal, focus and scroll return, no orphan modal; verify desktop/mobile and light/dark |
 
 Gate approval requires all rows to pass. Attach failures to the gate PR; do not
 continue to the next extraction phase while any result is unexplained.

--- a/docs/room-detail-drawer.md
+++ b/docs/room-detail-drawer.md
@@ -1,4 +1,4 @@
-# Room Detail Drawer — prototype decision
+# Room Detail Drawer — architecture and test gates
 
 Target: v1.5.0, issue #127. The source modularization passed its manual gate on
 2026-09-05 against commit `5756362111f9ce8952eab4871cd087c51302bc21`.
@@ -6,6 +6,49 @@ The user confirmed editor/save, existing controls, mobile and light/dark checks.
 The browser confirmed the pinned bundle URL and loaded header images.
 The modularized baseline has 98 passing automated tests and green PR CI.
 No quantitative cold-load timing was recorded; no performance gain is claimed.
+
+## Integration candidate
+
+The prototype landed separately in #150 after the owner's manual confirmation.
+The integration uses `card/surface.js` for the static scaffold and
+`_updateSurfaceState(surface)` for shared rendering. Each surface has its own
+root, controls and configuration signature. The drawer surface has a nested
+shadow root inside the modal host; it is not a second RoomCard instance.
+Image requests are tracked per image node so card/drawer loads cannot invalidate
+each other. Native control focus is restored within the correct surface.
+
+`lib/control-placement.js` defines fallback/placement semantics. Header state,
+images, information, status groups and modes are rendered from the owner's
+configuration. `both` controls have independent listeners but share state and
+history requests. Closed drawer-only or hidden controls do not request history;
+the owner retains at most one sparkline polling interval across both locations.
+
+`shared/drawer-preview.js` pairs the editor with its existing HA preview via
+their common `hui-dialog-edit-card` scope. It never creates another card. If HA
+has not mounted a unique preview, the UI explains how to open it from the saved
+dashboard instead. Live-preview-off changes remain pending until Save.
+
+Automated integration coverage includes placement/defaults, ordering, visibility,
+separate nodes, single actions/service calls, unavailable controls, state updates,
+shared history requests/timer, headers/status/modes, native-control focus,
+cleanup, editor roundtrip/duplication, area setup and preview/save boundaries.
+The suite currently passes 116 tests, including the earlier prototype lifecycle
+tests. Local browser checks verified the integrated desktop view and 390×844
+bottom sheet, plus history from a drawer control and Escape returning to it.
+These checks use simulated data and do not replace the final real-HA test.
+
+### Final manual integration gate — pending
+
+- Assign one control to Card, one to Room details and one to Both; verify order,
+  state updates, presets/sliders/actions and only one physical action per input.
+- Collapse the card; drawer controls must remain accessible. Disable room details;
+  all non-hidden controls must return to the card. Save and reopen the editor.
+- Test live preview on/off, title changes, placement, duplicate/reorder and the
+  editor's Room details preview button on the actual HA frontend.
+- Recheck history/status/HA subdialogs, keyboard focus/Escape, route changes,
+  multiple cards, desktop/mobile and light/dark after full integration.
+- Capture final desktop/mobile release screenshots from actual HA, not the
+  simulated fixture. Only then prepare the final v1.5.0 release gate.
 
 ## Primitive and ownership
 
@@ -23,17 +66,18 @@ only the top modal's Tab, Escape and backdrop. All listeners disappear after
 the last modal closes. A document-scoped symbol also coordinates duplicate
 bundle evaluations. Only one RoomCard drawer can be open at once.
 
-The prototype does not clone or move active controls. Full integration will
-create independent DOM nodes through shared renderers, with the original
-`controls` list as the only configuration source. `display_in` handling and
-the visual editor section belong to the integration PR after this gate.
+The implementation does not clone or move active controls. It creates independent
+DOM nodes through shared renderers, with the original `controls` list as the only
+configuration source. Placement and the visual editor were added only after the
+prototype gate passed.
 
 ## Child dialogs and cleanup
 
 The existing history and status dialogs share the coordinator and render in
 the drawer's shadow root when the drawer owns them. Closing a child restores
-the triggering button without resetting the drawer scroll position. Opening
-the drawer itself does not fetch history or create polling timers.
+the triggering button without resetting the drawer scroll position. Opening an
+empty drawer does not fetch history; visible drawer sparkline controls reuse
+the owner's cache and polling interval.
 
 `ha-dialog-adapter.js` observes confirmed HA `opened` events from dialog
 primitives and matching owner `dialog-closed` events. A dispatched request
@@ -63,7 +107,7 @@ position; the editor's existing deferred save remains the configuration boundary
 - Monkey-patching HA methods or polling for dialog visibility was rejected in
   favor of an isolated event adapter that can be verified on the actual HA build.
 
-## Test the prototype (release remains blocked)
+## Archived prototype gate (passed; final integration gate still pending)
 
 The owner confirmed the actual HA prototype gate on 2026-09-05 against
 `3bdbd2c780a39afed845970be0e68d61f8d4fe65`: HA details/history/status with
@@ -87,8 +131,8 @@ detail_drawer:
   title: Wohnzimmer
 ```
 
-The new **Room details / Raumdetails** header button opens the prototype.
-Existing controls stay on the card during this phase. Optional explicit
+The **Room details / Raumdetails** header button opened the prototype.
+Existing controls stayed on the card during that phase. Optional explicit
 `tap_action`, `hold_action` and `double_tap_action` can use `action: room-details`.
 The preview contains three diagnostic entry points:
 
@@ -96,7 +140,7 @@ The preview contains three diagnostic entry points:
 - History uses a configured sensor sparkline or `temp_sensor`.
 - Status uses contributors from configured `status_groups`.
 
-Before full control integration, manually verify on the actual HA installation:
+The prototype manual checklist was:
 
 1. Desktop sidebar (480px), mobile bottom sheet (90dvh), light/dark, safe-area
    edges, fixed close header and content scroll.
@@ -106,7 +150,7 @@ Before full control integration, manually verify on the actual HA installation:
 4. Open a second card's drawer; navigate away; disable; remove the owner preview.
    No orphan host, stale focus trap or background requests should remain.
 5. Open from an editor preview and verify its interaction with HA's own editor
-   dialog and layering. This is a manual compatibility gate, not yet certified.
+   dialog and layering. The owner confirmed this prototype compatibility gate.
 
 Automated DOM tests verify event contracts and cleanup but cannot certify HA's
 native top-layer implementation, physical mobile interactions or theme visuals.

--- a/docs/room-detail-drawer.md
+++ b/docs/room-detail-drawer.md
@@ -32,7 +32,7 @@ Automated integration coverage includes placement/defaults, ordering, visibility
 separate nodes, single actions/service calls, unavailable controls, state updates,
 shared history requests/timer, headers/status/modes, native-control focus,
 cleanup, editor roundtrip/duplication, area setup and preview/save boundaries.
-The suite currently passes 116 tests, including the earlier prototype lifecycle
+The suite currently passes 117 tests, including invalid `status_groups` YAML and the earlier prototype lifecycle
 tests. Local browser checks verified the integrated desktop view and 390×844
 bottom sheet, plus history from a drawer control and Escape returning to it.
 These checks use simulated data and do not replace the final real-HA test.

--- a/src/card/detail-drawer.js
+++ b/src/card/detail-drawer.js
@@ -19,8 +19,7 @@ export const createDetailDrawer = ({ title, closeLabel, trigger, onClose }) => {
       button:disabled { opacity:.5; cursor:default; }
       button:focus-visible { outline:2px solid var(--primary-color,#03a9f4); outline-offset:2px; }
       .content { flex:1; min-height:0; overflow:auto; overscroll-behavior:contain; padding:16px calc(16px + env(safe-area-inset-right,0px)) calc(16px + env(safe-area-inset-bottom,0px)) calc(16px + env(safe-area-inset-left,0px)); }
-      .prototype-actions { display:flex; flex-wrap:wrap; gap:10px; }
-      .prototype-note { color:var(--secondary-text-color,#666); }
+      .drawer-actions { display:flex; flex-wrap:wrap; gap:10px; margin-bottom:16px; }
       @keyframes enter { from { opacity:0; transform:translateX(24px); } to { opacity:1; transform:none; } }
       @media (max-width:767px) {
         .panel { inset:auto 0 0; width:100%; max-height:90vh; max-height:90dvh; border-radius:20px 20px 0 0; animation-name:enter-bottom; }

--- a/src/card/room-card.js
+++ b/src/card/room-card.js
@@ -2650,7 +2650,7 @@ class OneLineRoomCard extends HTMLElement {
   }
 
   _drawerStatusRows() {
-    return (this.config?.status_groups || []).flatMap(group => {
+    return (Array.isArray(this.config?.status_groups) ? this.config.status_groups : []).flatMap(group => {
       const result = getStatusGroupResult(group, this._hass);
       return result.visible ? result.contributors : [];
     });

--- a/src/card/room-card.js
+++ b/src/card/room-card.js
@@ -11,6 +11,9 @@ import { SHARED_SPARKLINE_CACHE, SHARED_SPARKLINE_PENDING, normalizeSparklineSam
 import { MEDIA_PLAYER_FEATURES, getSliderCapabilities, getInlineButtons, supportsMediaFeature } from "../lib/capabilities.js";
 import { VERSION, EDITOR_DOM_REVISION } from "../version.js";
 import { createDetailDrawer } from "./detail-drawer.js";
+import { getRoomSurfaceMarkup } from "./surface.js";
+import { isControlInContext } from "../lib/control-placement.js";
+import { registerDrawerPreview } from "../shared/drawer-preview.js";
 import { deepActiveElement, getDialogCoordinator } from "../shared/dialog-coordinator.js";
 import { IMAGE_UPLOAD_LIMITS, parseImagePosition, validateImageUpload, ROOM_IMAGE_PRESETS, ROOM_IMAGE_PRESET_MAP, getRoomImagePresetUrl, resolveRoomImageUrl, evaluateAdaptiveImageConditions, resolveAdaptiveRoomImage, getStatusGroupResult, isHeaderManualColorEnabled, resolveLabelPosition, setAlignmentClass, applyLabelPosition, evalTemplateString, resolveTemplateCtrl, resolveSubChipPresentations, TEMPLATE_VALUE_KEYS, getTemplateEntityDependencies, templateNeedsEveryHassUpdate, formatLastChanged } from "../shared/presentation.js";
 
@@ -36,10 +39,16 @@ class OneLineRoomCard extends HTMLElement {
     this._closeDialog = null;
     this._sparklineDialogRequest = 0;
     this._headerImageRequest = 0;
+    this._headerImageRequests = new WeakMap();
     this._adaptiveMediaQueries = [];
   }
 
   connectedCallback() {
+    this._stopDrawerPreview?.();
+    this._stopDrawerPreview = registerDrawerPreview(this, trigger => {
+      this._showDetailDrawer(trigger);
+      return !!this._detailDrawer;
+    });
     document.addEventListener("visibilitychange", this._boundPageVisibilityChange);
     this._setupSparklineVisibilityObserver();
     if (this.config) {
@@ -53,6 +62,8 @@ class OneLineRoomCard extends HTMLElement {
   }
 
   disconnectedCallback() {
+    this._stopDrawerPreview?.();
+    this._stopDrawerPreview = null;
     this._detailDrawer?.close(false);
     this._closeDialog?.();
     this._closeDialog = null;
@@ -94,7 +105,13 @@ class OneLineRoomCard extends HTMLElement {
   }
 
   _isSparklinePollingActive() {
-    return this.isConnected && this._sparklineVisible && document.hidden !== true;
+    return this.isConnected && (this._sparklineVisible || !!this._detailDrawer) && document.hidden !== true;
+  }
+
+  _isControlRendered(ctrl) {
+    if (ctrl.hide || !this._checkConditions(ctrl.visibility, this._hass)) return false;
+    return (this._sparklineVisible && isControlInContext(ctrl, this.config, "card"))
+      || (!!this._detailDrawer && isControlInContext(ctrl, this.config, "drawer"));
   }
 
   set hass(hass) {
@@ -188,7 +205,7 @@ class OneLineRoomCard extends HTMLElement {
   _hasSparklineControls() {
     return (this.config?.controls || []).some((ctrl) => {
       const domain = ctrl?.entity?.split?.(".")?.[0];
-      return domain === "sensor" && ctrl.show_sparkline === true;
+      return domain === "sensor" && ctrl.show_sparkline === true && this._isControlRendered(ctrl);
     });
   }
 
@@ -247,6 +264,7 @@ class OneLineRoomCard extends HTMLElement {
     if (!this._hasSparklineControls() || !this._hass || !this._isSparklinePollingActive()) return;
     const requests = [];
     for (const ctrl of this.config.controls || []) {
+      if (!this._isControlRendered(ctrl)) continue;
       if (ctrl?.show_sparkline !== true) continue;
       const domain = ctrl?.entity?.split?.(".")?.[0];
       if (domain !== "sensor") continue;
@@ -259,7 +277,8 @@ class OneLineRoomCard extends HTMLElement {
   }
 
   _updateSparklineElements(key, data) {
-    const wrappers = this.shadowRoot?.querySelectorAll?.(`.btn-sparkline[data-sparkline-key="${key}"]`) || [];
+    const wrappers = [this._cardSurface, this._detailDrawer?.surface].filter(Boolean)
+      .flatMap(surface => Array.from(surface.root.querySelectorAll(`.btn-sparkline[data-sparkline-key="${key}"]`)));
     wrappers.forEach(wrapper => {
       const btn = wrapper.closest(".btn");
       if (!btn) return;
@@ -360,7 +379,7 @@ class OneLineRoomCard extends HTMLElement {
       wrapper.style.display = "block";
       this._drawSparkline(wrapper, points, color || "currentColor");
     }
-    if (this._isSparklinePollingActive() && !this._sparklinePending.has(key) && !this._sparklineCache.has(key)) {
+    if (this._isSparklinePollingActive() && this._isControlRendered(ctrl) && !this._sparklinePending.has(key) && !this._sparklineCache.has(key)) {
       this._fetchSparklineData(entityId, hours);
     }
   }
@@ -510,183 +529,16 @@ class OneLineRoomCard extends HTMLElement {
     return { name: "", entity: "", collapsible: true, controls: [] };
   }
 
+  _createSurface(root, kind) {
+    root.innerHTML = getRoomSurfaceMarkup(this._hass);
+    const surface = { root, kind, controls: root.getElementById("ctrls"), signature: null };
+    surface.controls.dataset.renderContext = kind;
+    return surface;
+  }
+
   render() {
     if (!this.config) return;
-    const actOpts = [
-      { value: "more-info", label: getTranslation(this._hass, "act_more") || "Details (Default)" },
-      { value: "toggle", label: getTranslation(this._hass, "act_toggle") || "Toggle" },
-      { value: "navigate", label: getTranslation(this._hass, "act_navigate") || "Navigate" },
-      { value: "none", label: getTranslation(this._hass, "act_none") || "None" }
-    ];
-    // Static runtime scaffold: interpolations below are package-owned labels/options,
-    // never entity states, attributes, template output, or user-provided text.
-    this.shadowRoot.innerHTML = `
-      <style>
-        ha-card { position: relative; overflow: hidden; border-radius: 16px; background: none; border: none; cursor: default; }
-        ha-card.warning-battery { outline: 2px solid var(--error-color, #d32f2f); outline-offset: -2px; }
-        ha-card.warning-humidity { outline: 2px solid var(--info-color, #2196F3); outline-offset: -2px; box-shadow: 0 0 0 2px rgba(33,150,243,0.35), 0 0 12px rgba(33,150,243,0.35), 0 0 22px rgba(33,150,243,0.25); }
-        ha-card.alert-sensor { outline: 2px solid var(--rc-alert-border-color, var(--error-color, #d32f2d)); outline-offset: -2px; box-shadow: 0 0 0 2px rgba(211,47,47,0.15); }
-        .container { display: flex; flex-direction: column; background: var(--ha-card-background, rgba(255,255,255,0.1)); border-radius: 16px; }
-        .img-box { position: relative; width: 100%; height: 120px; overflow: hidden; border-radius: 16px 16px 0 0; background: #444; cursor: pointer; }
-        .img-box.no-image { background: transparent; }
-        .img-box.no-image .img { display: none; }
-        .img-box.no-image .overlay { background: none; position: relative; }
-        .img { width: 100%; height: 100%; object-fit: cover; display: block; transition: filter 0.8s ease; }
-        .img.grayscale { filter: grayscale(100%) brightness(0.6); }
-        .overlay { position: absolute; top: 0; left: 0; width: 100%; padding: 12px; box-sizing: border-box; background: linear-gradient(to bottom, rgba(0,0,0,0.8) 0%, rgba(0,0,0,0) 100%); display: flex; align-items: center; gap: 12px; }
-        .text { display: flex; flex: 1; min-width: 0; flex-direction: column; align-items: flex-start; color: white; text-shadow: 0 1px 2px rgba(0,0,0,0.5); }
-        ha-card.no-header-text-shadow .text { text-shadow: none; }
-        ha-icon { color: var(--icon-color, white); }
-        .primary { display: block; max-width: 100%; font-weight: var(--rc-header-name-weight, bold); font-size: var(--rc-header-name-size, 14px); font-style: var(--rc-header-name-style, normal); color: var(--rc-header-name-color, white); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-        .secondary { max-width: 100%; min-width: 0; font-weight: var(--rc-header-info-weight, normal); font-size: var(--rc-header-info-size, 12px); font-style: var(--rc-header-info-style, normal); color: var(--rc-header-info-color, white); opacity: 0.9; display: flex; flex-wrap: nowrap; gap: 6px; align-items: center; overflow: hidden; }
-        .info-item { display: inline-flex; align-items: center; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-        .info-item.badge { padding: 2px 6px; border-radius: 999px; }
-        .chips { position: absolute; bottom: 8px; left: 8px; display: flex; gap: 6px; flex-wrap: wrap; z-index: 2; }
-        .chip { display: flex; align-items: center; gap: 4px; padding: 4px 8px; border: 0; border-radius: 8px; font-family: inherit; font-size: 11px; font-weight: bold; background: #FFF8E1; color: #FFA000; box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
-        .chip.status-group-chip { background:rgba(var(--rgb-primary-color, 3,169,244),.14); color:var(--primary-color, #03a9f4); }
-        button.chip.status-group-chip { cursor:pointer; }
-        button.chip.status-group-chip:focus-visible { outline:2px solid var(--primary-color, #03a9f4); outline-offset:2px; }
-        .chip ha-icon { color: currentColor; }
-        ha-card.no-chip-shadow .chip { box-shadow: none; }
-        .chip.alert { background: #FFEBEE; color: #D32F2F; }
-        .chip.humidity { background: #E3F2FD; color: #1976D2; }
-        .chip.info { background: #E3F2FD; color: #1976D2; }
-        .chip.custom { background: var(--chip-bg); color: var(--chip-color); }
-        .controls { display: flex; flex-wrap: wrap; gap: 6px; padding: 10px; }
-        .btn.has-sparkline { height: auto; align-items: stretch; overflow: visible; flex-wrap: wrap; padding-bottom: 6px; }
-        .btn-sparkline { width: 100%; flex: 0 0 100%; order: 99; align-self: stretch; min-height: 28px; margin-top: 6px; display: flex; align-items: center; padding: 4px 6px; border: 0; border-radius: 12px; color: inherit; font: inherit; background: rgba(255,255,255,0.06); box-sizing: border-box; }
-        button.btn-sparkline { cursor: pointer; }
-        button.btn-sparkline:focus-visible { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: 2px; }
-        .btn-sparkline svg { width: 100%; height: 22px; display: block; overflow: visible; }
-        .btn-sparkline polyline { fill: none; vector-effect: non-scaling-stroke; }
-        .btn { position: relative; display: flex; align-items: center; gap: 10px; padding: 0 10px; border-radius: 12px; cursor: pointer; background: var(--rc-btn-bg, var(--btn-bg, var(--card-background-color, rgba(128,128,128,0.05)))); border: 1px solid transparent; flex-grow: 1; flex-shrink: 1; min-width: 0; overflow: hidden; box-sizing: border-box; transition: background 0.2s; user-select: none; -webkit-user-select: none; touch-action: manipulation; -webkit-tap-highlight-color: transparent; flex-basis: var(--btn-flex-basis, auto); height: var(--btn-height, 60px); justify-content: var(--btn-justify, center); }
-        .btn.label-right { flex-direction: row; align-items: center; justify-content: var(--btn-justify, center); gap: 10px; padding: 0 10px; }
-        .btn.label-left { flex-direction: row-reverse; align-items: center; justify-content: var(--btn-justify, center); gap: 10px; padding: 0 10px; }
-        .btn.label-bottom { flex-direction: column; justify-content: flex-start; align-items: center; gap: 1px; padding: 2px 4px; overflow: hidden; }
-        .btn.label-top { flex-direction: column-reverse; justify-content: center; gap: 4px; padding: 6px 8px; overflow: hidden; }
-        .btn.has-inline-ctrl.label-bottom,
-        .btn.has-inline-ctrl.label-top { align-items: center; }
-        .btn.has-inline-ctrl.label-bottom .btn-top,
-        .btn.has-inline-ctrl.label-top .btn-top { align-items: center; width: 100%; }
-        .btn.label-left .btn-txt { text-align: right; align-items: flex-end; }
-        .btn.label-bottom .icon-box,
-        .btn.label-top .icon-box { flex-shrink: 0; }
-        .btn.label-bottom .icon-box { width: 28px; height: 28px; margin-top: 1px; }
-        .btn.label-bottom ha-icon { --mdc-icon-size: 18px; }
-        .btn.label-bottom .btn-txt,
-        .btn.label-top .btn-txt { text-align: center; align-items: center; flex: 1; min-height: 0; max-width: 100%; overflow: hidden; }
-        .btn.label-bottom .btn-txt { flex: 0 0 auto; min-height: 22px; max-height: 22px; gap: 1px; }
-        .btn.label-bottom .btn-name,
-        .btn.label-bottom .btn-state,
-        .btn.label-top .btn-name,
-        .btn.label-top .btn-state { font-size: 11px; line-height: 1.1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
-        .btn.label-bottom .btn-name { font-size: 11px; line-height: 11px; }
-        .btn.label-bottom .btn-state { font-size: 10px; line-height: 10px; margin-top: 0; }
-        .btn:hover { background: var(--rc-btn-bg-hover, rgba(128,128,128,0.1)); border-color: rgba(128,128,128,0.2); }
-        .btn:active { background: var(--rc-btn-bg-active, rgba(128,128,128,0.15)); }
-        .btn:focus-visible, button:focus-visible, select:focus-visible, input:focus-visible, .img-box:focus-visible { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: 2px; }
-        .btn.state-unavailable { opacity: 0.56; }
-        .btn.state-unavailable:hover,
-        .btn.state-unavailable:active { background: var(--rc-btn-bg, var(--btn-bg, var(--card-background-color, rgba(128,128,128,0.05)))); border-color: transparent; }
-        .btn.state-unavailable .btn-name,
-        .btn.state-unavailable .btn-state,
-        .btn.state-unavailable ha-icon { color: var(--disabled-text-color, var(--secondary-text-color)); }
-        .icon-box { display: flex; align-items: center; justify-content: center; width: 32px; height: 32px; border-radius: 50%; flex-shrink: 0; background: var(--icon-bg, transparent); }
-        .btn-txt { display: flex; flex-direction: column; text-align: left; overflow: hidden; min-width: 0; flex: initial; max-width: 100%; }
-        .btn ha-icon { color: var(--rc-icon-color, var(--icon-color, grey)); --mdc-icon-size: 20px; }
-        .btn-name { font-size: 13px; font-weight: 600; color: var(--primary-text-color); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
-        .btn-state { font-size: 11px; color: var(--secondary-text-color); margin-top: 1px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
-        .warn { position: absolute; top: 4px; right: 4px; color: #d32f2f; --mdc-icon-size: 16px; background: rgba(255,255,255,0.8); border-radius: 50%; padding: 1px; }
-        .warn.warn-offline { color: var(--warning-color, var(--secondary-text-color)); background: var(--card-background-color, rgba(255,255,255,0.85)); }
-        .btn.has-inline-ctrl { flex-direction: column; align-items: stretch; padding: 6px 10px; gap: 4px; height: auto; min-height: var(--btn-height, 60px); }
-        .btn.has-inline-ctrl .btn-top { display: flex; align-items: center; gap: 10px; width: 100%; flex: 0 0 auto; }
-        .btn.has-inline-ctrl .btn-txt { flex: 1; min-width: 0; }
-        .btn-slider-wrap { width: 100%; flex: 0 0 auto; padding: 0 2px 4px; }
-        .btn-slider { -webkit-appearance: none; appearance: none; width: 100%; height: 4px; border-radius: 2px; outline: none; cursor: pointer; background: linear-gradient(to right, var(--icon-color, #ff9800) 0%, var(--icon-color, #ff9800) var(--slider-pct, 0%), rgba(128,128,128,0.3) var(--slider-pct, 0%), rgba(128,128,128,0.3) 100%); }
-        .btn-slider::-webkit-slider-thumb { -webkit-appearance: none; width: 14px; height: 14px; border-radius: 50%; background: var(--icon-color, #ff9800); cursor: pointer; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
-        .btn-slider::-moz-range-thumb { width: 14px; height: 14px; border-radius: 50%; background: var(--icon-color, #ff9800); cursor: pointer; border: none; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
-        .btn-cover-actions { display: flex; gap: 4px; width: 100%; flex: 0 0 auto; padding-bottom: 4px; }
-        .cover-action-btn { flex: 0 0 auto; display: flex; align-items: center; justify-content: center; background: rgba(128,128,128,0.1); border: 0; color: inherit; font: inherit; border-radius: 6px; padding: 4px 6px; cursor: pointer; transition: background 0.15s; touch-action: manipulation; }
-        .cover-action-btn:hover { background: rgba(128,128,128,0.22); }
-        .cover-action-btn ha-icon { --mdc-icon-size: 16px; color: var(--primary-text-color); }
-        .media-transport-row, .media-volume-row { display: flex; align-items: center; gap: 6px; width: 100%; flex: 0 0 auto; }
-        .media-transport-row { justify-content: center; padding-top: 2px; }
-        .media-volume-row { padding: 2px 0 4px; }
-        .media-ctrl-btn { flex: 0 0 auto; display: flex; align-items: center; justify-content: center; width: 32px; height: 32px; padding: 0; border: 0; border-radius: 50%; background: transparent; color: inherit; cursor: pointer; transition: background 0.15s; touch-action: manipulation; }
-        .media-ctrl-btn:hover { background: rgba(128,128,128,0.18); }
-        .media-ctrl-btn ha-icon { --mdc-icon-size: 19px; color: var(--primary-text-color); }
-        .media-ctrl-btn.muted ha-icon { color: var(--secondary-text-color); }
-        .media-volume-row .btn-slider-wrap { flex: 1; min-width: 0; padding: 0; }
-        .media-volume-row .btn-slider { height: 4px; }
-        .media-volume-row .vol-label { font-size: 10px; font-weight: 600; color: var(--secondary-text-color); min-width: 32px; text-align: center; flex: 0 0 auto; }
-        .media-thumb { width: 40px; height: 40px; border-radius: 4px; object-fit: cover; flex-shrink: 0; }
-        .media-full-layout { display: flex; gap: 10px; width: 100%; align-items: stretch; }
-        .media-full-layout .media-thumb { width: 72px; height: 72px; aspect-ratio: 1; border-radius: 6px; align-self: center; object-fit: cover; }
-        .media-full-layout .media-right { display: flex; flex-direction: column; flex: 1; min-width: 0; justify-content: center; gap: 2px; }
-        .btn-cover-presets { display: flex; gap: 4px; width: 100%; flex: 0 0 auto; padding-bottom: 4px; }
-        .preset-btn { flex: 1; display: flex; align-items: center; justify-content: center; background: rgba(128,128,128,0.1); border: 0; border-radius: 6px; padding: 3px 4px; cursor: pointer; transition: background 0.15s, color 0.15s; font: inherit; font-size: 11px; font-weight: 600; color: var(--secondary-text-color); white-space: nowrap; touch-action: manipulation; }
-        .preset-btn:hover { background: rgba(128,128,128,0.22); color: var(--primary-text-color); }
-        .preset-btn.active { background: var(--icon-color, var(--primary-color, #ff9800)); color: #fff; }
-        .btn-select-dropdown { width: 100%; padding-bottom: 4px; }
-        .btn-select-dropdown select { width: 100%; padding: 4px 8px; border-radius: 6px; border: none; background: rgba(128,128,128,0.12); color: var(--primary-text-color); font-size: 12px; font-weight: 500; cursor: pointer; appearance: auto; outline: none; touch-action: manipulation; }
-        .btn-select-dropdown select:focus { box-shadow: 0 0 0 1px var(--icon-color, var(--primary-color, #ff9800)); }
-        .btn-select-options { flex-wrap: wrap; }
-        .btn-select-options .preset-btn { flex: 0 1 auto; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
-        .btn-color-favorites { display: flex; gap: 6px; width: 100%; flex: 0 0 auto; padding-bottom: 4px; flex-wrap: wrap; }
-        .color-swatch { width: 20px; height: 20px; padding: 0; border-radius: 50%; cursor: pointer; flex-shrink: 0; border: 2px solid transparent; transition: transform 0.15s, border-color 0.15s; box-shadow: 0 1px 3px rgba(0,0,0,0.25); touch-action: manipulation; }
-        .color-swatch:hover { transform: scale(1.2); }
-        .color-swatch.active { border-color: var(--primary-text-color); transform: scale(1.15); }
-        .controls { transition: max-height 0.35s ease, padding 0.35s ease; overflow: hidden; max-height: 2000px; }
-        .controls.collapsed { max-height: 0 !important; padding-top: 0 !important; padding-bottom: 0 !important; }
-        .collapse-btn { position: absolute; bottom: 8px; right: 8px; z-index: 3; width: 28px; height: 28px; padding: 0; border: 0; border-radius: 50%; background: rgba(0,0,0,0.38); display: none; align-items: center; justify-content: center; cursor: pointer; }
-        .collapse-btn ha-icon { --mdc-icon-size: 18px; color: white; transition: transform 0.35s ease; }
-        .collapse-btn.open ha-icon { transform: rotate(180deg); }
-        .details-btn { position:absolute; top:8px; right:8px; z-index:3; min-width:44px; min-height:44px; padding:8px 12px; border:0; border-radius:12px; background:rgba(0,0,0,.55); color:white; font:inherit; cursor:pointer; }
-        .details-btn[hidden] { display:none; }
-        .details-btn:focus-visible { outline:2px solid var(--primary-color,#03a9f4); outline-offset:2px; }
-        .btn-chips { display: flex; flex-direction: row; flex-wrap: wrap; gap: 2px; align-items: center; max-width: 100%; margin-top: 2px; }
-        .btn-chips.chips-top { margin-top: 0; margin-bottom: 2px; }
-        .btn.has-inline-ctrl .btn-chips { margin-top: 4px; padding-bottom: 2px; }
-        .btn.has-inline-ctrl .btn-chips.chips-top { margin-top: 0; margin-bottom: 4px; padding-bottom: 0; padding-top: 2px; }
-        .btn-chip { display: inline-flex; align-items: center; gap: 2px; padding: 2px 5px; background: rgba(var(--rgb-primary-text-color, 0, 0, 0), 0.12); color: var(--secondary-text-color, rgba(0,0,0,0.6)); border-radius: 6px; max-width: 100%; box-sizing: border-box; }
-        .btn-chip span { font-size: 9px; line-height: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-        .btn-chip ha-icon { --mdc-icon-size: 11px; }
-        .info-bar { display: none; flex-wrap: nowrap; gap: 6px; padding: 4px 12px 6px; align-items: center; overflow: hidden; font-size: var(--rc-header-info-size, 12px); font-weight: var(--rc-header-info-weight, normal); font-style: var(--rc-header-info-style, normal); color: var(--rc-header-info-color, var(--secondary-text-color)); }
-        .info-bar.active { display: flex; }
-        .room-modes { display: flex; gap: 7px; padding: 8px 10px; overflow-x: auto; overflow-y: hidden; scrollbar-width: thin; overscroll-behavior-inline: contain; border-top: 1px solid var(--divider-color, rgba(128,128,128,.18)); }
-        .room-modes:empty { display: none; }
-        .room-mode { flex: 0 0 auto; min-height: 34px; display: inline-flex; align-items: center; gap: 6px; padding: 6px 11px; border: 1px solid var(--divider-color, rgba(128,128,128,.25)); border-radius: 999px; color: var(--primary-text-color); background: rgba(128,128,128,.08); font: inherit; font-size: 12px; font-weight: 600; white-space: nowrap; cursor: pointer; touch-action: manipulation; }
-        .room-mode ha-icon { --mdc-icon-size: 18px; color: var(--room-mode-color, var(--primary-color)); }
-        .room-mode.active { color: var(--text-primary-color, #fff); background: var(--room-mode-color, var(--primary-color)); border-color: var(--room-mode-color, var(--primary-color)); }
-        .room-mode.active ha-icon { color: currentColor; }
-        .room-mode:disabled { opacity: .45; cursor: not-allowed; }
-        .room-mode:focus-visible { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: 2px; }
-        @media (max-width: 480px) {
-          .media-full-layout { gap: 8px; }
-          .media-full-layout .media-thumb { width: 60px; height: 60px; }
-          .media-ctrl-btn { width: 30px; height: 30px; }
-        }
-      </style>
-      <ha-card>
-        <div class="container">
-          <div class="img-box">
-            <img id="bg" class="img">
-            <div class="overlay">
-              <ha-icon id="icon"></ha-icon>
-              <div class="text">
-                <span id="name" class="primary"></span>
-                <span id="info" class="secondary"></span>
-              </div>
-            </div>
-            <div id="chips" class="chips"></div>
-            <button id="collapse-btn" class="collapse-btn" type="button"><ha-icon icon="mdi:chevron-down"></ha-icon></button>
-            <button id="details-btn" class="details-btn" type="button" hidden></button>
-          </div>
-          <div id="info-bar" class="info-bar"></div>
-          <div id="room-modes" class="room-modes" role="group" aria-label="${getTranslation(this._hass, "room_modes")}"></div>
-          <div id="ctrls" class="controls"></div>
-        </div>
-      </ha-card>`;
+    this._cardSurface = this._createSurface(this.shadowRoot, "card");
 
     this.content = this.shadowRoot.querySelector(".container");
     this.controls = this.shadowRoot.getElementById("ctrls");
@@ -1105,12 +957,13 @@ class OneLineRoomCard extends HTMLElement {
     const targetUrl = selection?.url || "/static/images/card_media/cover.png";
     image.style.objectPosition = selection?.position || "50% 50%";
     if (image.dataset.roomImageUrl === targetUrl) {
-      this._headerImageRequest += 1;
+      this._headerImageRequests.set(image, null);
       return;
     }
-    const request = ++this._headerImageRequest;
+    const request = {};
+    this._headerImageRequests.set(image, request);
     const commit = () => {
-      if (request !== this._headerImageRequest || !image.isConnected) return;
+      if (request !== this._headerImageRequests.get(image) || !image.isConnected) return;
       image.src = targetUrl;
       image.dataset.roomImageUrl = targetUrl;
     };
@@ -1127,6 +980,15 @@ class OneLineRoomCard extends HTMLElement {
   _updateContentState() {
     if (!this.config || !this._hass || !this.content) return;
     this._syncDetailDrawer();
+    this._updateSurfaceState(this._cardSurface);
+    if (this._detailDrawer?.surface) this._updateSurfaceState(this._detailDrawer.surface);
+    this._configChanged = false;
+    const shouldPoll = this._hasSparklineControls() && this._isSparklinePollingActive();
+    if (shouldPoll !== !!this._sparklineInterval) this._setupSparklineInterval();
+  }
+
+  _updateSurfaceState(surface) {
+    if (!this.config || !this._hass || !this.content) return;
     const h = this._hass, c = this.config;
     const effectiveEntity = c.entity;
     const effectiveTempSensor = c.temp_sensor;
@@ -1136,7 +998,7 @@ class OneLineRoomCard extends HTMLElement {
     const systemTempUnit = normalizeTemperatureUnit(h.config.unit_system.temperature) || "°C";
     const configuredTempUnit = normalizeTemperatureUnit(c.temp_unit);
 
-    const bgEl = this.shadowRoot.getElementById("bg");
+    const bgEl = surface.root.getElementById("bg");
     this._applyHeaderImage(bgEl, resolveAdaptiveRoomImage(c, h));
     if (c.image_entity && h.states[c.image_entity]) {
       const isOff = !isEntityActive(h.states[c.image_entity], c.image_entity);
@@ -1144,7 +1006,7 @@ class OneLineRoomCard extends HTMLElement {
     } else {
       bgEl.classList.remove("grayscale");
     }
-    const imgBox = this.shadowRoot.querySelector(".img-box");
+    const imgBox = surface.root.querySelector(".img-box");
     if (imgBox) {
       const hh = c.header_height !== undefined ? Number(c.header_height) : NaN;
       const hideImg = c.show_image === false;
@@ -1153,10 +1015,10 @@ class OneLineRoomCard extends HTMLElement {
       else imgBox.style.height = "120px";
       imgBox.classList.toggle("no-image", hideImg);
     }
-    const nameEl = this.shadowRoot.getElementById("name");
+    const nameEl = surface.root.getElementById("name");
     nameEl.innerText = c.name || "Room";
     nameEl.style.display = c.show_name === false ? "none" : "";
-    const ico = this.shadowRoot.getElementById("icon");
+    const ico = surface.root.getElementById("icon");
     ico.icon = c.icon || "mdi:home";
     // Priority: force/manual > dynamic state color > default/theme fallback.
     const headerManualColor = isHeaderManualColorEnabled(c);
@@ -1192,8 +1054,8 @@ class OneLineRoomCard extends HTMLElement {
     }
 
     const infoPos = c.info_line_position || "header";
-    const infoEl = this.shadowRoot.getElementById("info");
-    const infoBarEl = this.shadowRoot.getElementById("info-bar");
+    const infoEl = surface.root.getElementById("info");
+    const infoBarEl = surface.root.getElementById("info-bar");
     const infoParts = [];
     const standardHeaderBadgeBackground = trimStr(c.header_info_background);
     if (t != null && t !== "-" && !isNaN(parseFloat(t))) {
@@ -1275,7 +1137,7 @@ class OneLineRoomCard extends HTMLElement {
 
     if (infoBarEl) infoBarEl.classList.toggle("active", infoPos === "below_header" && infoParts.length > 0);
 
-    const textEl = this.shadowRoot.querySelector(".text");
+    const textEl = surface.root.querySelector(".text");
     const nameOffset = Number(c.header_name_offset ?? 0);
     const infoOffset = infoPos === "header" ? Number(c.header_info_offset ?? 0) : 0;
     if (textEl) textEl.style.flex = (nameOffset > 0 || infoOffset > 0) ? "1" : "";
@@ -1286,7 +1148,7 @@ class OneLineRoomCard extends HTMLElement {
     // Info line horizontal offset (only relevant when inside the header)
     if (infoPos === "header") this._applyHeaderOffset(infoEl, infoOffset, textEl);
 
-    const ch = this.shadowRoot.getElementById("chips");
+    const ch = surface.root.getElementById("chips");
     ch.replaceChildren();
     const createHeaderChip = (className, iconName, text, tagName = "div") => {
       const chip = document.createElement(tagName);
@@ -1422,7 +1284,7 @@ class OneLineRoomCard extends HTMLElement {
 
     this._renderStatusGroups(ch, c, h);
 
-    const cardEl = this.shadowRoot.querySelector("ha-card");
+    const cardEl = surface.root.querySelector("ha-card");
     if (cardEl) {
       const showStatusBorder = c.show_status_border !== false;
       cardEl.classList.toggle("no-header-text-shadow", c.show_header_text_shadow === false);
@@ -1452,10 +1314,11 @@ class OneLineRoomCard extends HTMLElement {
       setStrProp("--rc-header-info-color", c.header_info_color, "white");
     }
 
-    this._renderRoomModes(c, h);
-    this._syncCollapseUI();
+    this._renderRoomModes(c, h, surface.root);
+    if (surface.kind === "card") this._syncCollapseUI();
 
     let visibleCtrls = (c.controls || []).filter(ctrl => {
+      if (!isControlInContext(ctrl, c, surface.kind)) return false;
       if (ctrl.hide) return false;
       if (Array.isArray(ctrl.visibility) && ctrl.visibility.length > 0) {
         if (!this._checkConditions(ctrl.visibility, h)) return false;
@@ -1463,7 +1326,7 @@ class OneLineRoomCard extends HTMLElement {
       return (ctrl.entity || ctrl.type === "template");
     });
 
-    if (c.auto_climate_button && c.entity && getEntityDomain(c.entity) === "climate") {
+    if (surface.kind === "card" && c.auto_climate_button && c.entity && getEntityDomain(c.entity) === "climate") {
       const alreadyPresent = visibleCtrls.some(ctrl => ctrl.entity === c.entity);
       if (!alreadyPresent) {
         const climateState = h.states[c.entity];
@@ -1471,20 +1334,20 @@ class OneLineRoomCard extends HTMLElement {
       }
     }
 
-    const controlsSig = JSON.stringify(visibleCtrls.map(ct => ct.entity + (ct.type || "")));
+    const controlsSig = JSON.stringify(visibleCtrls);
 
-    if (this._configChanged || this._lastControlsSig !== controlsSig) {
-      this._lastControlsSig = controlsSig;
-      this.controls.replaceChildren();
+    if (this._configChanged || surface.signature !== controlsSig) {
+      surface.signature = controlsSig;
+      for (const node of surface.controls.children) node._disposeActions?.();
+      surface.controls.replaceChildren();
       visibleCtrls.forEach(ctrl => {
         const btn = this._createBtn(ctrl);
-        this.controls.appendChild(btn);
+        surface.controls.appendChild(btn);
         this._updateBtnState(btn, ctrl, h);
       });
-      this._configChanged = false;
     } else {
       visibleCtrls.forEach((ctrl, i) => {
-        const btn = this.controls.children[i];
+        const btn = surface.controls.children[i];
         if (btn) this._updateBtnState(btn, ctrl, h);
       });
     }
@@ -1576,8 +1439,8 @@ class OneLineRoomCard extends HTMLElement {
     requestAnimationFrame(() => requestAnimationFrame(apply));
   }
 
-  _renderRoomModes(config, hass) {
-    const container = this.shadowRoot.getElementById("room-modes");
+  _renderRoomModes(config, hass, root = this.shadowRoot) {
+    const container = root.getElementById("room-modes");
     if (!container) return;
     const modes = (Array.isArray(config?.room_modes) ? config.room_modes : [])
       .filter((mode) => ["scene", "script"].includes(getEntityDomain(mode?.entity)));
@@ -1589,7 +1452,8 @@ class OneLineRoomCard extends HTMLElement {
       active_when: mode.active_when || null
     })));
     if (container.dataset.configSignature !== signature) {
-      const focusedEntity = this.shadowRoot.activeElement?.closest?.(".room-mode")?.dataset?.entity;
+      const active = deepActiveElement();
+      const focusedEntity = container.contains(active) ? active?.closest?.(".room-mode")?.dataset?.entity : null;
       const buttons = modes.map((mode) => {
         const domain = getEntityDomain(mode.entity);
         const button = document.createElement("button");
@@ -1666,7 +1530,7 @@ class OneLineRoomCard extends HTMLElement {
     const domain = ctrl.entity ? ctrl.entity.split(".")[0] : "";
     const isTemplate = ctrl.type === "template";
     const subChipPresentations = resolveSubChipPresentations(ctrl, h);
-    const activeElement = this.shadowRoot.activeElement;
+    const activeElement = deepActiveElement();
     const focusedControlKey = activeElement && btn.contains(activeElement)
       ? activeElement.dataset?.rcFocusKey || ""
       : "";
@@ -2502,7 +2366,10 @@ class OneLineRoomCard extends HTMLElement {
     } else {
       btn.classList.remove("has-inline-ctrl");
     }
-    if (focusedControlKey && !this.controls?.hasAttribute("inert")) {
+    Array.from(btn.querySelectorAll("button,input,select,textarea,a[href],[tabindex]")).forEach((element, index) => {
+      element.dataset.rcFocusKey ||= `${element.localName}:${index}`;
+    });
+    if (focusedControlKey && !btn.closest(".controls")?.hasAttribute("inert")) {
       const replacement = Array.from(btn.querySelectorAll("[data-rc-focus-key]"))
         .find((element) => element.dataset.rcFocusKey === focusedControlKey);
       replacement?.focus();
@@ -2526,11 +2393,12 @@ class OneLineRoomCard extends HTMLElement {
     let timer = null, held = false, holdTimer = null;
     let startX = 0, isDragging = false;
     const trackTimeout = (fn, ms) => {
-      const id = setTimeout(() => { this._activeTimers.delete(id); fn(); }, ms);
+      const id = setTimeout(() => { this._activeTimers.delete(id); if (node.isConnected) fn(); }, ms);
       this._activeTimers.add(id);
       return id;
     };
     const cancelTimeout = (id) => { clearTimeout(id); this._activeTimers.delete(id); };
+    node._disposeActions = () => { cancelTimeout(timer); cancelTimeout(holdTimer); timer = null; holdTimer = null; };
     const triggerTap = () => {
       if (this._isEntityUnavailable(ctrl.entity) || held) return;
       if (config.double_tap_action.action !== "none") {
@@ -2630,7 +2498,7 @@ class OneLineRoomCard extends HTMLElement {
     node.addEventListener("blur", cancel);
   }
 
-  _attachHeaderActions(node) {
+  _attachHeaderActions(node, context = "card") {
     const getActionContext = () => {
       const config = this.config || {};
       return {
@@ -2647,19 +2515,21 @@ class OneLineRoomCard extends HTMLElement {
     node.style.touchAction = "manipulation";
     let timer = null, held = false, holdTimer = null;
     const trackTimeout = (fn, ms) => {
-      const id = setTimeout(() => { this._activeTimers.delete(id); fn(); }, ms);
+      const id = setTimeout(() => { this._activeTimers.delete(id); if (node.isConnected) fn(); }, ms);
       this._activeTimers.add(id);
       return id;
     };
     const cancelTimeout = (id) => { clearTimeout(id); this._activeTimers.delete(id); };
     const handleTap = () => {
       const { cardConfig, actionConfig, hasExplicitTap } = getActionContext();
+      if (context === "drawer" && !hasExplicitTap) return;
       if (!hasExplicitTap && cardConfig.collapsible === true) { this._toggleCollapse(); return; }
       this._fireAction("tap", actionConfig);
     };
     const cancel = () => {
       if (holdTimer) { cancelTimeout(holdTimer); holdTimer = null; }
     };
+    node._disposeActions = () => { cancelTimeout(timer); cancelTimeout(holdTimer); timer = null; holdTimer = null; };
     node.addEventListener("pointerdown", () => {
       held = false;
       const { actionConfig } = getActionContext();
@@ -2741,14 +2611,15 @@ class OneLineRoomCard extends HTMLElement {
       closeLabel: t("a11y_close"), trigger,
       onClose: () => {
         this._closeDialog?.(false);
+        for (const node of this._detailDrawer?.surface?.controls.children || []) node._disposeActions?.();
+        this._detailDrawer?.surface?.root.querySelector(".img-box")?._disposeActions?.();
         this._detailDrawer = null;
         this.shadowRoot.getElementById("details-btn")?.setAttribute("aria-expanded", "false");
+        this._setupSparklineInterval();
       }
     });
-    const note = document.createElement("p");
-    note.className = "prototype-note";
     const actions = document.createElement("div");
-    actions.className = "prototype-actions";
+    actions.className = "drawer-actions";
     for (const [name, action] of [
       ["more", event => {
         event.currentTarget.focus({ preventScroll: true });
@@ -2763,8 +2634,14 @@ class OneLineRoomCard extends HTMLElement {
       button.addEventListener("click", action);
       actions.append(button);
     }
-    this._detailDrawer.content.append(note, actions);
+    const surfaceHost = document.createElement("div");
+    surfaceHost.dataset.roomSurface = "drawer";
+    this._detailDrawer.content.append(actions, surfaceHost);
+    this._detailDrawer.surface = this._createSurface(surfaceHost.attachShadow({ mode: "open" }), "drawer");
+    this._attachHeaderActions(this._detailDrawer.surface.root.querySelector(".img-box"), "drawer");
     this._syncDetailDrawer();
+    this._updateSurfaceState(this._detailDrawer.surface);
+    this._setupSparklineInterval();
   }
 
   _drawerHistoryEntity() {
@@ -2791,7 +2668,14 @@ class OneLineRoomCard extends HTMLElement {
     }
     if (!this._detailDrawer) return;
     this._detailDrawer.update({ title: this.config.detail_drawer.title || this.config.name || t("room_details"), closeLabel: t("a11y_close"), themeSource: this });
-    this._detailDrawer.content.querySelector(".prototype-note").textContent = t("drawer_prototype_note");
+    const header = this._detailDrawer.surface?.root.querySelector(".img-box");
+    const hasAction = [this.config.tap_action, this.config.hold_action, this.config.double_tap_action].some(action => action?.action && action.action !== "none");
+    if (header) {
+      header.tabIndex = hasAction ? 0 : -1;
+      if (hasAction) header.setAttribute("role", "button");
+      else header.removeAttribute("role");
+      header.setAttribute("aria-label", this.config.name || t("room_details"));
+    }
     const more = this._detailDrawer.content.querySelector('[data-drawer-action="more"]');
     more.textContent = t("act_more");
     more.disabled = !this.config.entity || !this._hass?.states?.[this.config.entity] || this._isEntityUnavailable(this.config.entity);

--- a/src/card/surface.js
+++ b/src/card/surface.js
@@ -1,0 +1,171 @@
+import { getTranslation } from "../i18n/translations.js";
+
+// Static package-owned scaffold. Each render context gets independent nodes.
+export const getRoomSurfaceMarkup = (hass) => `
+      <style>
+        ha-card { position: relative; overflow: hidden; border-radius: 16px; background: none; border: none; cursor: default; }
+        ha-card.warning-battery { outline: 2px solid var(--error-color, #d32f2f); outline-offset: -2px; }
+        ha-card.warning-humidity { outline: 2px solid var(--info-color, #2196F3); outline-offset: -2px; box-shadow: 0 0 0 2px rgba(33,150,243,0.35), 0 0 12px rgba(33,150,243,0.35), 0 0 22px rgba(33,150,243,0.25); }
+        ha-card.alert-sensor { outline: 2px solid var(--rc-alert-border-color, var(--error-color, #d32f2d)); outline-offset: -2px; box-shadow: 0 0 0 2px rgba(211,47,47,0.15); }
+        .container { display: flex; flex-direction: column; background: var(--ha-card-background, rgba(255,255,255,0.1)); border-radius: 16px; }
+        .img-box { position: relative; width: 100%; height: 120px; overflow: hidden; border-radius: 16px 16px 0 0; background: #444; cursor: pointer; }
+        .img-box.no-image { background: transparent; }
+        .img-box.no-image .img { display: none; }
+        .img-box.no-image .overlay { background: none; position: relative; }
+        .img { width: 100%; height: 100%; object-fit: cover; display: block; transition: filter 0.8s ease; }
+        .img.grayscale { filter: grayscale(100%) brightness(0.6); }
+        .overlay { position: absolute; top: 0; left: 0; width: 100%; padding: 12px; box-sizing: border-box; background: linear-gradient(to bottom, rgba(0,0,0,0.8) 0%, rgba(0,0,0,0) 100%); display: flex; align-items: center; gap: 12px; }
+        .text { display: flex; flex: 1; min-width: 0; flex-direction: column; align-items: flex-start; color: white; text-shadow: 0 1px 2px rgba(0,0,0,0.5); }
+        ha-card.no-header-text-shadow .text { text-shadow: none; }
+        ha-icon { color: var(--icon-color, white); }
+        .primary { display: block; max-width: 100%; font-weight: var(--rc-header-name-weight, bold); font-size: var(--rc-header-name-size, 14px); font-style: var(--rc-header-name-style, normal); color: var(--rc-header-name-color, white); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        .secondary { max-width: 100%; min-width: 0; font-weight: var(--rc-header-info-weight, normal); font-size: var(--rc-header-info-size, 12px); font-style: var(--rc-header-info-style, normal); color: var(--rc-header-info-color, white); opacity: 0.9; display: flex; flex-wrap: nowrap; gap: 6px; align-items: center; overflow: hidden; }
+        .info-item { display: inline-flex; align-items: center; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        .info-item.badge { padding: 2px 6px; border-radius: 999px; }
+        .chips { position: absolute; bottom: 8px; left: 8px; display: flex; gap: 6px; flex-wrap: wrap; z-index: 2; }
+        .chip { display: flex; align-items: center; gap: 4px; padding: 4px 8px; border: 0; border-radius: 8px; font-family: inherit; font-size: 11px; font-weight: bold; background: #FFF8E1; color: #FFA000; box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
+        .chip.status-group-chip { background:rgba(var(--rgb-primary-color, 3,169,244),.14); color:var(--primary-color, #03a9f4); }
+        button.chip.status-group-chip { cursor:pointer; }
+        button.chip.status-group-chip:focus-visible { outline:2px solid var(--primary-color, #03a9f4); outline-offset:2px; }
+        .chip ha-icon { color: currentColor; }
+        ha-card.no-chip-shadow .chip { box-shadow: none; }
+        .chip.alert { background: #FFEBEE; color: #D32F2F; }
+        .chip.humidity { background: #E3F2FD; color: #1976D2; }
+        .chip.info { background: #E3F2FD; color: #1976D2; }
+        .chip.custom { background: var(--chip-bg); color: var(--chip-color); }
+        .controls { display: flex; flex-wrap: wrap; gap: 6px; padding: 10px; }
+        .btn.has-sparkline { height: auto; align-items: stretch; overflow: visible; flex-wrap: wrap; padding-bottom: 6px; }
+        .btn-sparkline { width: 100%; flex: 0 0 100%; order: 99; align-self: stretch; min-height: 28px; margin-top: 6px; display: flex; align-items: center; padding: 4px 6px; border: 0; border-radius: 12px; color: inherit; font: inherit; background: rgba(255,255,255,0.06); box-sizing: border-box; }
+        button.btn-sparkline { cursor: pointer; }
+        button.btn-sparkline:focus-visible { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: 2px; }
+        .btn-sparkline svg { width: 100%; height: 22px; display: block; overflow: visible; }
+        .btn-sparkline polyline { fill: none; vector-effect: non-scaling-stroke; }
+        .btn { position: relative; display: flex; align-items: center; gap: 10px; padding: 0 10px; border-radius: 12px; cursor: pointer; background: var(--rc-btn-bg, var(--btn-bg, var(--card-background-color, rgba(128,128,128,0.05)))); border: 1px solid transparent; flex-grow: 1; flex-shrink: 1; min-width: 0; overflow: hidden; box-sizing: border-box; transition: background 0.2s; user-select: none; -webkit-user-select: none; touch-action: manipulation; -webkit-tap-highlight-color: transparent; flex-basis: var(--btn-flex-basis, auto); height: var(--btn-height, 60px); justify-content: var(--btn-justify, center); }
+        .btn.label-right { flex-direction: row; align-items: center; justify-content: var(--btn-justify, center); gap: 10px; padding: 0 10px; }
+        .btn.label-left { flex-direction: row-reverse; align-items: center; justify-content: var(--btn-justify, center); gap: 10px; padding: 0 10px; }
+        .btn.label-bottom { flex-direction: column; justify-content: flex-start; align-items: center; gap: 1px; padding: 2px 4px; overflow: hidden; }
+        .btn.label-top { flex-direction: column-reverse; justify-content: center; gap: 4px; padding: 6px 8px; overflow: hidden; }
+        .btn.has-inline-ctrl.label-bottom,
+        .btn.has-inline-ctrl.label-top { align-items: center; }
+        .btn.has-inline-ctrl.label-bottom .btn-top,
+        .btn.has-inline-ctrl.label-top .btn-top { align-items: center; width: 100%; }
+        .btn.label-left .btn-txt { text-align: right; align-items: flex-end; }
+        .btn.label-bottom .icon-box,
+        .btn.label-top .icon-box { flex-shrink: 0; }
+        .btn.label-bottom .icon-box { width: 28px; height: 28px; margin-top: 1px; }
+        .btn.label-bottom ha-icon { --mdc-icon-size: 18px; }
+        .btn.label-bottom .btn-txt,
+        .btn.label-top .btn-txt { text-align: center; align-items: center; flex: 1; min-height: 0; max-width: 100%; overflow: hidden; }
+        .btn.label-bottom .btn-txt { flex: 0 0 auto; min-height: 22px; max-height: 22px; gap: 1px; }
+        .btn.label-bottom .btn-name,
+        .btn.label-bottom .btn-state,
+        .btn.label-top .btn-name,
+        .btn.label-top .btn-state { font-size: 11px; line-height: 1.1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+        .btn.label-bottom .btn-name { font-size: 11px; line-height: 11px; }
+        .btn.label-bottom .btn-state { font-size: 10px; line-height: 10px; margin-top: 0; }
+        .btn:hover { background: var(--rc-btn-bg-hover, rgba(128,128,128,0.1)); border-color: rgba(128,128,128,0.2); }
+        .btn:active { background: var(--rc-btn-bg-active, rgba(128,128,128,0.15)); }
+        .btn:focus-visible, button:focus-visible, select:focus-visible, input:focus-visible, .img-box:focus-visible { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: 2px; }
+        .btn.state-unavailable { opacity: 0.56; }
+        .btn.state-unavailable:hover,
+        .btn.state-unavailable:active { background: var(--rc-btn-bg, var(--btn-bg, var(--card-background-color, rgba(128,128,128,0.05)))); border-color: transparent; }
+        .btn.state-unavailable .btn-name,
+        .btn.state-unavailable .btn-state,
+        .btn.state-unavailable ha-icon { color: var(--disabled-text-color, var(--secondary-text-color)); }
+        .icon-box { display: flex; align-items: center; justify-content: center; width: 32px; height: 32px; border-radius: 50%; flex-shrink: 0; background: var(--icon-bg, transparent); }
+        .btn-txt { display: flex; flex-direction: column; text-align: left; overflow: hidden; min-width: 0; flex: initial; max-width: 100%; }
+        .btn ha-icon { color: var(--rc-icon-color, var(--icon-color, grey)); --mdc-icon-size: 20px; }
+        .btn-name { font-size: 13px; font-weight: 600; color: var(--primary-text-color); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+        .btn-state { font-size: 11px; color: var(--secondary-text-color); margin-top: 1px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+        .warn { position: absolute; top: 4px; right: 4px; color: #d32f2f; --mdc-icon-size: 16px; background: rgba(255,255,255,0.8); border-radius: 50%; padding: 1px; }
+        .warn.warn-offline { color: var(--warning-color, var(--secondary-text-color)); background: var(--card-background-color, rgba(255,255,255,0.85)); }
+        .btn.has-inline-ctrl { flex-direction: column; align-items: stretch; padding: 6px 10px; gap: 4px; height: auto; min-height: var(--btn-height, 60px); }
+        .btn.has-inline-ctrl .btn-top { display: flex; align-items: center; gap: 10px; width: 100%; flex: 0 0 auto; }
+        .btn.has-inline-ctrl .btn-txt { flex: 1; min-width: 0; }
+        .btn-slider-wrap { width: 100%; flex: 0 0 auto; padding: 0 2px 4px; }
+        .btn-slider { -webkit-appearance: none; appearance: none; width: 100%; height: 4px; border-radius: 2px; outline: none; cursor: pointer; background: linear-gradient(to right, var(--icon-color, #ff9800) 0%, var(--icon-color, #ff9800) var(--slider-pct, 0%), rgba(128,128,128,0.3) var(--slider-pct, 0%), rgba(128,128,128,0.3) 100%); }
+        .btn-slider::-webkit-slider-thumb { -webkit-appearance: none; width: 14px; height: 14px; border-radius: 50%; background: var(--icon-color, #ff9800); cursor: pointer; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
+        .btn-slider::-moz-range-thumb { width: 14px; height: 14px; border-radius: 50%; background: var(--icon-color, #ff9800); cursor: pointer; border: none; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
+        .btn-cover-actions { display: flex; gap: 4px; width: 100%; flex: 0 0 auto; padding-bottom: 4px; }
+        .cover-action-btn { flex: 0 0 auto; display: flex; align-items: center; justify-content: center; background: rgba(128,128,128,0.1); border: 0; color: inherit; font: inherit; border-radius: 6px; padding: 4px 6px; cursor: pointer; transition: background 0.15s; touch-action: manipulation; }
+        .cover-action-btn:hover { background: rgba(128,128,128,0.22); }
+        .cover-action-btn ha-icon { --mdc-icon-size: 16px; color: var(--primary-text-color); }
+        .media-transport-row, .media-volume-row { display: flex; align-items: center; gap: 6px; width: 100%; flex: 0 0 auto; }
+        .media-transport-row { justify-content: center; padding-top: 2px; }
+        .media-volume-row { padding: 2px 0 4px; }
+        .media-ctrl-btn { flex: 0 0 auto; display: flex; align-items: center; justify-content: center; width: 32px; height: 32px; padding: 0; border: 0; border-radius: 50%; background: transparent; color: inherit; cursor: pointer; transition: background 0.15s; touch-action: manipulation; }
+        .media-ctrl-btn:hover { background: rgba(128,128,128,0.18); }
+        .media-ctrl-btn ha-icon { --mdc-icon-size: 19px; color: var(--primary-text-color); }
+        .media-ctrl-btn.muted ha-icon { color: var(--secondary-text-color); }
+        .media-volume-row .btn-slider-wrap { flex: 1; min-width: 0; padding: 0; }
+        .media-volume-row .btn-slider { height: 4px; }
+        .media-volume-row .vol-label { font-size: 10px; font-weight: 600; color: var(--secondary-text-color); min-width: 32px; text-align: center; flex: 0 0 auto; }
+        .media-thumb { width: 40px; height: 40px; border-radius: 4px; object-fit: cover; flex-shrink: 0; }
+        .media-full-layout { display: flex; gap: 10px; width: 100%; align-items: stretch; }
+        .media-full-layout .media-thumb { width: 72px; height: 72px; aspect-ratio: 1; border-radius: 6px; align-self: center; object-fit: cover; }
+        .media-full-layout .media-right { display: flex; flex-direction: column; flex: 1; min-width: 0; justify-content: center; gap: 2px; }
+        .btn-cover-presets { display: flex; gap: 4px; width: 100%; flex: 0 0 auto; padding-bottom: 4px; }
+        .preset-btn { flex: 1; display: flex; align-items: center; justify-content: center; background: rgba(128,128,128,0.1); border: 0; border-radius: 6px; padding: 3px 4px; cursor: pointer; transition: background 0.15s, color 0.15s; font: inherit; font-size: 11px; font-weight: 600; color: var(--secondary-text-color); white-space: nowrap; touch-action: manipulation; }
+        .preset-btn:hover { background: rgba(128,128,128,0.22); color: var(--primary-text-color); }
+        .preset-btn.active { background: var(--icon-color, var(--primary-color, #ff9800)); color: #fff; }
+        .btn-select-dropdown { width: 100%; padding-bottom: 4px; }
+        .btn-select-dropdown select { width: 100%; padding: 4px 8px; border-radius: 6px; border: none; background: rgba(128,128,128,0.12); color: var(--primary-text-color); font-size: 12px; font-weight: 500; cursor: pointer; appearance: auto; outline: none; touch-action: manipulation; }
+        .btn-select-dropdown select:focus { box-shadow: 0 0 0 1px var(--icon-color, var(--primary-color, #ff9800)); }
+        .btn-select-options { flex-wrap: wrap; }
+        .btn-select-options .preset-btn { flex: 0 1 auto; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+        .btn-color-favorites { display: flex; gap: 6px; width: 100%; flex: 0 0 auto; padding-bottom: 4px; flex-wrap: wrap; }
+        .color-swatch { width: 20px; height: 20px; padding: 0; border-radius: 50%; cursor: pointer; flex-shrink: 0; border: 2px solid transparent; transition: transform 0.15s, border-color 0.15s; box-shadow: 0 1px 3px rgba(0,0,0,0.25); touch-action: manipulation; }
+        .color-swatch:hover { transform: scale(1.2); }
+        .color-swatch.active { border-color: var(--primary-text-color); transform: scale(1.15); }
+        .controls { transition: max-height 0.35s ease, padding 0.35s ease; overflow: hidden; max-height: 2000px; }
+        .controls.collapsed { max-height: 0 !important; padding-top: 0 !important; padding-bottom: 0 !important; }
+        .collapse-btn { position: absolute; bottom: 8px; right: 8px; z-index: 3; width: 28px; height: 28px; padding: 0; border: 0; border-radius: 50%; background: rgba(0,0,0,0.38); display: none; align-items: center; justify-content: center; cursor: pointer; }
+        .collapse-btn ha-icon { --mdc-icon-size: 18px; color: white; transition: transform 0.35s ease; }
+        .collapse-btn.open ha-icon { transform: rotate(180deg); }
+        .details-btn { position:absolute; top:8px; right:8px; z-index:3; min-width:44px; min-height:44px; padding:8px 12px; border:0; border-radius:12px; background:rgba(0,0,0,.55); color:white; font:inherit; cursor:pointer; }
+        .details-btn[hidden] { display:none; }
+        .details-btn:focus-visible { outline:2px solid var(--primary-color,#03a9f4); outline-offset:2px; }
+        .btn-chips { display: flex; flex-direction: row; flex-wrap: wrap; gap: 2px; align-items: center; max-width: 100%; margin-top: 2px; }
+        .btn-chips.chips-top { margin-top: 0; margin-bottom: 2px; }
+        .btn.has-inline-ctrl .btn-chips { margin-top: 4px; padding-bottom: 2px; }
+        .btn.has-inline-ctrl .btn-chips.chips-top { margin-top: 0; margin-bottom: 4px; padding-bottom: 0; padding-top: 2px; }
+        .btn-chip { display: inline-flex; align-items: center; gap: 2px; padding: 2px 5px; background: rgba(var(--rgb-primary-text-color, 0, 0, 0), 0.12); color: var(--secondary-text-color, rgba(0,0,0,0.6)); border-radius: 6px; max-width: 100%; box-sizing: border-box; }
+        .btn-chip span { font-size: 9px; line-height: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .btn-chip ha-icon { --mdc-icon-size: 11px; }
+        .info-bar { display: none; flex-wrap: nowrap; gap: 6px; padding: 4px 12px 6px; align-items: center; overflow: hidden; font-size: var(--rc-header-info-size, 12px); font-weight: var(--rc-header-info-weight, normal); font-style: var(--rc-header-info-style, normal); color: var(--rc-header-info-color, var(--secondary-text-color)); }
+        .info-bar.active { display: flex; }
+        .room-modes { display: flex; gap: 7px; padding: 8px 10px; overflow-x: auto; overflow-y: hidden; scrollbar-width: thin; overscroll-behavior-inline: contain; border-top: 1px solid var(--divider-color, rgba(128,128,128,.18)); }
+        .room-modes:empty { display: none; }
+        .room-mode { flex: 0 0 auto; min-height: 34px; display: inline-flex; align-items: center; gap: 6px; padding: 6px 11px; border: 1px solid var(--divider-color, rgba(128,128,128,.25)); border-radius: 999px; color: var(--primary-text-color); background: rgba(128,128,128,.08); font: inherit; font-size: 12px; font-weight: 600; white-space: nowrap; cursor: pointer; touch-action: manipulation; }
+        .room-mode ha-icon { --mdc-icon-size: 18px; color: var(--room-mode-color, var(--primary-color)); }
+        .room-mode.active { color: var(--text-primary-color, #fff); background: var(--room-mode-color, var(--primary-color)); border-color: var(--room-mode-color, var(--primary-color)); }
+        .room-mode.active ha-icon { color: currentColor; }
+        .room-mode:disabled { opacity: .45; cursor: not-allowed; }
+        .room-mode:focus-visible { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: 2px; }
+        @media (max-width: 480px) {
+          .media-full-layout { gap: 8px; }
+          .media-full-layout .media-thumb { width: 60px; height: 60px; }
+          .media-ctrl-btn { width: 30px; height: 30px; }
+        }
+      </style>
+      <ha-card>
+        <div class="container">
+          <div class="img-box">
+            <img id="bg" class="img">
+            <div class="overlay">
+              <ha-icon id="icon"></ha-icon>
+              <div class="text">
+                <span id="name" class="primary"></span>
+                <span id="info" class="secondary"></span>
+              </div>
+            </div>
+            <div id="chips" class="chips"></div>
+            <button id="collapse-btn" class="collapse-btn" type="button"><ha-icon icon="mdi:chevron-down"></ha-icon></button>
+            <button id="details-btn" class="details-btn" type="button" hidden></button>
+          </div>
+          <div id="info-bar" class="info-bar"></div>
+          <div id="room-modes" class="room-modes" role="group" aria-label="${getTranslation(hass, "room_modes")}"></div>
+          <div id="ctrls" class="controls"></div>
+        </div>
+      </ha-card>`;
+

--- a/src/editor/room-card-editor.js
+++ b/src/editor/room-card-editor.js
@@ -10,6 +10,8 @@ import { buildHassActionDetail } from "../lib/actions.js";
 import { SHARED_SPARKLINE_CACHE, SHARED_SPARKLINE_PENDING, SHARED_SPARKLINE_CACHE_LIMIT, SHARED_SPARKLINE_MAX_AGE_MS, normalizeSparklineSamples, getSparklineStats, pruneSharedSparklineCache, fetchHistorySamples } from "../lib/history.js";
 import { MEDIA_PLAYER_FEATURES, getSliderCapabilities, getInlineButtons, supportsMediaFeature } from "../lib/capabilities.js";
 import { VERSION, EDITOR_DOM_REVISION } from "../version.js";
+import { getControlPlacement } from "../lib/control-placement.js";
+import { requestDrawerPreview } from "../shared/drawer-preview.js";
 import { IMAGE_UPLOAD_LIMITS, parseImagePosition, validateImageUpload, ROOM_IMAGE_PRESETS, ROOM_IMAGE_PRESET_MAP, getRoomImagePresetUrl, resolveRoomImageUrl, evaluateAdaptiveImageConditions, resolveAdaptiveRoomImage, POWER_UNIT_FACTORS, getStatusGroupResult, isHeaderManualColorEnabled, resolveLabelPosition, setAlignmentClass, applyLabelPosition, evalTemplateString, resolveTemplateCtrl, resolveSubChipPresentations, TEMPLATE_VALUE_KEYS, getTemplateEntityDependencies, templateNeedsEveryHassUpdate, formatLastChanged } from "../shared/presentation.js";
 
 class OneLineRoomCardEditor extends HTMLElement {
@@ -940,6 +942,14 @@ connectedCallback() {
       </div>
       </div>
       <div class="sec">
+        <h3>${getTranslation(h, "room_details")}</h3>
+        <ha-formfield label="${getTranslation(h, "drawer_enable")}"><ha-switch id="drawer-enabled"></ha-switch></ha-formfield>
+        <oneline-room-card-textfield id="drawer-title" label="${getTranslation(h, "drawer_title")}" style="display:block;margin-top:12px"></oneline-room-card-textfield>
+        <p>${getTranslation(h, "drawer_help")}</p>
+        <button type="button" id="drawer-preview">${getTranslation(h, "drawer_preview")}</button>
+        <p id="drawer-preview-status" role="status"></p>
+      </div>
+      <div class="sec">
         <div id="room-modes-head" class="sec-head" style="cursor:pointer;user-select:none;padding:4px 0">
           <h3>${getTranslation(h, "room_modes")}</h3>
           <ha-icon id="room-modes-chev" icon="mdi:chevron-right" style="--mdc-icon-size:18px;opacity:0.7;transition:transform 0.15s ease"></ha-icon>
@@ -1424,6 +1434,24 @@ connectedCallback() {
       });
     }
     const roomModesHead = this.shadowRoot.getElementById("room-modes-head");
+    const setDrawerOption = (key, value) => {
+      const drawer = { ...this._config.detail_drawer, [key]: value };
+      if (value === "") delete drawer[key];
+      this._fire({ ...this._config, detail_drawer: drawer });
+      this._updateDrawerUI();
+    };
+    this.shadowRoot.getElementById("drawer-enabled").addEventListener("change", event => {
+      event.stopPropagation(); setDrawerOption("enabled", event.target.checked === true);
+    });
+    this.shadowRoot.getElementById("drawer-title").addEventListener("input", event => {
+      event.stopPropagation(); setDrawerOption("title", event.target.value);
+    });
+    this.shadowRoot.getElementById("drawer-preview").addEventListener("click", event => {
+      event.preventDefault(); event.stopPropagation();
+      if (!this._livePreview || this._config.detail_drawer?.enabled !== true) return;
+      const opened = requestDrawerPreview(this, event.currentTarget);
+      this.shadowRoot.getElementById("drawer-preview-status").textContent = opened ? "" : getTranslation(this._hass, "drawer_preview_unavailable");
+    });
     if (roomModesHead) {
       roomModesHead.addEventListener("click", () => {
         this._roomModesSectionOpen = !this._roomModesSectionOpen;
@@ -2113,7 +2141,8 @@ connectedCallback() {
       });
     }
     const actOpts = [
-      { value: "more-info", label: getTranslation(h, "act_more") || "Details (Default)" },
+     { value: "more-info", label: getTranslation(h, "act_more") || "Details (Default)" },
+      { value: "room-details", label: getTranslation(h, "room_details") },
       { value: "toggle", label: getTranslation(h, "act_toggle") || "Toggle" },
       { value: "navigate", label: getTranslation(h, "act_navigate") || "Navigate" },
       { value: "none", label: getTranslation(h, "act_none") || "None" }
@@ -2408,6 +2437,7 @@ const updateActionFields = (action, serviceField, serviceDataField, targetField,
         const enabled = ev.target.checked !== false;
         const wasEnabled = this._livePreview !== false;
         this._livePreview = enabled;
+        this._updateDrawerUI();
         if (enabled && !wasEnabled) this._flushPendingConfig();
       });
     }
@@ -2760,6 +2790,20 @@ if (tmplSelect) {
     if (content) content.hidden = !this._actionsSectionOpen;
     if (section) section.classList.toggle("open", this._actionsSectionOpen);
     if (chev) chev.style.transform = this._actionsSectionOpen ? "rotate(90deg)" : "";
+  }
+
+  _updateDrawerUI() {
+    const enabled = this._config?.detail_drawer?.enabled === true;
+    const toggle = this.shadowRoot?.getElementById("drawer-enabled");
+    const title = this.shadowRoot?.getElementById("drawer-title");
+    const preview = this.shadowRoot?.getElementById("drawer-preview");
+    if (toggle) toggle.checked = enabled;
+    if (title) {
+      title.value = this._config?.detail_drawer?.title || "";
+      title.placeholder = this._config?.name || getTranslation(this._hass, "room_details");
+      title.disabled = !enabled;
+    }
+    if (preview) preview.disabled = !enabled || !this._livePreview;
   }
 
   _updateRoomModesUI() {
@@ -3898,6 +3942,7 @@ if (tmplSelect) {
     if (!h) return;
     this._syncControlIds();
     const actOpts = [
+      { value: "room-details", label: getTranslation(h, "room_details") },
       { value: "more-info", label: getTranslation(h, "act_more") || "Details (Default)" },
       { value: "toggle", label: getTranslation(h, "act_toggle") || "Toggle" },
       { value: "navigate", label: getTranslation(h, "act_navigate") || "Navigate" },
@@ -4090,6 +4135,36 @@ if (tmplSelect) {
 
       const keepOpen = () => { this._collapsedState[key] = false; };
       const upd = (k, v, skipRender = false) => { keepOpen(); const c = [...this._config.controls]; c[i] = { ...c[i], [k]: v }; if (skipRender) { this._lastRenderedControlsSig = JSON.stringify(c); } this._fire({ ...this._config, controls: c }); };
+      const placement = document.createElement("ha-selector");
+      placement.className = "display-in";
+      placement.label = getTranslation(h, "drawer_placement");
+      placement.hass = h;
+      placement.selector = { select: { mode: "dropdown", options: [
+        { value: "card", label: getTranslation(h, "drawer_card") },
+        { value: "drawer", label: getTranslation(h, "room_details") },
+        { value: "both", label: getTranslation(h, "drawer_both") }
+      ] } };
+      placement.value = getControlPlacement(ctrl);
+      placement.addEventListener("value-changed", event => {
+        event.stopPropagation();
+        const value = getControlPlacement({ display_in: event.detail?.value });
+        placement.value = value;
+        upd("display_in", value, true);
+      });
+      box.querySelector(".body").prepend(placement);
+      const duplicate = document.createElement("button");
+      duplicate.type = "button";
+      duplicate.className = "dup";
+      duplicate.textContent = getTranslation(h, "control_duplicate");
+      duplicate.addEventListener("click", event => {
+        event.preventDefault(); event.stopPropagation();
+        const controls = [...this._config.controls];
+        controls.splice(i + 1, 0, structuredClone(controls[i]));
+        this._controlIds.splice(i + 1, 0, this._makeControlId());
+        this._fire({ ...this._config, controls });
+        this.renBtn();
+      });
+      box.querySelector(".body").append(duplicate);
       const updAct = (type, val) => { keepOpen(); const c = [...this._config.controls]; const old = c[i][type] || {}; c[i] = { ...c[i], [type]: { ...old, action: val } }; this._fire({ ...this._config, controls: c }); this.renBtn(); };
       box.querySelector(".u").onclick = (e) => {
         e.preventDefault(); e.stopPropagation();
@@ -5050,6 +5125,7 @@ const cm = box.querySelector(".cm");
 
   updVal() {
     if (!this._config) return;
+    this._updateDrawerUI();
     this.shadowRoot.querySelectorAll(".i").forEach(e => {
       const k = e.getAttribute("cfg");
       let v = k === "nav_path" ? this._config.tap_action?.navigation_path || "" : this._config[k] ?? "";

--- a/src/i18n/translations.js
+++ b/src/i18n/translations.js
@@ -1,6 +1,9 @@
 const TRANSLATIONS = {
   en: {
-    room_details: "Room details", drawer_prototype_note: "Preview: test opening, focus and nested dialogs. Room controls follow after this prototype is validated.",
+    control_duplicate: "Duplicate control",
+    room_details: "Room details", drawer_enable: "Enable room details", drawer_title: "Title (optional)", drawer_preview: "Preview room details", drawer_placement: "Display in", drawer_card: "Card", drawer_both: "Both",
+    drawer_help: "Choose Card, Room details or Both for each control. With room details disabled, all controls return to the card. Preview requires live preview; otherwise changes apply on Save.",
+    drawer_preview_unavailable: "The HA card preview is not ready yet. Wait for the preview, or save and open Room details on the dashboard.",
     empty: "Empty", low: "Low", critical: "Critical", window: "Window", general: "General",
     sensors_manual: "Sensors (Manual)", buttons: "Buttons", button: "Button", add_button: "Add Button",
     main_climate: "Main Climate Device (Optional)", climate_info: "Fills Temp/Humidity automatically if empty below.",
@@ -100,7 +103,10 @@ const TRANSLATIONS = {
     a11y_activate: "Activate {name}", a11y_set_value: "Set {name}", a11y_select_option: "Select {name}"
   },
   de: {
-    room_details: "Raumdetails", drawer_prototype_note: "Vorschau: Öffnen, Fokus und Unterdialoge testen. Die Raumsteuerung folgt nach Prüfung dieses Prototyps.",
+    control_duplicate: "Control duplizieren",
+    room_details: "Raumdetails", drawer_enable: "Raumdetails aktivieren", drawer_title: "Titel (optional)", drawer_preview: "Raumdetails ansehen", drawer_placement: "Anzeigen in", drawer_card: "Karte", drawer_both: "Beide",
+    drawer_help: "Pro Control Karte, Raumdetails oder Beide wählen. Bei deaktivierten Raumdetails erscheinen alle Controls wieder auf der Karte. Die Vorschau benötigt Live-Vorschau; sonst gelten Änderungen erst nach dem Speichern.",
+    drawer_preview_unavailable: "Die HA-Kartenvorschau ist noch nicht bereit. Bitte kurz warten oder speichern und die Raumdetails im Dashboard öffnen.",
     empty: "Leer", low: "Niedrig", critical: "Kritisch", window: "Fenster", general: "Allgemein",
     sensors_manual: "Sensoren (Manuell)", buttons: "Buttons", button: "Button", add_button: "Button hinzufügen",
     main_climate: "Haupt-Klima-Gerät", climate_info: "Füllt Temp/Feuchtigkeit automatisch, wenn unten leer.",
@@ -204,7 +210,10 @@ const TRANSLATIONS = {
     a11y_activate: "{name} bedienen", a11y_set_value: "{name} einstellen", a11y_select_option: "{name} auswählen"
   },
   fr: {
-    room_details: "Détails de la pièce", drawer_prototype_note: "Aperçu : testez l’ouverture, le focus et les boîtes de dialogue imbriquées. Les commandes suivront après validation de ce prototype.",
+    control_duplicate: "Dupliquer la commande",
+    room_details: "Détails de la pièce", drawer_enable: "Activer les détails de la pièce", drawer_title: "Titre (facultatif)", drawer_preview: "Aperçu des détails", drawer_placement: "Afficher dans", drawer_card: "Carte", drawer_both: "Les deux",
+    drawer_help: "Pour chaque commande, choisissez Carte, Détails de la pièce ou Les deux. Si les détails sont désactivés, toutes les commandes reviennent sur la carte. L’aperçu nécessite l’aperçu en direct ; sinon les modifications s’appliquent à l’enregistrement.",
+    drawer_preview_unavailable: "L’aperçu de la carte HA n’est pas encore prêt. Patientez, ou enregistrez puis ouvrez les détails depuis le tableau de bord.",
     empty: "Vide", low: "Faible", critical: "Critique", window: "Fenêtre", general: "Général",
     sensors_manual: "Capteurs (Manuel)", buttons: "Boutons", button: "Bouton", add_button: "Ajouter un bouton",
     main_climate: "Appareil climatique principal (Optionnel)", climate_info: "Remplit automatiquement Temp/Humidité si vide ci-dessous.",

--- a/src/lib/control-placement.js
+++ b/src/lib/control-placement.js
@@ -1,0 +1,8 @@
+export const getControlPlacement = (control) =>
+  ["card", "drawer", "both"].includes(control?.display_in) ? control.display_in : "card";
+
+export const isControlInContext = (control, config, context) => {
+  if (config?.detail_drawer?.enabled !== true) return context === "card";
+  const placement = getControlPlacement(control);
+  return placement === "both" || placement === context;
+};

--- a/src/shared/drawer-preview.js
+++ b/src/shared/drawer-preview.js
@@ -1,0 +1,20 @@
+// Match the editor and its existing HA preview without creating another card.
+const KEY = Symbol.for("room-card.drawer-preview");
+const scopeOf = (node) => {
+  for (let current = node; current; current = current.parentNode || current.host) {
+    if (current.localName === "hui-dialog-edit-card") return current;
+  }
+  return null;
+};
+export const registerDrawerPreview = (node, open) => {
+  const scope = scopeOf(node);
+  if (!scope) return () => {};
+  const entries = scope[KEY] ||= new Set();
+  entries.add(open);
+  return () => { entries.delete(open); if (!entries.size) delete scope[KEY]; };
+};
+export const requestDrawerPreview = (editor, trigger) => {
+  const entries = scopeOf(editor)?.[KEY];
+  if (!entries || entries.size !== 1) return false;
+  return [...entries][0](trigger);
+};

--- a/src/version.js
+++ b/src/version.js
@@ -1,4 +1,4 @@
 const VERSION = "1.4.0";
-const EDITOR_DOM_REVISION = "6";
+const EDITOR_DOM_REVISION = "7";
 
 export { VERSION, EDITOR_DOM_REVISION };

--- a/tests/drawer-integration.test.mjs
+++ b/tests/drawer-integration.test.mjs
@@ -17,6 +17,30 @@ const entities = controls => Array.from(controls.children, node => node.dataset.
 const drawer = card => card._detailDrawer.surface;
 const change = (node, value) => node.dispatchEvent(new CustomEvent("value-changed", { detail: { value }, bubbles: true }));
 
+test("drawer treats non-array status_groups as empty across opening, updates and cleanup", () => {
+  for (const status_groups of [{}, { entities: ["light.test"] }, "invalid", true, 42, false, 0, "", null, undefined, []]) {
+    const card = createCard({ status_groups });
+    try {
+      // Call directly so the DOM's event-error reporting cannot swallow a throw.
+      assert.doesNotThrow(() => card._showDetailDrawer());
+      assert.deepEqual(card._drawerStatusRows(), []);
+      const host = card._detailDrawer.host;
+      assert.equal(host.isConnected, true);
+      assert.equal(card._detailDrawer.root.querySelector('[data-drawer-action="status"]').disabled, true);
+      assert.doesNotThrow(() => { card.hass = createHass(); });
+      assert.doesNotThrow(() => card.setConfig({ ...card.config, name: "Updated" }));
+      assert.equal(card._detailDrawer.host, host);
+      card._detailDrawer.close();
+      assert.equal(host.isConnected, false);
+      assert.equal(card._detailDrawer, null);
+      assert.doesNotThrow(() => card._showDetailDrawer());
+    } finally {
+      card.remove();
+    }
+    assert.equal(document.querySelector("[data-room-card-drawer]"), null);
+  }
+});
+
 test("placement validates values and disabled drawer falls back to card", () => {
   for (const value of [undefined, null, "", "unknown", false]) assert.equal(getControlPlacement({ display_in: value }), "card");
   for (const placement of ["card", "drawer", "both"]) {

--- a/tests/drawer-integration.test.mjs
+++ b/tests/drawer-integration.test.mjs
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createHass, importRoomCard, installDomEnvironment, wait } from "./support/dom-env.mjs";
+import { getControlPlacement, isControlInContext } from "../src/lib/control-placement.js";
+import { deepActiveElement } from "../src/shared/dialog-coordinator.js";
+
+installDomEnvironment();
+await importRoomCard();
+const state = (value, attributes = {}) => ({ state: value, attributes });
+const createCard = (config, hass = createHass(), parent = document.body) => {
+  const card = document.createElement("oneline-room-card");
+  card.setConfig({ name: "Test room", controls: [], detail_drawer: { enabled: true }, ...config });
+  card.hass = hass; parent.append(card); return card;
+};
+const open = card => card.shadowRoot.getElementById("details-btn").click();
+const entities = controls => Array.from(controls.children, node => node.dataset.entity);
+const drawer = card => card._detailDrawer.surface;
+const change = (node, value) => node.dispatchEvent(new CustomEvent("value-changed", { detail: { value }, bubbles: true }));
+
+test("placement validates values and disabled drawer falls back to card", () => {
+  for (const value of [undefined, null, "", "unknown", false]) assert.equal(getControlPlacement({ display_in: value }), "card");
+  for (const placement of ["card", "drawer", "both"]) {
+    assert.equal(isControlInContext({ display_in: placement }, {}, "card"), true);
+    assert.equal(isControlInContext({ display_in: placement }, {}, "drawer"), false);
+  }
+  assert.equal(isControlInContext({ display_in: "drawer" }, { detail_drawer: { enabled: "true" } }, "card"), true);
+});
+
+test("independent render contexts retain order, visibility, hide and disabled fallback", () => {
+  const hass = createHass({ states: { "input_boolean.visible": state("off") } });
+  const config = { controls: [
+    { entity: "light.card" }, { entity: "light.drawer", display_in: "drawer" },
+    { entity: "light.both", display_in: "both" }, { entity: "light.invalid", display_in: "invalid" },
+    { entity: "light.hidden", display_in: "both", hide: true },
+    { entity: "light.conditional", display_in: "both", visibility: [{ condition: "state", entity: "input_boolean.visible", state: "on" }] }
+  ] };
+  const card = createCard(config, hass);
+  assert.deepEqual(entities(card.controls), ["light.card", "light.both", "light.invalid"]);
+  const original = card.controls.children[1]; open(card);
+  assert.equal(card.controls.children[1], original, "opening never moves or rebuilds card controls");
+  assert.deepEqual(entities(drawer(card).controls), ["light.drawer", "light.both"]);
+  assert.notEqual(drawer(card).controls.children[1], original);
+  card.hass = { ...hass, states: { "input_boolean.visible": state("on") } };
+  assert.equal(entities(drawer(card).controls).at(-1), "light.conditional");
+  card.setConfig({ ...card.config, detail_drawer: { enabled: false } });
+  assert.equal(card._detailDrawer, null);
+  assert.deepEqual(entities(card.controls), ["light.card", "light.drawer", "light.both", "light.invalid", "light.conditional"]);
+  card.remove();
+});
+
+test("both contexts emit one action/service, update together and suppress unavailable controls", () => {
+  const hass = createHass({ states: { "input_select.mode": state("Day", { options: ["Day", "Night"] }) } });
+  const card = createCard({ controls: [{ entity: "input_select.mode", display_in: "both" }] }, hass);
+  const events = []; card.addEventListener("hass-action", event => events.push(event.detail));
+  open(card);
+  for (const surface of [card._cardSurface, drawer(card)]) {
+    const control = surface.controls.firstElementChild;
+    control.click(); assert.equal(events.length, 1); events.length = 0;
+    const select = control.querySelector("select");
+    select.value = "Night";
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+    assert.deepEqual(hass.__serviceCalls.pop(), { domain: "input_select", service: "select_option", data: { entity_id: "input_select.mode", option: "Night" } });
+    assert.equal(hass.__serviceCalls.length, 0);
+    assert.equal(events.length, 0);
+  }
+  card.hass = { ...hass, states: { "input_select.mode": state("Night", { options: ["Day", "Night"] }) } };
+  for (const surface of [card._cardSurface, drawer(card)]) assert.equal(surface.controls.querySelector("select").value, "Night");
+  card.hass = { ...hass, states: { "input_select.mode": state("unavailable") } };
+  for (const surface of [card._cardSurface, drawer(card)]) {
+    assert.equal(surface.controls.firstElementChild.getAttribute("aria-disabled"), "true");
+    surface.controls.firstElementChild.click();
+  }
+  assert.equal(events.length, 0);
+  card.remove();
+});
+
+test("drawer has independent header/image/info/status/modes and remains expanded", () => {
+  const hass = createHass({ states: { "sensor.temperature": state("20", { unit_of_measurement: "°C" }), "light.reading": state("on"), "scene.movie": state("scening") } });
+  const card = createCard({ name: "Room", image: "/local/room.jpg", temp_sensor: "sensor.temperature", collapsible: true, default_state: "collapsed", remember_state: false,
+    status_groups: [{ name: "Lights", type: "count", entities: ["light.reading"], active_states: ["on"], details: true }],
+    room_modes: [{ entity: "scene.movie", name: "Movie" }], controls: [{ entity: "light.reading", display_in: "both" }]
+  }, hass);
+  open(card);
+  const root = drawer(card).root;
+  assert.equal(root.getElementById("bg").getAttribute("src"), "/local/room.jpg");
+  assert.equal(root.getElementById("name").innerText, "Room");
+  assert.ok(root.getElementById("info").textContent.includes("20"));
+  assert.ok(root.getElementById("chips").querySelector("button.status-group-chip"));
+  root.querySelector(".room-mode").click();
+  assert.deepEqual(hass.__serviceCalls, [{ domain: "scene", service: "turn_on", data: { entity_id: "scene.movie" } }]);
+  assert.equal(card.controls.hasAttribute("inert"), true);
+  assert.equal(drawer(card).controls.hasAttribute("inert"), false);
+  assert.equal(root.getElementById("details-btn").hidden, true, "no recursive drawer button");
+  const host = card._detailDrawer.host;
+  card.setConfig({ ...card.config, name: "Renamed", image: "/local/new.jpg" });
+  assert.equal(card._detailDrawer.host, host);
+  assert.equal(root.getElementById("name").innerText, "Renamed");
+  assert.equal(root.getElementById("bg").getAttribute("src"), "/local/new.jpg");
+  card.remove();
+});
+
+test("drawer-only sparklines fetch only while open; both contexts share pending data and one timer", async () => {
+  let calls = 0, resolveRequest;
+  const entity = "sensor.drawer_only_history";
+  const hass = createHass({ states: { [entity]: state("4", { unit_of_measurement: "W" }) }, callWS: () => { calls++; return new Promise(resolve => { resolveRequest = resolve; }); } });
+  const card = createCard({ controls: [{ entity, display_in: "drawer", show_sparkline: true, sparkline_detail: true }] }, hass);
+  await wait(); assert.equal(calls, 0); assert.equal(card._sparklineInterval, null);
+  open(card); await wait(); assert.equal(calls, 1); assert.ok(card._sparklineInterval);
+  card.setConfig({ ...card.config, controls: [{ ...card.config.controls[0], display_in: "both" }] });
+  await wait(); assert.equal(calls, 1);
+  resolveRequest({ [entity]: [{ s: "2", lu: Date.now() / 1000 - 60 }, { s: "4", lu: Date.now() / 1000 }] });
+  await wait();
+  for (const surface of [card._cardSurface, drawer(card)]) assert.ok(surface.controls.querySelector(".btn-sparkline svg polyline"));
+  card._detailDrawer.close();
+  assert.ok(card._sparklineInterval, "card's shared control retains polling");
+  card.setConfig({ ...card.config, controls: [{ ...card.config.controls[0], display_in: "drawer" }] });
+  assert.equal(card._sparklineInterval, null);
+  await card._refreshSparklineData(); assert.equal(calls, 1);
+  card.remove();
+});
+
+test("hidden drawer controls do not request history and queued holds are disposed on close", async () => {
+  let calls = 0;
+  const hass = createHass({ states: { "sensor.hidden_drawer": state("1"), "light.hold": state("on") }, callWS: async () => { calls++; return {}; } });
+  const card = createCard({ controls: [
+    { entity: "sensor.hidden_drawer", display_in: "drawer", show_sparkline: true, hide: true },
+    { entity: "light.hold", display_in: "drawer" }
+  ] }, hass);
+  const actions = []; card.addEventListener("hass-action", event => actions.push(event.detail));
+  open(card); await wait(); assert.equal(calls, 0);
+  drawer(card).controls.firstElementChild.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+  assert.ok(card._activeTimers.size);
+  card._detailDrawer.close(); assert.equal(card._activeTimers.size, 0);
+  await wait(520); assert.equal(actions.length, 0); card.remove();
+});
+
+test("drawer native control keyboard focus survives state rendering while card stays collapsed", () => {
+  const hass = createHass({ states: { "light.focus": state("on", { brightness: 100, supported_color_modes: ["brightness"] }) } });
+  const card = createCard({ collapsible: true, default_state: "collapsed", remember_state: false,
+    controls: [{ entity: "light.focus", display_in: "both", show_brightness_presets: true, brightness_presets: [25, 100] }]
+  }, hass);
+  open(card);
+  const button = drawer(card).controls.querySelector(".preset-btn");
+  assert.ok(button); assert.ok(button.dataset.rcFocusKey); button.focus();
+  card.hass = { ...hass, states: { "light.focus": state("on", { brightness: 255, supported_color_modes: ["brightness"] }) } };
+  assert.equal(deepActiveElement().dataset.rcFocusKey, button.dataset.rcFocusKey);
+  assert.ok(drawer(card).controls.contains(deepActiveElement()));
+  card.remove();
+});
+
+test("editor roundtrip retains placements through order, duplicate, reopen and deferred save", async () => {
+  const editor = document.createElement("oneline-room-card-editor"); document.body.append(editor);
+  editor.hass = createHass(); editor.setConfig({ name: "Room", controls: [{ entity: "light.one" }, { entity: "light.two", display_in: "drawer" }] });
+  let root = editor.shadowRoot;
+  const enabled = root.getElementById("drawer-enabled"); enabled.checked = true; enabled.dispatchEvent(new Event("change", { bubbles: true }));
+  const title = root.getElementById("drawer-title"); title.value = "Details"; title.dispatchEvent(new Event("input", { bubbles: true }));
+  change(root.querySelector(".display-in"), "both");
+  root.querySelector(".d").click();
+  assert.deepEqual(editor._config.controls.map(getControlPlacement), ["drawer", "both"]);
+  root.querySelector(".dup").click();
+  assert.deepEqual(editor._config.controls.map(getControlPlacement), ["drawer", "drawer", "both"]);
+  const config = structuredClone(editor._config); editor.setConfig(config);
+  assert.equal(root.getElementById("drawer-title").value, "Details");
+  assert.ok(root.getElementById("tap-action").selector.select.options.some(option => option.value === "room-details"));
+  assert.ok(root.querySelector(".tap").selector.select.options.some(option => option.value === "room-details"));
+  await wait(120);
+  const events = []; editor.addEventListener("config-changed", event => events.push(event.detail.config));
+  const live = root.getElementById("live-preview-toggle"); live.checked = false; live.dispatchEvent(new Event("change", { bubbles: true }));
+  change(root.querySelector(".display-in"), "card");
+  await wait(120); assert.equal(events.length, 0);
+  assert.equal(root.getElementById("drawer-preview").disabled, true);
+  editor._flushPendingConfig(); assert.equal(events.length, 1); assert.equal(events[0].controls[0].display_in, "card");
+  editor.remove();
+});
+
+test("editor preview targets only its existing card, preserves save boundary and cleans its bridge", async () => {
+  const dialog = document.createElement("hui-dialog-edit-card"); document.body.append(dialog);
+  const config = { name: "Preview", controls: [], detail_drawer: { enabled: true } };
+  const card = createCard(config, createHass(), dialog);
+  const editor = document.createElement("oneline-room-card-editor"); dialog.append(editor);
+  editor.hass = createHass(); editor.setConfig(config);
+  editor.addEventListener("config-changed", event => card.setConfig(event.detail.config));
+  const preview = editor.shadowRoot.getElementById("drawer-preview"); preview.click();
+  assert.ok(card._detailDrawer); assert.equal(dialog.querySelectorAll("oneline-room-card").length, 1);
+  const title = editor.shadowRoot.getElementById("drawer-title"); title.value = "Live"; title.dispatchEvent(new Event("input", { bubbles: true }));
+  await wait(120); assert.equal(card._detailDrawer.root.querySelector("h2").textContent, "Live");
+  const live = editor.shadowRoot.getElementById("live-preview-toggle"); live.checked = false; live.dispatchEvent(new Event("change", { bubbles: true }));
+  title.value = "Saved"; title.dispatchEvent(new Event("input", { bubbles: true }));
+  await wait(120); assert.equal(card._detailDrawer.root.querySelector("h2").textContent, "Live");
+  editor._flushPendingConfig(); assert.equal(card._detailDrawer.root.querySelector("h2").textContent, "Saved");
+  card.remove(); assert.equal(document.querySelector("[data-room-card-drawer]"), null);
+  live.checked = true; live.dispatchEvent(new Event("change", { bubbles: true })); preview.click();
+  assert.ok(editor.shadowRoot.getElementById("drawer-preview-status").textContent);
+  dialog.remove();
+});
+
+test("area setup preserves existing placements and new controls start on the card", async () => {
+  const editor = document.createElement("oneline-room-card-editor"); document.body.append(editor);
+  editor.hass = createHass({ states: { "light.new": state("on", { friendly_name: "New" }) } });
+  editor.setConfig({ controls: [{ entity: "light.existing", display_in: "drawer" }], detail_drawer: { enabled: true } });
+  editor._getAreaEntities = async () => [{ entity_id: "light.new" }];
+  await editor._generateFromArea("living_room");
+  assert.equal(editor._config.controls[0].display_in, "drawer");
+  assert.ok(editor._config.controls.length > 1);
+  for (const ctrl of editor._config.controls.slice(1)) assert.equal(getControlPlacement(ctrl), "card");
+  editor.remove();
+});

--- a/tests/fixtures/drawer-prototype.html
+++ b/tests/fixtures/drawer-prototype.html
@@ -1,14 +1,14 @@
 <!doctype html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>RoomCard drawer prototype — local fixture</title>
+<title>RoomCard drawer integration — local fixture</title>
 <style>
   body { margin:24px; font:16px system-ui; background:#f3f5f7; --primary-text-color:#20252c; --secondary-text-color:#616875; --ha-card-background:#fff; --divider-color:#d7dce2; --primary-color:#007fa8; }
   body.dark { background:#13171c; color:#e7edf6; --primary-text-color:#e7edf6; --secondary-text-color:#acb6c5; --ha-card-background:#222932; --divider-color:#414a58; --primary-color:#66cbed; }
   .layout { max-width:420px; transform:translateZ(0); overflow:hidden; }
   button { padding:12px; margin-bottom:16px; }
 </style>
-<h1>Drawer prototype</h1>
+<h1>Room Detail Drawer</h1>
 <p>Local rendering fixture only. Real HA dialog compatibility is tested separately.</p>
 <button id="theme">Switch light/dark</button>
 <div class="layout"><oneline-room-card></oneline-room-card></div>
@@ -19,13 +19,18 @@
     language:"en", locale:{language:"en"}, config:{unit_system:{temperature:"°C"}},
     states:{
       "sensor.temperature":{entity_id:"sensor.temperature",state:"22.1",attributes:{friendly_name:"Room temperature",unit_of_measurement:"°C"}},
-      "light.test":{entity_id:"light.test",state:"on",attributes:{friendly_name:"Reading light"}}
+      "light.test":{entity_id:"light.test",state:"on",attributes:{friendly_name:"Reading light",brightness:180,supported_color_modes:["brightness"]}},
+      "input_select.mode":{entity_id:"input_select.mode",state:"Relax",attributes:{friendly_name:"Room mode",options:["Relax","Movie","Reading"]}}
     },
     callWS:async () => ({"sensor.temperature":[{s:"21.2",lu:Date.now()/1000-7200},{s:"22.1",lu:Date.now()/1000}]}),
     formatEntityState: state => `${state.state} ${state.attributes.unit_of_measurement || ""}`,
-    entities:{},user:{id:"local-fixture"}
+    callService: () => {}, entities:{},user:{id:"local-fixture"}
   };
-  card.setConfig({name:"Living room",image_preset:"living-room",detail_drawer:{enabled:true},temp_sensor:"sensor.temperature",controls:[],status_groups:[{name:"Lights on",entities:["light.test"],type:"count",active_states:["on"],details:true}]});
+  card.setConfig({name:"Living room",image_preset:"living-room",detail_drawer:{enabled:true},temp_sensor:"sensor.temperature",controls:[
+    {entity:"light.test",display_in:"both",name:"Reading light",width:30,height:100,show_brightness_presets:true,brightness_presets:[25,50,100]},
+    {entity:"sensor.temperature",display_in:"both",name:"Temperature",width:30,height:100,show_sparkline:true,sparkline_detail:true},
+    {entity:"input_select.mode",display_in:"drawer",name:"Room mode",width:60,height:100,control_mode:"full"}
+  ],status_groups:[{name:"Lights on",entities:["light.test"],type:"count",active_states:["on"],details:true}]});
   card.hass = hass;
   document.querySelector("#theme").addEventListener("click", () => { document.body.classList.toggle("dark"); card.hass=hass; });
 </script>


### PR DESCRIPTION
## Scope

Refs #127. Full control integration on top of the independently merged prototype #150. The owner confirmed that prototype's actual Home Assistant dialog/mobile/editor-preview gate. This PR remains draft until the **integration** manual gate passes; it does not publish v1.5.0 or close #127.

## Implementation

- One `controls` list with `display_in: card | drawer | both`, card default for invalid/omitted values, disabled-drawer fallback, preserved hide/visibility/order.
- Shared scaffold and explicit per-surface render contexts: separate DOM/listeners, common configuration/state/history cache, no cloned or recursive RoomCard.
- Existing header images/info/status/modes in the drawer; independent per-image request tracking; drawer controls stay expanded when the card collapses.
- Closed drawer-only/hidden controls make no history requests; both locations share pending work and a single owner polling interval.
- Editor activation/title/placement/preview, control duplication and EN/DE/FR text, DOM revision 7. Preview targets HA's existing card; deferred-save behavior is retained.
- Native control focus restoration across state rendering, isolated action timers disposed on close/rebuild.

## Verification

- `npm run build` + `npm run check`: **116 tests pass**, including deterministic fresh artifact, module graph, registration, HACS image layout, translation parity and shipped-bundle tests.
- `git diff --check`: clean.
- New tests cover placement/order/hide/conditions, separate render nodes, one action/service per input, unavailable state, live updates, header/status/modes, collapsed card, shared history/timers, pending holds, focus, editor roundtrip/duplication/area setup, preview pairing and live/deferred save.
- Local simulated browser fixture: integrated desktop sidebar, 390×844 bottom sheet, history opened directly from a drawer control, Escape returns focus to that control. Actual HA integration is not certified by this fixture.

## Manual integration gate (pending)

- [ ] Card / Room details / Both with real controls, presets/sliders and no duplicate physical actions.
- [ ] Shared state, collapsed-card behavior and disabled-drawer fallback.
- [ ] Editor title/placement/duplicate/reorder/preview, save/reopen with live preview on/off.
- [ ] Nested history/status/HA more-info, Escape/focus/scroll, navigation and multiple cards.
- [ ] Desktop/mobile, light/dark, final real-HA release screenshots.

Version intentionally remains 1.4.0 until the separate final release gate. See `docs/room-detail-drawer.md` and README for configuration and remaining checks.
