### PR TITLE
fix: guard sparkline startup and correct drawer card sizing

### DIFF
--- a/dist/room-card.js
+++ b/dist/room-card.js
@@ -2487,7 +2487,7 @@ var OneLineRoomCard = class extends HTMLElement {
     return this.isConnected && (this._sparklineVisible || !!this._detailDrawer) && document.hidden !== true;
   }
   _isControlRendered(ctrl) {
-    if (ctrl.hide || !this._checkConditions(ctrl.visibility, this._hass)) return false;
+    if (!this._hass || ctrl.hide || !this._checkConditions(ctrl.visibility, this._hass)) return false;
     return this._sparklineVisible && isControlInContext(ctrl, this.config, "card") || !!this._detailDrawer && isControlInContext(ctrl, this.config, "drawer");
   }
   set hass(hass) {
@@ -2878,9 +2878,9 @@ var OneLineRoomCard = class extends HTMLElement {
     loadRange(supportedInitialHours);
   }
   getCardSize() {
-    const c = this.config?.controls;
+    const c = (Array.isArray(this.config?.controls) ? this.config.controls : []).filter((ctrl) => isControlInContext(ctrl, this.config, "card"));
     const hasRoomModes = (Array.isArray(this.config?.room_modes) ? this.config.room_modes : []).some((mode) => ["scene", "script"].includes(getEntityDomain(mode?.entity)));
-    return 3 + (hasRoomModes ? 1 : 0) + Math.ceil((Array.isArray(c) ? c.length : 0) / 2.5);
+    return 3 + (hasRoomModes ? 1 : 0) + Math.ceil(c.length / 2.5);
   }
   static getStubConfig(hass) {
     return { name: "", entity: "", collapsible: true, controls: [] };

--- a/src/card/room-card.js
+++ b/src/card/room-card.js
@@ -109,7 +109,8 @@ class OneLineRoomCard extends HTMLElement {
   }
 
   _isControlRendered(ctrl) {
-    if (ctrl.hide || !this._checkConditions(ctrl.visibility, this._hass)) return false;
+    // HA can configure/connect a card before providing its first state snapshot.
+    if (!this._hass || ctrl.hide || !this._checkConditions(ctrl.visibility, this._hass)) return false;
     return (this._sparklineVisible && isControlInContext(ctrl, this.config, "card"))
       || (!!this._detailDrawer && isControlInContext(ctrl, this.config, "drawer"));
   }
@@ -519,10 +520,11 @@ class OneLineRoomCard extends HTMLElement {
   }
 
   getCardSize() {
-    const c = this.config?.controls;
+    const c = (Array.isArray(this.config?.controls) ? this.config.controls : [])
+      .filter(ctrl => isControlInContext(ctrl, this.config, "card"));
     const hasRoomModes = (Array.isArray(this.config?.room_modes) ? this.config.room_modes : [])
       .some((mode) => ["scene", "script"].includes(getEntityDomain(mode?.entity)));
-    return 3 + (hasRoomModes ? 1 : 0) + Math.ceil((Array.isArray(c) ? c.length : 0) / 2.5);
+    return 3 + (hasRoomModes ? 1 : 0) + Math.ceil(c.length / 2.5);
   }
 
   static getStubConfig(hass) {

--- a/tests/drawer-integration.test.mjs
+++ b/tests/drawer-integration.test.mjs
@@ -17,6 +17,49 @@ const entities = controls => Array.from(controls.children, node => node.dataset.
 const drawer = card => card._detailDrawer.surface;
 const change = (node, value) => node.dispatchEvent(new CustomEvent("value-changed", { detail: { value }, bubbles: true }));
 
+test("conditional sparklines wait for hass before evaluating visibility or polling", () => {
+  for (const condition of [
+    { condition: "state", entity: "sensor.test", state: "20" },
+    { condition: "numeric_state", entity: "sensor.test", above: 10 },
+    { condition: "user", users: ["test-user"] }
+  ]) {
+    const card = document.createElement("oneline-room-card");
+    let refreshes = 0;
+    card._refreshSparklineData = () => { refreshes++; };
+    try {
+      assert.doesNotThrow(() => card.setConfig({ controls: [
+        { entity: "sensor.test", show_sparkline: true, visibility: [condition] }
+      ] }));
+      document.body.append(card);
+      assert.doesNotThrow(() => card._setupSparklineInterval());
+      assert.equal(card._sparklineInterval, null);
+      assert.equal(refreshes, 0);
+      card.hass = createHass({ states: { "sensor.test": state("20") } });
+      assert.ok(card._sparklineInterval, "polling starts on the first hass update");
+      assert.equal(refreshes, 1);
+      card.hass = createHass({ states: { "sensor.test": state("0") }, user: { id: "other" } });
+      assert.equal(card._sparklineInterval, null, "hidden controls stop polling");
+    } finally {
+      card.remove();
+    }
+    assert.equal(card._sparklineInterval, null);
+  }
+});
+
+test("card size excludes drawer-only controls and restores disabled-drawer fallback", () => {
+  const card = document.createElement("oneline-room-card");
+  const controls = [undefined, "card", "both", "invalid", ...Array(8).fill("drawer")]
+    .map(display_in => ({ entity: "light.test", display_in }));
+  card.setConfig({ controls, detail_drawer: { enabled: true } });
+  assert.equal(card.getCardSize(), 5);
+  card.setConfig({ ...card.config, room_modes: [{ entity: "scene.movie" }] });
+  assert.equal(card.getCardSize(), 6);
+  card.setConfig({ controls, detail_drawer: { enabled: false } });
+  assert.equal(card.getCardSize(), 8);
+  card.setConfig({ controls: controls.slice(4), detail_drawer: { enabled: true } });
+  assert.equal(card.getCardSize(), 3);
+});
+
 test("drawer treats non-array status_groups as empty across opening, updates and cleanup", () => {
   for (const status_groups of [{}, { entities: ["light.test"] }, "invalid", true, 42, false, 0, "", null, undefined, []]) {
     const card = createCard({ status_groups });


### PR DESCRIPTION
## Summary
Addresses both follow-up review findings from #151:
- Defer control visibility evaluation until hass exists, preventing conditional sparklines from crashing setConfig before the initial HA snapshot.
- Exclude drawer-only controls from the card size estimate while preserving disabled-drawer fallback and room-mode sizing.
- Rebuild the shipped distribution.

## Validation
- Both new regression tests failed against the previous bundle with the reported errors.
- npm run build and npm run check pass: 119 tests, syntax checks and deterministic distribution validation.
- Covers state/numeric-state/user visibility, no pre-hass polling, polling start/stop, placement defaults and disabled-drawer fallback.

Release remains paused pending CI and review.